### PR TITLE
pin compatible ISCE version

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -14,7 +14,7 @@ dependencies:
   # For running
   - boto3
   - gdal
-  - isce2>=2.3.3
+  - isce2=2.3.3
   - imageio
   - importlib_metadata
   - lxml


### PR DESCRIPTION
For whatever reason, ISCE is no longer being distributed with autoRIFT on conda-forge (or at least, makes no guarantee):
https://github.com/conda-forge/isce2-feedstock/pull/21

this pins ISCE back to 2.3.3 to guarantee autoRIFT 1.0.6 is included
