### PR TITLE
download additional dem files

### DIFF
--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -33,6 +33,8 @@ def _get_s3_keys_for_dem(prefix=AUTORIFT_PREFIX, dem='GRE240m'):
         'StableSurface',
         'dhdx',
         'dhdy',
+        'dhdxs',
+        'dhdys',
         'vx0',
         'vy0',
         'vxSearchRange',

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,6 +9,8 @@ def test_get_s3_keys_for_dem():
         'Prefix/GRE240m_StableSurface.tif',
         'Prefix/GRE240m_dhdx.tif',
         'Prefix/GRE240m_dhdy.tif',
+        'Prefix/GRE240m_dhdxs.tif',
+        'Prefix/GRE240m_dhdys.tif',
         'Prefix/GRE240m_vx0.tif',
         'Prefix/GRE240m_vy0.tif',
         'Prefix/GRE240m_vxSearchRange.tif',


### PR DESCRIPTION
Resolves S1 jobs failing with `ERROR 4: /home/conda/DEM/ANT240m_dhdxs.tif: No such file or directory`