### PR TITLE
Fix pixel offset bug in netCDF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.2...v0.3.3)
+
+### Fixed
+* 1/2 pixel offset in netCDF file due to gdal and netCDF using different pixel reference points. 
+
 ## [0.3.2](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.1...v0.3.2)
 
 ### Added

--- a/hyp3_autorift/__main__.py
+++ b/hyp3_autorift/__main__.py
@@ -114,7 +114,7 @@ def hyp3_process(cfg, n):
             upload_product(str(product_file), cfg, conn)
             success(conn, cfg)
 
-    except Exception as e:
+    except Exception as e:  # noqa: B902
         log.exception('autoRIFT processing failed!')
         log.exception('Notifying user')
         failure(cfg, str(e))

--- a/hyp3_autorift/netcdf_output.py
+++ b/hyp3_autorift/netcdf_output.py
@@ -146,7 +146,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, 
                  '* HyP3 processing environment: https://doi.org/10.5281/zenodo.3962581\n' \
                  '* HyP3 autoRIFT plugin: https://doi.org/10.5281/zenodo.4037016\n' \
                  '* autoRIFT: https://doi.org/10.5281/zenodo.4025445'
-    tran = [tran[0], tran[1], 0.0, tran[3], 0.0, tran[5]]
+    tran = [tran[0] + tran[1]/2, tran[1], 0.0, tran[3] + tran[5]/2, 0.0, tran[5]]
 
     clobber = True  # overwrite existing output nc file
 

--- a/hyp3_autorift/vend/workflow/netcdf_output.py
+++ b/hyp3_autorift/vend/workflow/netcdf_output.py
@@ -177,7 +177,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, 
 #    INTERPMASK = np.round(np.clip(INTERPMASK, 0, 255)).astype(np.uint8)
 
     
-    tran = [tran[0], tran[1], 0.0, tran[3], 0.0, tran[5]]
+    tran = [tran[0] + tran[1]/2, tran[1], 0.0, tran[3] + tran[5]/2, 0.0, tran[5]]
     
     clobber = True     # overwrite existing output nc file
 


### PR DESCRIPTION
gdal uses pixel corner to specify the coordinates, while netcdf uses pixel centers

From JPL.