### PR TITLE
Add Landsat collection 2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.4.0](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.3...v0.4.0)
 
 ### Added
-* Added support for processing Landsat Collection 2 scene pairs
+* Added support for processing Landsat-8 Collection 2 scene pairs
 * Example documentation for submitting autoRIFT jobs via the [HyP3 SDK](docs/sdk_example.ipynb)
   or [HyP3 API](docs/api_example.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.3](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.2...v0.3.3)
+## [0.4.0](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.3...v0.4.0)
+
+### Added
+* Added support for processing Landsat Collection 2 scene pairs
+* Example documentation for submitting autoRIFT jobs via the [HyP3 SDK](docs/sdk_example.ipynb)
+  or [HyP3 API](docs/api_example.md)
+
+### Changed
+* Sentinel-2 support now targets level-1c products instead of level-2a products to
+  remove baked in slope correction
 
 ### Fixed
 * 1/2 pixel offset in netCDF file due to gdal and netCDF using different pixel reference points. 
-
-## [0.3.2](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.1...v0.3.2)
-
-### Added
-* Example documentation for submitting autoRIFT jobs via the [HyP3 SDK](docs/sdk_example.ipynb)
-  or [HyP3 API](docs/api_example.md)
 
 ## [0.3.1](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.0...v0.3.1)
 

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -8,6 +8,10 @@ dependencies:
   - python=3.8
   - pip
   # For packaging, and testing
+  - flake8
+  - flake8-import-order
+  - flake8-blind-except
+  - flake8-builtins
   - pillow
   - pytest
   - pytest-console-scripts
@@ -25,7 +29,6 @@ dependencies:
   - matplotlib-base
   - netCDF4
   - numpy
-  - psycopg2  # missing hyp3proclib dep
   - requests
   - scikit-image  # missing autoRIFT dep
   - scipy
@@ -33,7 +36,3 @@ dependencies:
     # for packaging and testing
     - s3pypi
     - safety
-    # For running
-    - --trusted-host hyp3-pypi.s3-website-us-east-1.amazonaws.com
-      --extra-index-url http://hyp3-pypi.s3-website-us-east-1.amazonaws.com
-    - hyp3proclib>=1.0.1,<2

--- a/docs/api_example.md
+++ b/docs/api_example.md
@@ -52,8 +52,8 @@ For each supported satellite mission, the granule (scene) pairs to process are
 provided by ID:
 * Sentinel-1: [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/naming-conventions)
 * Sentinel-2: [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/naming-convention) 
-  *or* [COG ID on AWS](https://registry.opendata.aws/sentinel-2-l2a-cogs/#:~:text=The%20Sentinel%2D2%20mission%20is,great%20use%20in%20ongoing%20studies.)
-* Landsat: *Support coming soon*
+  *or* [Earth Search ID on AWS](https://registry.opendata.aws/sentinel-2/)
+* Landsat Collection 2: [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)
 
 To submit an example set of jobs including all supported missions, you could write a job list like:
 
@@ -74,8 +74,8 @@ To submit an example set of jobs including all supported missions, you could wri
       "name": "s2-esa-example",
       "job_parameters": {
         "granules": [
-          "S1A_IW_SLC__1SSH_20170221T204710_20170221T204737_015387_0193F6_AB07",
-          "S1B_IW_SLC__1SSH_20170227T204628_20170227T204655_004491_007D11_6654"
+          "S2B_MSIL1C_20200612T150759_N0209_R025_T22WEB_20200612T184700",
+          "S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912"
         ]
       },
       "job_type": "AUTORIFT"
@@ -84,8 +84,18 @@ To submit an example set of jobs including all supported missions, you could wri
       "name": "s2-cog-example",
       "job_parameters": {
         "granules": [
-          "S2B_22WEB_20200903_0_L2A",
-          "S2B_22WEB_20200913_0_L2A"
+          "S2B_22WEB_20200612_0_L1C",
+          "S2A_22WEB_20200627_0_L1C"
+        ]
+      },
+      "job_type": "AUTORIFT"
+    }
+    {
+      "name": "l8-example",
+      "job_parameters": {
+        "granules": [
+          "LC08_L1TP_009011_20200703_20200913_02_T1",
+          "LC08_L1TP_009011_20200820_20200905_02_T1"
         ]
       },
       "job_type": "AUTORIFT"

--- a/docs/api_example.md
+++ b/docs/api_example.md
@@ -46,7 +46,7 @@ definitions. A minimal job list for a single Sentinel-1 autoRIFT job would look 
 
 The job list may contain up to 200 job definitions.
 
-### Sentinel-1, Sentinel-2, and (soon!) Landsat 8
+### Sentinel-1, Sentinel-2, and (soon!) Landsat-8
 
 For each supported satellite mission, the granule (scene) pairs to process are
 provided by ID:

--- a/docs/api_example.md
+++ b/docs/api_example.md
@@ -53,7 +53,7 @@ provided by ID:
 * Sentinel-1: [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/naming-conventions)
 * Sentinel-2: [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/naming-convention) 
   *or* [Earth Search ID on AWS](https://registry.opendata.aws/sentinel-2/)
-* Landsat Collection 2: [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)
+* Landsat-8 Collection 2: [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)
 
 To submit an example set of jobs including all supported missions, you could write a job list like:
 

--- a/docs/sdk_example.ipynb
+++ b/docs/sdk_example.ipynb
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Landsat Collection 2\n",
+    "### Landsat-8 Collection 2\n",
     "\n",
     "Landsat-8 Collection 2 jobs are submitted using the [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)"
    ]

--- a/docs/sdk_example.ipynb
+++ b/docs/sdk_example.ipynb
@@ -127,10 +127,10 @@
    "source": [
     "s2_pairs = [\n",
     "    # Can be either ESA granule IDs\n",
-    "    ('S2B_MSIL2A_20201016T161349_N0214_R111_T07CDL_20201016T195625',\n",
-    "     'S2B_MSIL2A_20201030T155329_N0214_R025_T07CDL_20201030T200159'),\n",
+    "    ('S2B_MSIL1C_20200612T150759_N0209_R025_T22WEB_20200612T184700',\n",
+    "     'S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912'),\n",
     "    # or AWS COG IDs\n",
-    "    ('S2B_22WEB_20200903_0_L2A', 'S2B_22WEB_20200913_0_L2A'),\n",
+    "    ('S2B_22WEB_20200612_0_L1C', 'S2A_22WEB_20200627_0_L1C'),\n",
     "]\n",
     "\n",
     "s2_jobs = sdk.Batch()\n",
@@ -142,9 +142,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Landsat 8\n",
+    "### Landsat Collection 2\n",
     "\n",
-    "**NOTE: Landsat support is coming soon**"
+    "Landsat Collection 2 jobs are submitted using the [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)"
    ]
   },
   {
@@ -154,7 +154,10 @@
    "outputs": [],
    "source": [
     "# FIXME: Currently unsupported\n",
-    "l8_pairs = []\n",
+    "l8_pairs = [\n",
+    "    ('LC08_L1TP_009011_20200703_20200913_02_T1',\n",
+    "     'LC08_L1TP_009011_20200820_20200905_02_T1'),\n",
+    "]\n",
     "\n",
     "l8_jobs = sdk.Batch()\n",
     "for g1, g2 in l8_pairs:\n",

--- a/docs/sdk_example.ipynb
+++ b/docs/sdk_example.ipynb
@@ -116,7 +116,7 @@
     "### Sentinel-2\n",
     "\n",
     "Seninel-2 jobs can be submitted using either the [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/naming-convention)\n",
-    "or the [COG ID on AWS](https://registry.opendata.aws/sentinel-2-l2a-cogs/#:~:text=The%20Sentinel%2D2%20mission%20is,great%20use%20in%20ongoing%20studies.)"
+    "or the [Earth Search ID on AWS](https://registry.opendata.aws/sentinel-2/)"
    ]
   },
   {
@@ -129,7 +129,7 @@
     "    # Can be either ESA granule IDs\n",
     "    ('S2B_MSIL1C_20200612T150759_N0209_R025_T22WEB_20200612T184700',\n",
     "     'S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912'),\n",
-    "    # or AWS COG IDs\n",
+    "    # or Earth Search ID on AWS\n",
     "    ('S2B_22WEB_20200612_0_L1C', 'S2A_22WEB_20200627_0_L1C'),\n",
     "]\n",
     "\n",
@@ -144,7 +144,7 @@
    "source": [
     "### Landsat Collection 2\n",
     "\n",
-    "Landsat Collection 2 jobs are submitted using the [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)"
+    "Landsat-8 Collection 2 jobs are submitted using the [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)"
    ]
   },
   {
@@ -153,7 +153,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# FIXME: Currently unsupported\n",
     "l8_pairs = [\n",
     "    ('LC08_L1TP_009011_20200703_20200913_02_T1',\n",
     "     'LC08_L1TP_009011_20200820_20200905_02_T1'),\n",

--- a/hyp3_autorift/__main__.py
+++ b/hyp3_autorift/__main__.py
@@ -1,36 +1,21 @@
 """
 AutoRIFT processing for HyP3
 """
-import os
-import shutil
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from datetime import datetime
 
 from hyp3lib.aws import upload_file_to_s3
 from hyp3lib.fetch import write_credentials_to_netrc_file
 from hyp3lib.image import create_thumbnail
-from hyp3proclib import (
-    extra_arg_is,
-    failure,
-    success,
-    upload_product,
-    zip_dir,
-)
-from hyp3proclib.db import get_db_connection
-from hyp3proclib.file_system import cleanup_workdir
-from hyp3proclib.logger import log
-from hyp3proclib.proc_base import Processor
 from pkg_resources import load_entry_point
 
-import hyp3_autorift
 from hyp3_autorift.process import get_datetime, process
 
 
 def entry():
     parser = ArgumentParser(prefix_chars='+', formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '++entrypoint', choices=['hyp3_autorift', 'hyp3_autorift_v2'], default='hyp3_autorift',
+        '++entrypoint', choices=['hyp3_autorift'], default='hyp3_autorift',
         help='Select the HyP3 entrypoint version to use'
     )
     args, unknowns = parser.parse_known_args()
@@ -41,7 +26,7 @@ def entry():
     )
 
 
-def main_v2():
+def main():
     parser = ArgumentParser()
     parser.add_argument('--username')
     parser.add_argument('--password')
@@ -68,70 +53,6 @@ def main_v2():
         upload_file_to_s3(browse_file, args.bucket, args.bucket_prefix)
         thumbnail_file = create_thumbnail(browse_file)
         upload_file_to_s3(thumbnail_file, args.bucket, args.bucket_prefix)
-
-
-def hyp3_process(cfg, n):
-    try:
-        log.info(f'Processing autoRIFT-ISCE pair "{cfg["sub_name"]}" for "{cfg["username"]}"')
-
-        g1, g2 = sorted((cfg['granule'], cfg['other_granules'][0]), key=get_datetime)
-
-        d1 = datetime.strptime(g1[17:25], '%Y%m%d')
-        d2 = datetime.strptime(g2[17:25], '%Y%m%d')
-
-        cfg['email_text'] = f'This is a {(d2-d1).days}-day feature tracking pair ' \
-                            f'from {d1.strftime("%Y-%m-%d")} to {d2.strftime("%Y-%m-%d")}.'
-
-        cfg['ftd'] = '_'.join([g1[17:17+15], g2[17:17+15]])
-        log.debug(f'FTD dir is: {cfg["ftd"]}')
-
-        product_file = process(g1, g2)
-        cfg['attachment'] = str(product_file.with_suffix('.png'))
-        cfg['email_text'] = ' '  # fix line break in email
-
-        if extra_arg_is(cfg, 'intermediate_files', 'yes'):
-            tmp_product_dir = os.path.join(cfg['workdir'], 'PRODUCT')
-            if not os.path.isdir(tmp_product_dir):
-                log.info(f'PRODUCT directory not found: {tmp_product_dir}')
-                log.error('Processing failed')
-                raise Exception('Processing failed: PRODUCT directory not found')
-
-            product_dir = os.path.join(cfg['workdir'], product_file.stem)
-            product_file = f'{product_dir}.zip'
-            if os.path.isdir(product_dir):
-                shutil.rmtree(product_dir)
-            if os.path.isfile(product_file):
-                os.unlink(product_file)
-
-            log.debug('Renaming ' + tmp_product_dir + ' to ' + product_dir)
-            os.rename(tmp_product_dir, product_dir)
-
-            zip_dir(product_dir, product_file)
-
-        cfg['final_product_size'] = [os.stat(product_file).st_size, ]
-
-        with get_db_connection('hyp3-db') as conn:
-            upload_product(str(product_file), cfg, conn)
-            success(conn, cfg)
-
-    except Exception as e:  # noqa: B902
-        log.exception('autoRIFT processing failed!')
-        log.exception('Notifying user')
-        failure(cfg, str(e))
-
-    cleanup_workdir(cfg)
-
-    log.info('autoRIFT done')
-
-
-def main():
-    """
-    Main entrypoint for hyp3_autorift
-    """
-    processor = Processor(
-        'autorift_isce', hyp3_process, sci_version=hyp3_autorift.__version__
-    )
-    processor.run()
 
 
 if __name__ == '__main__':

--- a/hyp3_autorift/__main__.py
+++ b/hyp3_autorift/__main__.py
@@ -1,29 +1,13 @@
 """
 AutoRIFT processing for HyP3
 """
-import sys
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from argparse import ArgumentParser
 
 from hyp3lib.aws import upload_file_to_s3
 from hyp3lib.fetch import write_credentials_to_netrc_file
 from hyp3lib.image import create_thumbnail
-from pkg_resources import load_entry_point
 
 from hyp3_autorift.process import get_datetime, process
-
-
-def entry():
-    parser = ArgumentParser(prefix_chars='+', formatter_class=ArgumentDefaultsHelpFormatter)
-    parser.add_argument(
-        '++entrypoint', choices=['hyp3_autorift'], default='hyp3_autorift',
-        help='Select the HyP3 entrypoint version to use'
-    )
-    args, unknowns = parser.parse_known_args()
-
-    sys.argv = [args.entrypoint, *unknowns]
-    sys.exit(
-        load_entry_point('hyp3_autorift', 'console_scripts', args.entrypoint)()
-    )
 
 
 def main():

--- a/hyp3_autorift/etc/entrypoint.sh
+++ b/hyp3_autorift/etc/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash --login
 set -e
 conda activate hyp3-autorift
-exec autorift "$@"
+exec hyp3_autorift "$@"

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -4,6 +4,8 @@ import argparse
 import logging
 import os
 import textwrap
+from pathlib import Path
+from typing import Union
 
 import boto3
 from boto3.s3.transfer import TransferConfig
@@ -21,11 +23,10 @@ _s3_client_unsigned = boto3.client('s3', config=Config(signature_version=UNSIGNE
 _s3_client = boto3.client('s3')
 
 
-def download_s3_files_requester_pays(target_dir, bucket, key):
+def download_s3_files_requester_pays(target_path: Union[str, Path], bucket: str, key: str) -> Path:
     response = _s3_client.get_object(Bucket=bucket, Key=key, RequestPayer='requester')
-    filename = os.path.join(target_dir, os.path.basename(key))
-    with open(filename, 'wb') as f:
-        f.write(response['Body'].read())
+    filename = Path(target_path)
+    filename.write_bytes(response['Body'].read())
     return filename
 
 

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -23,7 +23,7 @@ _s3_client_unsigned = boto3.client('s3', config=Config(signature_version=UNSIGNE
 _s3_client = boto3.client('s3')
 
 
-def download_s3_files_requester_pays(target_path: Union[str, Path], bucket: str, key: str) -> Path:
+def download_s3_file_requester_pays(target_path: Union[str, Path], bucket: str, key: str) -> Path:
     response = _s3_client.get_object(Bucket=bucket, Key=key, RequestPayer='requester')
     filename = Path(target_path)
     filename.write_bytes(response['Body'].read())

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -26,7 +26,7 @@ from hyp3_autorift import io
 
 log = logging.getLogger(__name__)
 
-S2_SEARCH_URL = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items'
+S2_SEARCH_URL = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l1c/items'
 LC2_SEARCH_URL = 'https://landsatlook.usgs.gov/sat-api/collections/landsat-c2l1/items'
 
 
@@ -137,6 +137,7 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         reference_metadata = get_s2_metadata(reference)
         reference = reference_metadata['properties']['sentinel:product_id']
         reference_url = reference_metadata['assets'][band]['href']
+        reference_url = reference_url.replace()
 
         secondary_metadata = get_s2_metadata(secondary)
         secondary = secondary_metadata['properties']['sentinel:product_id']
@@ -151,9 +152,16 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
             band = 'B8'
         reference_metadata = get_lc2_metadata(reference)
         reference_url = reference_metadata['assets'][f'{band}.TIF']['href']
+        # FIXME: This is only because autoRIFT can't handle /vsis3/
+        reference_url = reference_url.replace(
+                'https://landsatlook.usgs.gov/data/', ''
+        )
 
         secondary_metadata = get_lc2_metadata(secondary)
         secondary_url = secondary_metadata['assets'][f'{band}.TIF']['href']
+        secondary_url = secondary_url.replace(
+            'https://landsatlook.usgs.gov/data/', ''
+        )
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
@@ -210,10 +218,8 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
 
     else:
         if reference.startswith('L'):
-            ref_loc = io.download_s3_files_requester_pays(os.getcwd(), 'usgs-landsat', reference_url.replace(
-                'https://landsatlook.usgs.gov/data/', ''))
-            sec_loc = io.download_s3_files_requester_pays(os.getcwd(), 'usgs-landsat', secondary_url.replace(
-                'https://landsatlook.usgs.gov/data/', ''))
+            ref_loc = io.download_s3_files_requester_pays(os.getcwd(), 'usgs-landsat', reference_url)
+            sec_loc = io.download_s3_files_requester_pays(os.getcwd(), 'usgs-landsat', secondary_url)
             urlflag = 0
             sensor = 'L'
         else:

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -114,8 +114,8 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
     """
 
     orbits = None
-    ref_path = None
-    sec_path = None
+    reference_path = None
+    secondary_path = None
     reference_state_vec = None
     secondary_state_vec = None
     sensor = None
@@ -143,16 +143,16 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         reference_url = reference_metadata['assets'][band]['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         reference_url = reference_url.replace('s3://sentinel-s2-l1c/', '')
-        ref_path = Path.cwd() / f'{reference}_{Path(reference_url).name}'
-        io.download_s3_file_requester_pays(ref_path, bucket, reference_url)
+        reference_path = Path.cwd() / f'{reference}_{Path(reference_url).name}'
+        io.download_s3_file_requester_pays(reference_path, bucket, reference_url)
 
         secondary_metadata = get_s2_metadata(secondary)
         secondary = secondary_metadata['properties']['sentinel:product_id']
         secondary_url = secondary_metadata['assets'][band]['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         secondary_url = secondary_url.replace('s3://sentinel-s2-l1c/', '')
-        sec_path = Path.cwd() / f'{secondary}_{Path(secondary_url).name}'
-        io.download_s3_file_requester_pays(sec_path, bucket, secondary_url)
+        secondary_path = Path.cwd() / f'{secondary}_{Path(secondary_url).name}'
+        io.download_s3_file_requester_pays(secondary_path, bucket, secondary_url)
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
@@ -168,15 +168,15 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         reference_url = reference_metadata['assets'][f'{band}.TIF']['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         reference_url = reference_url.replace('https://landsatlook.usgs.gov/data/', '')
-        ref_path = Path.cwd() / Path(reference_url).name
-        io.download_s3_file_requester_pays(ref_path, bucket, reference_url)
+        reference_path = Path.cwd() / Path(reference_url).name
+        io.download_s3_file_requester_pays(reference_path, bucket, reference_url)
 
         secondary_metadata = get_lc2_metadata(secondary)
         secondary_url = secondary_metadata['assets'][f'{band}.TIF']['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         secondary_url = secondary_url.replace('https://landsatlook.usgs.gov/data/', '')
-        sec_path = Path.cwd() / Path(secondary_url).name
-        io.download_s3_file_requester_pays(sec_path, bucket, secondary_url)
+        secondary_path = Path.cwd() / Path(secondary_url).name
+        io.download_s3_file_requester_pays(secondary_path, bucket, secondary_url)
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
@@ -229,11 +229,11 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
 
     else:
         with open('testGeogrid.txt', 'w') as f:
-            cmd = f'testGeogridOptical.py -r {ref_path.name} -s {sec_path.name} {geogrid_parameters} -urlflag 0'
+            cmd = f'testGeogridOptical.py -r {reference_path.name} -s {secondary_path.name} {geogrid_parameters} -urlflag 0'
             execute(cmd, logfile=f, uselogging=True)
 
         with open('testautoRIFT.txt', 'w') as f:
-            cmd = f'testautoRIFT.py -r {ref_path.name} -s {sec_path.name} {autorift_parameters} -nc {sensor} -fo 1 ' \
+            cmd = f'testautoRIFT.py -r {reference_path.name} -s {secondary_path.name} {autorift_parameters} -nc {sensor} -fo 1 ' \
                   f'-urlflag 0'
             execute(cmd, logfile=f, uselogging=True)
 

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -104,7 +104,7 @@ def get_product_name(reference_name, secondary_name, orbit_files=None, pixel_spa
 
 
 def process(reference: str, secondary: str, polarization: str = 'hh', band: str = 'B08') -> Path:
-    """Process a Sentinel-1, Sentinel-2, or Landsat image pair
+    """Process a Sentinel-1, Sentinel-2, or Landsat-8 image pair
 
     Args:
         reference: Name of the reference Sentinel-1, Sentinel-2, or Landsat-8 Collection 2 scene
@@ -144,7 +144,7 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         reference_url = reference_url.replace('s3://sentinel-s2-l1c/', '')
         ref_loc = Path.cwd() / f'{reference}_{Path(reference_url).name}'
-        io.download_s3_files_requester_pays(ref_loc, bucket, reference_url)
+        io.download_s3_file_requester_pays(ref_loc, bucket, reference_url)
 
         secondary_metadata = get_s2_metadata(secondary)
         secondary = secondary_metadata['properties']['sentinel:product_id']
@@ -152,7 +152,7 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         secondary_url = secondary_url.replace('s3://sentinel-s2-l1c/', '')
         sec_loc = Path.cwd() / f'{secondary}_{Path(secondary_url).name}'
-        io.download_s3_files_requester_pays(sec_loc, bucket, secondary_url)
+        io.download_s3_file_requester_pays(sec_loc, bucket, secondary_url)
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
@@ -169,14 +169,14 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         reference_url = reference_url.replace('https://landsatlook.usgs.gov/data/', '')
         ref_loc = Path.cwd() / Path(reference_url).name
-        io.download_s3_files_requester_pays(ref_loc, bucket, reference_url)
+        io.download_s3_file_requester_pays(ref_loc, bucket, reference_url)
 
         secondary_metadata = get_lc2_metadata(secondary)
         secondary_url = secondary_metadata['assets'][f'{band}.TIF']['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         secondary_url = secondary_url.replace('https://landsatlook.usgs.gov/data/', '')
         sec_loc = Path.cwd() / Path(secondary_url).name
-        io.download_s3_files_requester_pays(sec_loc, bucket, secondary_url)
+        io.download_s3_file_requester_pays(sec_loc, bucket, secondary_url)
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -27,11 +27,11 @@ from hyp3_autorift import io
 log = logging.getLogger(__name__)
 
 S2_SEARCH_URL = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items'
-LC2_SEACH_URL = 'https://landsatlook.usgs.gov/sat-api/collections/landsat-c2l1/items'
+LC2_SEARCH_URL = 'https://landsatlook.usgs.gov/sat-api/collections/landsat-c2l1/items'
 
 
 def get_lc2_metadata(scene_name):
-    response = requests.get(f'{LC2_SEACH_URL}/{scene_name}')
+    response = requests.get(f'{LC2_SEARCH_URL}/{scene_name}')
     response.raise_for_status()
     return response.json()
 

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -107,10 +107,10 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
     """Process a Sentinel-1, Sentinel-2, or Landsat image pair
 
     Args:
-        reference: Name of the reference Sentinel-1, Sentinel-2, or Landsat Collection 2 scene
-        secondary: Name of the secondary Sentinel-1, Sentinel-2, or Landsat Collection 2 scene
+        reference: Name of the reference Sentinel-1, Sentinel-2, or Landsat-8 Collection 2 scene
+        secondary: Name of the secondary Sentinel-1, Sentinel-2, or Landsat-8 Collection 2 scene
         polarization: Polarization to process for Sentinel-1 scenes, one of 'hh', 'hv', 'vv', or 'vh'
-        band: Band to process for Sentinel-2 or Landsat Collection 2 scenes
+        band: Band to process for Sentinel-2 or Landsat-8 Collection 2 scenes
     """
 
     orbits = None
@@ -264,13 +264,13 @@ def main():
         description=__doc__,
     )
     parser.add_argument('reference', type=os.path.abspath,
-                        help='Reference Sentinel-1, Sentinel-2, or Landsat Collection 2 scene')
+                        help='Reference Sentinel-1, Sentinel-2, or Landsat-8 Collection 2 scene')
     parser.add_argument('secondary', type=os.path.abspath,
-                        help='Secondary Sentinel-1, Sentinel-2, or Landsat Collection 2 scene')
+                        help='Secondary Sentinel-1, Sentinel-2, or Landsat-8 Collection 2 scene')
     parser.add_argument('-p', '--polarization', default='hh',
                         help='Polarization of the Sentinel-1 scenes')
     parser.add_argument('-b', '--band', default='B08',
-                        help='Band to process for Sentinel-2 or Landsat Collection 2 scenes')
+                        help='Band to process for Sentinel-2 or Landsat-8 Collection 2 scenes')
     args = parser.parse_args()
 
     process(**args.__dict__)

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -10,6 +10,7 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 from secrets import token_hex
+from typing import Optional
 
 import numpy as np
 import requests
@@ -103,6 +104,23 @@ def get_product_name(reference_name, secondary_name, orbit_files=None, pixel_spa
     return f'{mission}{plat1}{plat2}_{datetime1}_{datetime2}_{misc}{days:03}_VEL{pixel_spacing}_A_{product_id}'
 
 
+def get_platform(scene: str) -> str:
+    if scene.startswith('S1') or scene.startswith('S2'):
+        return scene[0:2]
+    elif scene.startswith('L'):
+        return scene[0]
+    else:
+        raise NotImplementedError(f'autoRIFT processing not available for this platform. {scene}')
+
+
+def get_bucket(platform: str) -> Optional[str]:
+    if platform == 'S2':
+        return 'sentinel-s2-l1c'
+    elif platform == 'L':
+        return 'usgs-landsat'
+    return
+
+
 def process(reference: str, secondary: str, polarization: str = 'hh', band: str = 'B08') -> Path:
     """Process a Sentinel-1, Sentinel-2, or Landsat-8 image pair
 
@@ -118,9 +136,11 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
     secondary_path = None
     reference_state_vec = None
     secondary_state_vec = None
-    sensor = None
+    lat_limits, lon_limits = None, None
+    platform = get_platform(reference)
+    bucket = get_bucket(platform)
 
-    if reference.startswith('S1'):
+    if platform == 'S1':
         for scene in [reference, secondary]:
             scene_url = get_download_url(scene)
             download_file(scene_url, chunk_size=5242880)
@@ -134,15 +154,12 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
 
         lat_limits, lon_limits = geometry.bounding_box(f'{reference}.zip', orbits=orbits)
 
-    elif reference.startswith('S2'):
-        sensor = 'S2'
-        bucket = 'sentinel-s2-l1c'
-
+    elif platform == 'S2':
         reference_metadata = get_s2_metadata(reference)
         reference = reference_metadata['properties']['sentinel:product_id']
         reference_url = reference_metadata['assets'][band]['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
-        reference_url = reference_url.replace('s3://sentinel-s2-l1c/', '')
+        reference_url = reference_url.replace(f's3://{bucket}/', '')
         reference_path = Path.cwd() / f'{reference}_{Path(reference_url).name}'
         io.download_s3_file_requester_pays(reference_path, bucket, reference_url)
 
@@ -150,7 +167,7 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         secondary = secondary_metadata['properties']['sentinel:product_id']
         secondary_url = secondary_metadata['assets'][band]['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
-        secondary_url = secondary_url.replace('s3://sentinel-s2-l1c/', '')
+        secondary_url = secondary_url.replace(f's3://{bucket}/', '')
         secondary_path = Path.cwd() / f'{secondary}_{Path(secondary_url).name}'
         io.download_s3_file_requester_pays(secondary_path, bucket, secondary_url)
 
@@ -158,10 +175,7 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         lat_limits = (bbox[1], bbox[3])
         lon_limits = (bbox[0], bbox[2])
 
-    elif reference.startswith('L'):
-        sensor = 'L'
-        bucket = 'usgs-landsat'
-
+    elif platform == 'L':
         if band == 'B08':
             band = 'B8'
         reference_metadata = get_lc2_metadata(reference)
@@ -182,9 +196,6 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         lat_limits = (bbox[1], bbox[3])
         lon_limits = (bbox[0], bbox[2])
 
-    else:
-        raise NotImplementedError(f'autoRIFT processing not available for this platform. {reference}, {secondary}')
-
     dem = geometry.find_jpl_dem(lat_limits, lon_limits)
     dem_dir = os.path.join(os.getcwd(), 'DEM')
     mkdir_p(dem_dir)
@@ -202,7 +213,7 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
                           '-vx window_rdr_off2vel_x_vec.tif -vy window_rdr_off2vel_y_vec.tif ' \
                           '-ssm window_stable_surface_mask.tif'
 
-    if reference.startswith('S1'):
+    if platform == 'S1':
         isce_dem = geometry.prep_isce_dem(f'{dem_prefix}_h.tif', lat_limits, lon_limits)
 
         io.format_tops_xml(reference, secondary, polarization, isce_dem, orbits)
@@ -229,12 +240,13 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
 
     else:
         with open('testGeogrid.txt', 'w') as f:
-            cmd = f'testGeogridOptical.py -r {reference_path.name} -s {secondary_path.name} {geogrid_parameters} -urlflag 0'
+            cmd = f'testGeogridOptical.py -r {reference_path.name} -s {secondary_path.name} {geogrid_parameters} ' \
+                  f'-urlflag 0'
             execute(cmd, logfile=f, uselogging=True)
 
         with open('testautoRIFT.txt', 'w') as f:
-            cmd = f'testautoRIFT.py -r {reference_path.name} -s {secondary_path.name} {autorift_parameters} -nc {sensor} -fo 1 ' \
-                  f'-urlflag 0'
+            cmd = f'testautoRIFT.py -r {reference_path.name} -s {secondary_path.name} {autorift_parameters} ' \
+                  f'-nc {platform} -fo 1 -urlflag 0'
             execute(cmd, logfile=f, uselogging=True)
 
     netcdf_files = glob.glob('*.nc')

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -114,8 +114,8 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
     """
 
     orbits = None
-    ref_loc = None
-    sec_loc = None
+    ref_path = None
+    sec_path = None
     reference_state_vec = None
     secondary_state_vec = None
     sensor = None
@@ -143,16 +143,16 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         reference_url = reference_metadata['assets'][band]['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         reference_url = reference_url.replace('s3://sentinel-s2-l1c/', '')
-        ref_loc = Path.cwd() / f'{reference}_{Path(reference_url).name}'
-        io.download_s3_file_requester_pays(ref_loc, bucket, reference_url)
+        ref_path = Path.cwd() / f'{reference}_{Path(reference_url).name}'
+        io.download_s3_file_requester_pays(ref_path, bucket, reference_url)
 
         secondary_metadata = get_s2_metadata(secondary)
         secondary = secondary_metadata['properties']['sentinel:product_id']
         secondary_url = secondary_metadata['assets'][band]['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         secondary_url = secondary_url.replace('s3://sentinel-s2-l1c/', '')
-        sec_loc = Path.cwd() / f'{secondary}_{Path(secondary_url).name}'
-        io.download_s3_file_requester_pays(sec_loc, bucket, secondary_url)
+        sec_path = Path.cwd() / f'{secondary}_{Path(secondary_url).name}'
+        io.download_s3_file_requester_pays(sec_path, bucket, secondary_url)
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
@@ -168,15 +168,15 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         reference_url = reference_metadata['assets'][f'{band}.TIF']['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         reference_url = reference_url.replace('https://landsatlook.usgs.gov/data/', '')
-        ref_loc = Path.cwd() / Path(reference_url).name
-        io.download_s3_file_requester_pays(ref_loc, bucket, reference_url)
+        ref_path = Path.cwd() / Path(reference_url).name
+        io.download_s3_file_requester_pays(ref_path, bucket, reference_url)
 
         secondary_metadata = get_lc2_metadata(secondary)
         secondary_url = secondary_metadata['assets'][f'{band}.TIF']['href']
         # FIXME: This is only because autoRIFT can't handle /vsis3/
         secondary_url = secondary_url.replace('https://landsatlook.usgs.gov/data/', '')
-        sec_loc = Path.cwd() / Path(secondary_url).name
-        io.download_s3_file_requester_pays(sec_loc, bucket, secondary_url)
+        sec_path = Path.cwd() / Path(secondary_url).name
+        io.download_s3_file_requester_pays(sec_path, bucket, secondary_url)
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
@@ -229,11 +229,11 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
 
     else:
         with open('testGeogrid.txt', 'w') as f:
-            cmd = f'testGeogridOptical.py -r {ref_loc.name} -s {sec_loc.name} {geogrid_parameters} -urlflag 0'
+            cmd = f'testGeogridOptical.py -r {ref_path.name} -s {sec_path.name} {geogrid_parameters} -urlflag 0'
             execute(cmd, logfile=f, uselogging=True)
 
         with open('testautoRIFT.txt', 'w') as f:
-            cmd = f'testautoRIFT.py -r {ref_loc.name} -s {sec_loc.name} {autorift_parameters} -nc {sensor} -fo 1 ' \
+            cmd = f'testautoRIFT.py -r {ref_path.name} -s {sec_path.name} {autorift_parameters} -nc {sensor} -fo 1 ' \
                   f'-urlflag 0'
             execute(cmd, logfile=f, uselogging=True)
 

--- a/hyp3_autorift/vend/testGeogridOptical.py
+++ b/hyp3_autorift/vend/testGeogridOptical.py
@@ -100,7 +100,7 @@ def loadMetadata(indir):
     info.XSize = trans[1]
     info.YSize = trans[5]
 
-    if re.findall("L8",DS.GetDescription()).__len__() > 0:
+    if re.findall("LC08",DS.GetDescription()).__len__() > 0:
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
     elif re.findall("S2",DS.GetDescription()).__len__() > 0:
@@ -137,7 +137,7 @@ def coregisterLoadMetadata(indir_r, indir_s, urlflag):
     info.XSize = trans[1]
     info.YSize = trans[5]
 
-    if re.findall("L8",DS.GetDescription()).__len__() > 0:
+    if re.findall("LC08",DS.GetDescription()).__len__() > 0:
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
     elif re.findall("S2",DS.GetDescription()).__len__() > 0:
@@ -157,7 +157,7 @@ def coregisterLoadMetadata(indir_r, indir_s, urlflag):
 
     info1 = Dummy()
 
-    if re.findall("L8",DS1.GetDescription()).__len__() > 0:
+    if re.findall("LC08",DS1.GetDescription()).__len__() > 0:
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif re.findall("S2",DS1.GetDescription()).__len__() > 0:

--- a/hyp3_autorift/vend/testGeogrid_ISCE.py
+++ b/hyp3_autorift/vend/testGeogrid_ISCE.py
@@ -199,7 +199,7 @@ def coregisterLoadMetadataOptical(indir_r, indir_s, urlflag):
     info.XSize = trans[1]
     info.YSize = trans[5]
 
-    if re.findall("L8",DS.GetDescription()).__len__() > 0:
+    if re.findall("LC08",DS.GetDescription()).__len__() > 0:
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
     elif re.findall("S2",DS.GetDescription()).__len__() > 0:
@@ -219,7 +219,7 @@ def coregisterLoadMetadataOptical(indir_r, indir_s, urlflag):
 
     info1 = Dummy()
 
-    if re.findall("L8",DS1.GetDescription()).__len__() > 0:
+    if re.findall("LC08",DS1.GetDescription()).__len__() > 0:
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif re.findall("S2",DS1.GetDescription()).__len__() > 0:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'botocore',
         'gdal',
         'hyp3lib==1.6.2',
-        'hyp3proclib',
         'matplotlib',
         'netCDF4',
         'numpy',
@@ -57,9 +56,7 @@ setup(
     packages=find_packages(),
 
     entry_points={'console_scripts': [
-        'autorift = hyp3_autorift.__main__:entry',
         'hyp3_autorift = hyp3_autorift.__main__:main',
-        'hyp3_autorift_v2 = hyp3_autorift.__main__:main_v2',
         'autorift_proc_pair = hyp3_autorift.process:main',
         'testautoRIFT_ISCE.py = hyp3_autorift.vend.testautoRIFT_ISCE:main',
         'testGeogrid_ISCE.py = hyp3_autorift.vend.testGeogrid_ISCE:main',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,14 @@
 import pytest
 from botocore.stub import Stubber
 
-from hyp3_autorift.io import _s3_client_unsigned
+from hyp3_autorift.io import _s3_client, _s3_client_unsigned
+
+
+@pytest.fixture
+def s3_stub():
+    with Stubber(_s3_client) as stubber:
+        yield stubber
+        stubber.assert_no_pending_responses()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 from botocore.stub import Stubber
 
-from hyp3_autorift.io import s3_client
+from hyp3_autorift.io import _s3_client_unsigned
 
 
 @pytest.fixture
-def s3_stub():
-    with Stubber(s3_client) as stubber:
+def s3_unsigned_stub():
+    with Stubber(_s3_client_unsigned) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -3,21 +3,6 @@ def test_hyp3_autorift(script_runner):
     assert ret.success
 
 
-def test_autorift_passthought(script_runner):
-    ret = script_runner.run('autorift', '--version')
-    assert ret.success
-    assert 'autorift_isce v' in ret.stdout
-    assert 'hyp3lib v' in ret.stdout
-    assert 'hyp3proclib v' in ret.stdout
-
-
-def test_autorift_passthough_v2(script_runner):
-    ret = script_runner.run('autorift', '++entrypoint', 'hyp3_autorift_v2', '--help')
-    assert ret.success
-    assert 'autorift_v2' in ret.stdout
-    assert '--bucket-prefix' in ret.stdout
-
-
 def test_autorift_proc_pair(script_runner):
     ret = script_runner.run('autorift_proc_pair', '-h')
     assert ret.success
@@ -30,6 +15,16 @@ def test_testautorift_isce(script_runner):
 
 def test_testgeogrid_isce(script_runner):
     ret = script_runner.run('testGeogrid_ISCE.py', '-h')
+    assert ret.success
+
+
+def test_testautorift(script_runner):
+    ret = script_runner.run('testautoRIFT.py', '-h')
+    assert ret.success
+
+
+def test_testgeogridoptical(script_runner):
+    ret = script_runner.run('testGeogridOptical.py', '-h')
     assert ret.success
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from hyp3_autorift import io
 
 
-def test_download_s3_files_requester_pays(tmp_path, s3_stub):
+def test_download_s3_file_requester_pays(tmp_path, s3_stub):
     s3_stub.add_response(
         'get_object',
         expected_params={
@@ -65,8 +65,8 @@ def test_download_s3_files(tmp_path, s3_unsigned_stub):
                 'Body': BytesIO(b'123'),
             },
         )
-    downloaded = io._download_s3_files(tmp_path, 'myBucket', keys)
-    for key, down in zip(keys, downloaded):
+    downloaded_files = io._download_s3_files(tmp_path, 'myBucket', keys)
+    for key, downloaded_file in zip(keys, downloaded_files):
         assert (tmp_path / key).exists()
         assert (tmp_path / key).read_text() == '123'
-        assert str(tmp_path / key) == down
+        assert str(tmp_path / key) == downloaded_file

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -24,10 +24,10 @@ def test_get_s3_keys_for_dem():
     assert sorted(io._get_s3_keys_for_dem('Prefix', 'GRE240m')) == sorted(expected)
 
 
-def test_download_s3_files(tmp_path, s3_stub):
+def test_download_s3_files(tmp_path, s3_unsigned_stub):
     keys = ['foo', 'bar']
     for key in keys:
-        s3_stub.add_response(
+        s3_unsigned_stub.add_response(
             'head_object',
             expected_params={
                 'Bucket': 'myBucket',
@@ -37,7 +37,7 @@ def test_download_s3_files(tmp_path, s3_stub):
                 'ContentLength': 3,
             },
         )
-        s3_stub.add_response(
+        s3_unsigned_stub.add_response(
             'get_object',
             expected_params={
                 'Bucket': 'myBucket',

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,7 +15,7 @@ def test_download_s3_files_requester_pays(tmp_path, s3_stub):
             'Body': BytesIO(b'123'),
         },
     )
-    file = io.download_s3_files_requester_pays(tmp_path / 'foobar.txt', 'myBucket', 'foobar.txt')
+    file = io.download_s3_file_requester_pays(tmp_path / 'foobar.txt', 'myBucket', 'foobar.txt')
     assert (tmp_path / 'foobar.txt').exists()
     assert (tmp_path / 'foobar.txt').read_text() == '123'
     assert tmp_path / 'foobar.txt' == file

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,10 +15,10 @@ def test_download_s3_files_requester_pays(tmp_path, s3_stub):
             'Body': BytesIO(b'123'),
         },
     )
-    file = io.download_s3_files_requester_pays(tmp_path, 'myBucket', 'foobar.txt')
+    file = io.download_s3_files_requester_pays(tmp_path / 'foobar.txt', 'myBucket', 'foobar.txt')
     assert (tmp_path / 'foobar.txt').exists()
     assert (tmp_path / 'foobar.txt').read_text() == '123'
-    assert str(tmp_path / 'foobar.txt') == file
+    assert tmp_path / 'foobar.txt' == file
 
 
 def test_get_s3_keys_for_dem():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,6 +3,24 @@ from io import BytesIO
 from hyp3_autorift import io
 
 
+def test_download_s3_files_requester_pays(tmp_path, s3_stub):
+    s3_stub.add_response(
+        'get_object',
+        expected_params={
+            'Bucket': 'myBucket',
+            'Key': 'foobar.txt',
+            'RequestPayer': 'requester',
+        },
+        service_response={
+            'Body': BytesIO(b'123'),
+        },
+    )
+    file = io.download_s3_files_requester_pays(tmp_path, 'myBucket', 'foobar.txt')
+    assert (tmp_path / 'foobar.txt').exists()
+    assert (tmp_path / 'foobar.txt').read_text() == '123'
+    assert str(tmp_path / 'foobar.txt') == file
+
+
 def test_get_s3_keys_for_dem():
     expected = [
         'Prefix/GRE240m_h.tif',
@@ -47,8 +65,8 @@ def test_download_s3_files(tmp_path, s3_unsigned_stub):
                 'Body': BytesIO(b'123'),
             },
         )
-    io._download_s3_files(tmp_path, 'myBucket', keys)
-    for key in keys:
+    downloaded = io._download_s3_files(tmp_path, 'myBucket', keys)
+    for key, down in zip(keys, downloaded):
         assert (tmp_path / key).exists()
-        with open(tmp_path / key, 'r') as f:
-            assert f.read() == '123'
+        assert (tmp_path / key).read_text() == '123'
+        assert str(tmp_path / key) == down

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -8,6 +8,31 @@ from requests import HTTPError
 from hyp3_autorift import process
 
 
+def test_get_platform():
+    assert process.get_platform('S1B_IW_GRDH_1SSH_20201203T095903_20201203T095928_024536_02EAB3_6D81') == 'S1'
+    assert process.get_platform('S1A_IW_SLC__1SDV_20180605T233148_20180605T233215_022228_0267AD_48B2') == 'S1'
+    assert process.get_platform('S2B_22WEB_20200913_0_L2A') == 'S2'
+    assert process.get_platform('S2A_11UNA_20201203_0_L2A') == 'S2'
+    assert process.get_platform('S2B_MSIL2A_20200913T151809_N0214_R068_T22WEB_20200913T180530') == 'S2'
+    assert process.get_platform('S2A_MSIL2A_20201203T190751_N0214_R013_T11UNA_20201203T195322') == 'S2'
+    assert process.get_platform('LE07_L2SP_233095_20200102_20200822_02_T2') == 'L'
+    assert process.get_platform('LC08_L1TP_009011_20200703_20200913_02_T1') == 'L'
+
+    with pytest.raises(NotImplementedError):
+        process.get_platform('S3B_IW_GRDH_1SSH_20201203T095903_20201203T095928_024536_02EAB3_6D81')
+
+    with pytest.raises(NotImplementedError):
+        process.get_platform('foobar')
+
+
+def test_get_bucket():
+    assert process.get_bucket('S1') is None
+    assert process.get_bucket('S2') == 'sentinel-s2-l1c'
+    assert process.get_bucket('S3') is None
+    assert process.get_bucket('L') == 'usgs-landsat'
+    assert process.get_bucket('FOO') is None
+
+
 @responses.activate
 def test_get_lc2_metadata_not_found():
     responses.add(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -89,6 +89,9 @@ def test_get_datetime():
     granule = 'LE07_L2SP_233095_20200102_20200822_02_T2'
     assert process.get_datetime(granule) == datetime(year=2020, month=1, day=2)
 
+    granule = 'LC08_L1TP_009011_20200703_20200913_02_T1'
+    assert process.get_datetime(granule) == datetime(year=2020, month=7, day=3)
+
     with pytest.raises(ValueError):
         process.get_datetime('AB_adsflafjladsf')
 
@@ -150,3 +153,12 @@ def test_get_product_name():
     }
     name = process.get_product_name(**payload)
     assert match(r'LE77_20200306T000000_20190115T000000_B7-416_VEL40_A_[0-9A-F]{4}$', name)
+
+    payload = {
+        'reference_name': 'LC08_L1TP_009011_20200703_20200913_02_T1',
+        'secondary_name': 'LC08_L1TP_009011_20200820_20200905_02_T1',
+        'band': 'B8',
+        'pixel_spacing': 40,
+    }
+    name = process.get_product_name(**payload)
+    assert match(r'LC88_20200703T000000_20200820T000000_B8-048_VEL40_A_[0-9A-F]{4}$', name)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -3,8 +3,28 @@ from re import match
 
 import pytest
 import responses
+from requests import HTTPError
 
 from hyp3_autorift import process
+
+
+@responses.activate
+def test_get_lc2_metadata_not_found():
+    responses.add(
+        responses.GET, f'{process.LC2_SEARCH_URL}/foo',
+        body='{"message": "Item not found"}', status=400,
+    )
+    with pytest.raises(HTTPError):
+        process.get_lc2_metadata('foo')
+
+
+@responses.activate
+def test_get_lc2_metadata():
+    responses.add(
+        responses.GET, f'{process.LC2_SEARCH_URL}/LC08_L1TP_009011_20200703_20200913_02_T1',
+        body='{"foo": "bar"}', status=200,
+    )
+    assert process.get_lc2_metadata('LC08_L1TP_009011_20200703_20200913_02_T1') == {'foo': 'bar'}
 
 
 @responses.activate


### PR DESCRIPTION
Landsat Collection 2 is in a "requester pays" bucket in AWS.

Right now, autoRIFT can't handle `/vsis3/` links, which would be needed for requester pays, nor does it allow some files to be remote and others local. So we have to download everything for Landsat Collection 2. 

Likewise, since Sentinel-2 L1c (required to remove a bad DEM slope correction baked into L2a products) is also requester pays, I've moved S2 to look for L1c data. *Note: these will come in JPEG2000 format, which GDAL should handle just fine...*

Also dropped the HyP3v1 entrypoint (no jobs have been run in the last couple months; autoRIFT team has moved to v2). Accordingly, I've frozen the autoRIFT container version and disabled the process the HyP3v1-test db (was never available in prod). 

TODOs:

- [x] test generating Landsat Collection 2 pair
- [x] test generating S2 L1c pair
- [x] update `examples` for S2 L1c and Landsat