### PR TITLE
Support global processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.4.0](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.3...v0.4.0)
 
 ### Added
+* Added support for global processing (previously only Greenland and Antarctica) 
+  by pointing at the new autoRIFT parameter files provided by JPL
 * Added support for processing Landsat-8 Collection 2 scene pairs
 * Example documentation for submitting autoRIFT jobs via the [HyP3 SDK](docs/sdk_example.ipynb)
   or [HyP3 API](docs/api_example.md)

--- a/docs/api_example.md
+++ b/docs/api_example.md
@@ -52,7 +52,7 @@ For each supported satellite mission, the granule (scene) pairs to process are
 provided by ID:
 * Sentinel-1: [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/naming-conventions)
 * Sentinel-2: [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/naming-convention) 
-  *or* [Earth Search ID on AWS](https://registry.opendata.aws/sentinel-2/)
+  *or* [Element 84 Earth Search ID](https://registry.opendata.aws/sentinel-2/)
 * Landsat-8 Collection 2: [USGS scene ID](https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes?qt-news_science_products=0#qt-news_science_products)
 
 To submit an example set of jobs including all supported missions, you could write a job list like:

--- a/docs/sdk_example.ipynb
+++ b/docs/sdk_example.ipynb
@@ -116,7 +116,7 @@
     "### Sentinel-2\n",
     "\n",
     "Seninel-2 jobs can be submitted using either the [ESA granule ID](https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/naming-convention)\n",
-    "or the [Earth Search ID on AWS](https://registry.opendata.aws/sentinel-2/)"
+    "or the [Element 84 Earth Search ID](https://registry.opendata.aws/sentinel-2/)"
    ]
   },
   {
@@ -129,7 +129,7 @@
     "    # Can be either ESA granule IDs\n",
     "    ('S2B_MSIL1C_20200612T150759_N0209_R025_T22WEB_20200612T184700',\n",
     "     'S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912'),\n",
-    "    # or Earth Search ID on AWS\n",
+    "    # or Element 84 Earth Search ID\n",
     "    ('S2B_22WEB_20200612_0_L1C', 'S2A_22WEB_20200627_0_L1C'),\n",
     "]\n",
     "\n",

--- a/hyp3_autorift/geometry.py
+++ b/hyp3_autorift/geometry.py
@@ -103,9 +103,9 @@ def find_jpl_dem(lat_limits, lon_limits):
     driver = ogr.GetDriverByName('ESRI Shapefile')
     shapes = driver.Open(shape_file, gdal.GA_ReadOnly)
 
-    extent = polygon_from_bbox(lat_limits, lon_limits)
+    centroid = polygon_from_bbox(lat_limits, lon_limits).Centroid()
     for feature in shapes.GetLayer(0):
-        if feature.geometry().Contains(extent.Centroid()):
+        if feature.geometry().Contains(centroid):
             return f'{feature["name"]}_0240m'
 
     raise DemError('Could not determine appropriate DEM for:\n'

--- a/hyp3_autorift/geometry.py
+++ b/hyp3_autorift/geometry.py
@@ -3,16 +3,10 @@
 import logging
 import os
 
-import isce  # noqa: F401
-import isceobj
 import numpy as np
-from contrib.demUtils import createDemStitcher
-from contrib.geo_autoRIFT.geogrid import Geogrid
 from hyp3lib import DemError
-from isceobj.Orbit.Orbit import Orbit
-from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
 from osgeo import gdal
-from osgeo import osr
+from osgeo import ogr
 
 from hyp3_autorift.io import AUTORIFT_PREFIX, ITS_LIVE_BUCKET
 
@@ -32,6 +26,9 @@ def bounding_box(safe, priority='reference', polarization='hh', orbits='Orbits',
         lat_limits: list containing the [minimum, maximum] latitudes
         lat_limits: list containing the [minimum, maximum] longitudes
     """
+    from isce.components.contrib.geo_autoRIFT.geogrid import Geogrid
+    from isce.components.isceobj.Orbit.Orbit import Orbit
+    from isce.components.isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
     frames = []
     for swath in range(1, 4):
         rdr = Sentinel1()
@@ -89,59 +86,37 @@ def bounding_box(safe, priority='reference', polarization='hh', orbits='Orbits',
     return lat_limits, lon_limits
 
 
-def find_jpl_dem(lat_limits, lon_limits, z_limits=(-200, 4000)):
+def polygon_from_bbox(lat_limits, lon_limits):
+    ring = ogr.Geometry(ogr.wkbLinearRing)
+    ring.AddPoint(lon_limits[0], lat_limits[0])
+    ring.AddPoint(lon_limits[1], lat_limits[0])
+    ring.AddPoint(lon_limits[1], lat_limits[1])
+    ring.AddPoint(lon_limits[0], lat_limits[1])
+    ring.AddPoint(lon_limits[0], lat_limits[0])
+    polygon = ogr.Geometry(ogr.wkbPolygon)
+    polygon.AddGeometry(ring)
+    return polygon
 
-    dems = ['GRE240m', 'ANT240m']
-    bounding_dem = None
-    for dem in dems:
-        dem_file = f'/vsicurl/http://{ITS_LIVE_BUCKET}.s3.amazonaws.com/{AUTORIFT_PREFIX}/{dem}_h.tif'
-        log.info(f'Checking DEM: {dem_file}')
-        dem_ds = gdal.Open(dem_file, gdal.GA_ReadOnly)
-        dem_sr = dem_ds.GetSpatialRef()
-        log.debug(f'DEM projection: {dem_sr}')
 
-        latlon = osr.SpatialReference()
-        latlon.ImportFromEPSG(4326)
+def find_jpl_dem(lat_limits, lon_limits):
+    shape_file = f'/vsicurl/http://{ITS_LIVE_BUCKET}.s3.amazonaws.com/{AUTORIFT_PREFIX}/autorift_parameters.shp'
+    driver = ogr.GetDriverByName('ESRI Shapefile')
+    shapes = driver.Open(shape_file, gdal.GA_ReadOnly)
 
-        trans = osr.CoordinateTransformation(latlon, dem_sr)
+    extent = polygon_from_bbox(lat_limits, lon_limits)
+    for feature in shapes.GetLayer(0):
+        if feature.geometry().Contains(extent.Centroid()):
+            return f'{feature["name"]}_0240m'
 
-        # NOTE: This is probably unnecessary and just the lower-left and upper-right could be used,
-        #       but this does cover the case of skewed bounding boxes
-        all_xyz = []
-        for lat in lat_limits:
-            for lon in lon_limits:
-                for zed in z_limits:
-                    xyz = trans.TransformPoint(lat, lon, zed)
-                    all_xyz.append(xyz)
-
-        x, y, _ = zip(*all_xyz)
-
-        x_limits = (min(x), max(x))
-        y_limits = (min(y), max(y))
-
-        log.info(f'Image X limits: {x_limits}')
-        log.info(f'Image Y limits: {y_limits}')
-
-        dem_geo_trans = dem_ds.GetGeoTransform()
-        dem_x_limits = (dem_geo_trans[0], dem_geo_trans[0] + dem_ds.RasterXSize * dem_geo_trans[1])
-        dem_y_limits = (dem_geo_trans[3] + dem_ds.RasterYSize * dem_geo_trans[5], dem_geo_trans[3])
-
-        log.info(f'DEM X limits: {dem_x_limits}')
-        log.info(f'DEM Y limits: {dem_y_limits}')
-
-        if x_limits[0] > dem_x_limits[0] and x_limits[1] < dem_x_limits[1] \
-           and y_limits[0] > dem_y_limits[0] and y_limits[1] < dem_y_limits[1]:
-            bounding_dem = dem
-            break
-
-    if bounding_dem is None:
-        raise DemError('Existing DEMs do not (fully) cover the image data')
-
-    log.info(f'Bounding DEM is: {bounding_dem}')
-    return bounding_dem
+    raise DemError('Could not determine appropriate DEM for:\n'
+                   f'    lat (min, max): {lat_limits}'
+                   f'    lon (min, max): {lon_limits}'
+                   f'    using: {shape_file}')
 
 
 def prep_isce_dem(input_dem, lat_limits, lon_limits, isce_dem=None):
+    from isce.components.contrib.demUtils import createDemStitcher
+    from isce.components.isceobj import createDemImage
 
     if isce_dem is None:
         seamstress = createDemStitcher()
@@ -163,7 +138,7 @@ def prep_isce_dem(input_dem, lat_limits, lon_limits, isce_dem=None):
     isce_ds = gdal.Open(isce_dem, gdal.GA_ReadOnly)
     isce_trans = isce_ds.GetGeoTransform()
 
-    img = isceobj.createDemImage()
+    img = createDemImage()
     img.width = isce_ds.RasterXSize
     img.length = isce_ds.RasterYSize
     img.bands = 1

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,3 +1,6 @@
+import pytest
+from hyp3lib import DemError
+
 from hyp3_autorift import geometry
 
 
@@ -32,3 +35,23 @@ def test_find_jpl_dem():
     lat_limits = (-56, -57)
     lon_limits = (40, 41)
     assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'SPS_0240m'
+
+    with pytest.raises(DemError):
+        lat_limits = (-90, -91)
+        lon_limits = (40, 41)
+        geometry.find_jpl_dem(lat_limits, lon_limits)
+
+    with pytest.raises(DemError):
+        lat_limits = (90, 91)
+        lon_limits = (40, 41)
+        geometry.find_jpl_dem(lat_limits, lon_limits)
+
+    with pytest.raises(DemError):
+        lat_limits = (55, 56)
+        lon_limits = (180, 181)
+        geometry.find_jpl_dem(lat_limits, lon_limits)
+
+    with pytest.raises(DemError):
+        lat_limits = (55, 56)
+        lon_limits = (-180, -181)
+        geometry.find_jpl_dem(lat_limits, lon_limits)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -36,22 +36,22 @@ def test_find_jpl_dem():
     lon_limits = (40, 41)
     assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'SPS_0240m'
 
+    lat_limits = (-90, -91)
+    lon_limits = (40, 41)
     with pytest.raises(DemError):
-        lat_limits = (-90, -91)
-        lon_limits = (40, 41)
         geometry.find_jpl_dem(lat_limits, lon_limits)
 
+    lat_limits = (90, 91)
+    lon_limits = (40, 41)
     with pytest.raises(DemError):
-        lat_limits = (90, 91)
-        lon_limits = (40, 41)
         geometry.find_jpl_dem(lat_limits, lon_limits)
 
+    lat_limits = (55, 56)
+    lon_limits = (180, 181)
     with pytest.raises(DemError):
-        lat_limits = (55, 56)
-        lon_limits = (180, 181)
         geometry.find_jpl_dem(lat_limits, lon_limits)
 
+    lat_limits = (55, 56)
+    lon_limits = (-180, -181)
     with pytest.raises(DemError):
-        lat_limits = (55, 56)
-        lon_limits = (-180, -181)
         geometry.find_jpl_dem(lat_limits, lon_limits)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,34 @@
+from hyp3_autorift import geometry
+
+
+def test_polygon_from_bbox():
+    lat_limits = (1, 2)
+    lon_limits = (3, 4)
+    assert geometry.polygon_from_bbox(lat_limits, lon_limits).ExportToWkt() \
+           == 'POLYGON ((3 1 0,4 1 0,4 2 0,3 2 0,3 1 0))'
+
+
+def test_find_jpl_dem():
+    lat_limits = (55, 56)
+    lon_limits = (40, 41)
+    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'NPS_0240m'
+
+    lat_limits = (54, 55)
+    lon_limits = (40, 41)
+    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'N37_0240m'
+
+    lat_limits = (54, 55)
+    lon_limits = (-40, -41)
+    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'N24_0240m'
+
+    lat_limits = (-54, -55)
+    lon_limits = (-40, -41)
+    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'S24_0240m'
+
+    lat_limits = (-55, -56)
+    lon_limits = (40, 41)
+    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'S37_0240m'
+
+    lat_limits = (-56, -57)
+    lon_limits = (40, 41)
+    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'SPS_0240m'

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -37,7 +37,7 @@ def test_get_s3_keys_for_dem():
         'Prefix/GRE240m_yMinChipSize.tif',
         'Prefix/GRE240m_xMaxChipSize.tif',
         'Prefix/GRE240m_yMaxChipSize.tif',
-        'Prefix/GRE240m_masks.tif',
+        'Prefix/GRE240m_sp.tif',
     ]
     assert sorted(io._get_s3_keys_for_dem('Prefix', 'GRE240m')) == sorted(expected)
 


### PR DESCRIPTION
This allows global processing with autoRIFT using the new JPL parameter files

It currently downloads all the DEM files for the right region -- when autoRIFT can support `/vsis3/` and hybrid local and remote files, this could be optimized. 
