### PR TITLE
Move ISCE imports back to top in the terrible ISCE way

### DIFF
--- a/hyp3_autorift/geometry.py
+++ b/hyp3_autorift/geometry.py
@@ -3,8 +3,14 @@
 import logging
 import os
 
+import isce  # noqa: F401
+import isceobj
 import numpy as np
+from contrib.demUtils import createDemStitcher
+from contrib.geo_autoRIFT.geogrid import Geogrid
 from hyp3lib import DemError
+from isceobj.Orbit.Orbit import Orbit
+from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
 from osgeo import gdal
 from osgeo import ogr
 
@@ -26,9 +32,6 @@ def bounding_box(safe, priority='reference', polarization='hh', orbits='Orbits',
         lat_limits: list containing the [minimum, maximum] latitudes
         lat_limits: list containing the [minimum, maximum] longitudes
     """
-    from isce.components.contrib.geo_autoRIFT.geogrid import Geogrid
-    from isce.components.isceobj.Orbit.Orbit import Orbit
-    from isce.components.isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
     frames = []
     for swath in range(1, 4):
         rdr = Sentinel1()
@@ -115,9 +118,6 @@ def find_jpl_dem(lat_limits, lon_limits):
 
 
 def prep_isce_dem(input_dem, lat_limits, lon_limits, isce_dem=None):
-    from isce.components.contrib.demUtils import createDemStitcher
-    from isce.components.isceobj import createDemImage
-
     if isce_dem is None:
         seamstress = createDemStitcher()
         isce_dem = seamstress.defaultName([*lat_limits, *lon_limits])
@@ -138,7 +138,7 @@ def prep_isce_dem(input_dem, lat_limits, lon_limits, isce_dem=None):
     isce_ds = gdal.Open(isce_dem, gdal.GA_ReadOnly)
     isce_trans = isce_ds.GetGeoTransform()
 
-    img = createDemImage()
+    img = isceobj.createDemImage()
     img.width = isce_ds.RasterXSize
     img.length = isce_ds.RasterYSize
     img.bands = 1

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -12,6 +12,7 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from botocore import UNSIGNED
 from botocore.config import Config
+from isce.applications.topsApp import TopsInSAR
 from scipy.io import savemat
 
 log = logging.getLogger(__name__)
@@ -118,7 +119,6 @@ def format_tops_xml(reference, secondary, polarization, dem, orbits, xml_file='t
 
 
 def save_topsinsar_mat():
-    from isce.applications.topsApp import TopsInSAR
     insar = TopsInSAR(name="topsApp")
     insar.configure()
 


### PR DESCRIPTION
#47 moved the ISCE imports inside ISCE functions so as to not clutter logs with the ISCE banner when ISCE isn't being used (optical procesing). 

This, backs those change out because ISCE apparently can't tell these are the same (and import path matters):

![image](https://user-images.githubusercontent.com/7882693/104786482-7e617280-5739-11eb-933d-ce469306e144.png)
