### PR TITLE
GDAL Warp JPL parameter files instead of downloading whole files

### DIFF
--- a/hyp3_autorift/geometry.py
+++ b/hyp3_autorift/geometry.py
@@ -9,13 +9,10 @@ import isceobj
 import numpy as np
 from contrib.demUtils import createDemStitcher
 from contrib.geo_autoRIFT.geogrid import Geogrid
-from hyp3lib import DemError
 from isceobj.Orbit.Orbit import Orbit
 from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
 from osgeo import gdal
 from osgeo import ogr
-
-from hyp3_autorift.io import AUTORIFT_PREFIX, ITS_LIVE_BUCKET
 
 log = logging.getLogger(__name__)
 
@@ -100,21 +97,6 @@ def polygon_from_bbox(lat_limits: Tuple[float, float], lon_limits: Tuple[float, 
     polygon = ogr.Geometry(ogr.wkbPolygon)
     polygon.AddGeometry(ring)
     return polygon
-
-
-def find_jpl_dem(polygon: ogr.Geometry) -> str:
-    shape_file = f'/vsicurl/http://{ITS_LIVE_BUCKET}.s3.amazonaws.com/{AUTORIFT_PREFIX}/autorift_parameters.shp'
-    driver = ogr.GetDriverByName('ESRI Shapefile')
-    shapes = driver.Open(shape_file, gdal.GA_ReadOnly)
-
-    centroid = polygon.Centroid()
-    for feature in shapes.GetLayer(0):
-        if feature.geometry().Contains(centroid):
-            return f'{feature["name"]}_0240m'
-
-    raise DemError('Could not determine appropriate DEM for:\n'
-                   f'    centroid: {centroid}'
-                   f'    using: {shape_file}')
 
 
 def prep_isce_dem(input_dem, lat_limits, lon_limits, isce_dem=None):

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -5,12 +5,12 @@ import logging
 import os
 import textwrap
 from pathlib import Path
-from typing import Union, List
+from typing import List, Union
 
 import boto3
+from isce.applications.topsApp import TopsInSAR
 from osgeo import gdal
 from osgeo import ogr
-from isce.applications.topsApp import TopsInSAR
 from scipy.io import savemat
 
 log = logging.getLogger(__name__)

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -28,7 +28,6 @@ def download_s3_file_requester_pays(target_path: Union[str, Path], bucket: str, 
     return filename
 
 
-# FIXME: get keys from shapefile...
 def _get_s3_keys_for_dem(prefix: str = AUTORIFT_PREFIX, dem: str = 'GRE240m') -> List[str]:
     tags = [
         'h',
@@ -45,8 +44,6 @@ def _get_s3_keys_for_dem(prefix: str = AUTORIFT_PREFIX, dem: str = 'GRE240m') ->
         'yMinChipSize',
         'xMaxChipSize',
         'yMaxChipSize',
-        # FIXME: Was renamed from masks to sp by JPL; change hasn't been propagated to autoRIFT
-        #        keep last so we can easily rename the file after downloading
         'sp',
     ]
     keys = [f'{prefix}/{dem}_{tag}.tif' for tag in tags]

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -5,7 +5,7 @@ import logging
 import os
 import textwrap
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 import boto3
 from hyp3lib import DemError
@@ -96,8 +96,7 @@ def subset_jpl_tifs(polygon: ogr.Geometry, buffer: float = 0.15, target_dir: Uni
         subset_tifs[key] = out_path
 
         gdal.Warp(
-            out_path, tif, outputBounds=output_bounds,
-            xRes=240, yRes=240, targetAlignedPixels=True,
+            out_path, tif, outputBounds=output_bounds, xRes=240, yRes=240, targetAlignedPixels=True, multithread=True,
         )
 
     return subset_tifs

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -77,12 +77,12 @@ def subset_jpl_tifs(polygon: ogr.Geometry, buffer: float = 0.15, target_dir: Uni
     out_srs.ImportFromEPSG(dem_info['epsg'])
 
     transformation = osr.CoordinateTransformation(in_srs, out_srs)
-    transformed_poly = ogr.Geometry(wkb=polygon.ExportToWkb())
-    transformed_poly = transformed_poly.Buffer(buffer)
-    transformed_poly.Transform(transformation)
+    ring = ogr.Geometry(ogr.wkbLinearRing)
+    for lon, lat in polygon.Buffer(buffer).GetBoundary().GetPoints():
+        ring.AddPoint(*transformation.TransformPoint(lat, lon))
 
-    lon_min, lon_max, lat_min, lat_max = transformed_poly.GetEnvelope()
-    output_bounds = (lon_min, lat_min, lon_max, lat_max)
+    min_x, max_x, min_y, max_y = ring.GetEnvelope()
+    output_bounds = (min_x, min_y, max_x, max_y)
     log.debug(f'Subset bounds: {output_bounds}')
 
     subset_tifs = {}

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from typing import List, Union
 
 import boto3
+from hyp3lib import DemError
 from isce.applications.topsApp import TopsInSAR
 from osgeo import gdal
 from osgeo import ogr
+from osgeo import osr
 from scipy.io import savemat
 
 log = logging.getLogger(__name__)
@@ -28,50 +30,77 @@ def download_s3_file_requester_pays(target_path: Union[str, Path], bucket: str, 
     return filename
 
 
-def _get_s3_keys_for_dem(prefix: str = AUTORIFT_PREFIX, dem: str = 'GRE240m') -> List[str]:
-    tags = [
-        'h',
-        'StableSurface',
-        'dhdx',
-        'dhdy',
-        'dhdxs',
-        'dhdys',
-        'vx0',
-        'vy0',
-        'vxSearchRange',
-        'vySearchRange',
-        'xMinChipSize',
-        'yMinChipSize',
-        'xMaxChipSize',
-        'yMaxChipSize',
-        'sp',
-    ]
-    keys = [f'{prefix}/{dem}_{tag}.tif' for tag in tags]
-    return keys
+def find_jpl_dem(polygon: ogr.Geometry) -> dict:
+    shape_file = f'/vsicurl/http://{ITS_LIVE_BUCKET}.s3.amazonaws.com/{AUTORIFT_PREFIX}/autorift_parameters.shp'
+    driver = ogr.GetDriverByName('ESRI Shapefile')
+    shapes = driver.Open(shape_file, gdal.GA_ReadOnly)
+
+    centroid = polygon.Centroid()
+    for feature in shapes.GetLayer(0):
+        if feature.geometry().Contains(centroid):
+            dem_info = {
+                'name': f'{feature["name"]}_0240m',
+                'epsg': feature['epsg'],
+                'tifs': {
+                    'h': f"/vsicurl/{feature['h']}",
+                    'StableSurface': f"/vsicurl/{feature['StableSurfa']}",
+                    'dhdx': f"/vsicurl/{feature['dhdx']}",
+                    'dhdy': f"/vsicurl/{feature['dhdy']}",
+                    'dhdxs': f"/vsicurl/{feature['dhdxs']}",
+                    'dhdys': f"/vsicurl/{feature['dhdys']}",
+                    'vx0': f"/vsicurl/{feature['vx0']}",
+                    'vy0': f"/vsicurl/{feature['vy0']}",
+                    'vxSearchRange': f"/vsicurl/{feature['vxSearchRan']}",
+                    'vySearchRange': f"/vsicurl/{feature['vySearchRan']}",
+                    'xMinChipSize': f"/vsicurl/{feature['xMinChipSiz']}",
+                    'yMinChipSize': f"/vsicurl/{feature['yMinChipSiz']}",
+                    'xMaxChipSize': f"/vsicurl/{feature['xMaxChipSiz']}",
+                    'yMaxChipSize': f"/vsicurl/{feature['yMaxChipSiz']}",
+                    'sp': f"/vsicurl/{feature['sp']}",
+                },
+            }
+            return dem_info
+
+    raise DemError('Could not determine appropriate DEM for:\n'
+                   f'    centroid: {centroid}'
+                   f'    using: {shape_file}')
 
 
-def subset_jpl_tifs(polygon: ogr.Geometry, buffer: float = 0.15, dem: str = 'NPS_0240m', target_dir: str = 'DEM',
-                    bucket: str = ITS_LIVE_BUCKET, prefix: str = AUTORIFT_PREFIX):
-    log.info(f'Subsetting {dem} tifs from s3://{bucket}')
+def subset_jpl_tifs(polygon: ogr.Geometry, buffer: float = 0.15, target_dir: Union[str, Path] = '.'):
+    dem_info = find_jpl_dem(polygon)
+    log.info(f'Subsetting {dem_info["name"]} tifs from s3://{ITS_LIVE_BUCKET}/{AUTORIFT_PREFIX}/')
 
-    min_x, max_x, min_y, max_y = polygon.Buffer(buffer).GetEnvelope()
-    output_bounds = (min_x, min_y, max_x, max_y)
+    in_srs = osr.SpatialReference()
+    in_srs.ImportFromEPSG(4326)
 
-    for key in _get_s3_keys_for_dem(prefix, dem):
-        in_file = f'/vsicurl/http://{bucket}.s3.amazonaws.com/{key}'
-        out_file = os.path.join(target_dir, os.path.basename(key))
+    out_srs = osr.SpatialReference()
+    out_srs.ImportFromEPSG(dem_info['epsg'])
+
+    transformation = osr.CoordinateTransformation(in_srs, out_srs)
+    transformed_poly = ogr.Geometry(wkb=polygon.ExportToWkb())
+    transformed_poly = transformed_poly.Buffer(buffer)
+    transformed_poly.Transform(transformation)
+
+    lon_min, lon_max, lat_min, lat_max = transformed_poly.GetEnvelope()
+    output_bounds = (lon_min, lat_min, lon_max, lat_max)
+    log.debug(f'Subset bounds: {output_bounds}')
+
+    subset_tifs = {}
+    for key, tif in dem_info['tifs'].items():
+        out_path = os.path.join(target_dir, os.path.basename(tif))
 
         # FIXME: shouldn't need to do after next autoRIFT upgrade
-        if out_file.endswith('_sp.tif'):
-            out_file = out_file.replace('_sp.tif', '_masks.tif')
+        if out_path.endswith('_sp.tif'):
+            out_path = out_path.replace('_sp.tif', '_masks.tif')
+
+        subset_tifs[key] = out_path
 
         gdal.Warp(
-            out_file, in_file, outputBounds=output_bounds, multithread=True,
-            # FIXME: hard coded x-y resolution; required for targetAlignedPixels
-            #        could pull this out of a gdal.info call to any one of the tifs
-            #        or out of the dem name...
+            out_path, tif, outputBounds=output_bounds,
             xRes=240, yRes=240, targetAlignedPixels=True,
         )
+
+    return subset_tifs
 
 
 def format_tops_xml(reference, secondary, polarization, dem, orbits, xml_file='topsApp.xml'):

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -196,10 +196,11 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         lat_limits = (bbox[1], bbox[3])
         lon_limits = (bbox[0], bbox[2])
 
-    dem = geometry.find_jpl_dem(lat_limits, lon_limits)
+    scene_poly = geometry.polygon_from_bbox(lat_limits, lon_limits)
+    dem = geometry.find_jpl_dem(scene_poly)
     dem_dir = os.path.join(os.getcwd(), 'DEM')
     mkdir_p(dem_dir)
-    io.fetch_jpl_tifs(dem=dem, target_dir=dem_dir)
+    io.subset_jpl_tifs(scene_poly, dem=dem, target_dir=dem_dir)
     dem_prefix = os.path.join(dem_dir, dem)
 
     geogrid_parameters = f'-d {dem_prefix}_h.tif -ssm {dem_prefix}_StableSurface.tif ' \

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -197,25 +197,21 @@ def process(reference: str, secondary: str, polarization: str = 'hh', band: str 
         lon_limits = (bbox[0], bbox[2])
 
     scene_poly = geometry.polygon_from_bbox(lat_limits, lon_limits)
-    dem = geometry.find_jpl_dem(scene_poly)
-    dem_dir = os.path.join(os.getcwd(), 'DEM')
-    mkdir_p(dem_dir)
-    io.subset_jpl_tifs(scene_poly, dem=dem, target_dir=dem_dir)
-    dem_prefix = os.path.join(dem_dir, dem)
+    tifs = io.subset_jpl_tifs(scene_poly, target_dir=Path.cwd())
 
-    geogrid_parameters = f'-d {dem_prefix}_h.tif -ssm {dem_prefix}_StableSurface.tif ' \
-                         f'-sx {dem_prefix}_dhdx.tif -sy {dem_prefix}_dhdy.tif ' \
-                         f'-vx {dem_prefix}_vx0.tif -vy {dem_prefix}_vy0.tif ' \
-                         f'-srx {dem_prefix}_vxSearchRange.tif -sry {dem_prefix}_vySearchRange.tif ' \
-                         f'-csminx {dem_prefix}_xMinChipSize.tif -csminy {dem_prefix}_yMinChipSize.tif ' \
-                         f'-csmaxx {dem_prefix}_xMaxChipSize.tif -csmaxy {dem_prefix}_yMaxChipSize.tif'
+    geogrid_parameters = f'-d {tifs["h"]} -ssm {tifs["StableSurface"]} ' \
+                         f'-sx {tifs["dhdx"]} -sy {tifs["dhdy"]} ' \
+                         f'-vx {tifs["vx0"]} -vy {tifs["vy0"]} ' \
+                         f'-srx {tifs["vxSearchRange"]} -sry {tifs["vySearchRange"]} ' \
+                         f'-csminx {tifs["xMinChipSize"]} -csminy {tifs["yMinChipSize"]} ' \
+                         f'-csmaxx {tifs["xMaxChipSize"]} -csmaxy {tifs["yMaxChipSize"]}'
     autorift_parameters = '-g window_location.tif -o window_offset.tif -sr window_search_range.tif ' \
                           '-csmin window_chip_size_min.tif -csmax window_chip_size_max.tif ' \
                           '-vx window_rdr_off2vel_x_vec.tif -vy window_rdr_off2vel_y_vec.tif ' \
                           '-ssm window_stable_surface_mask.tif'
 
     if platform == 'S1':
-        isce_dem = geometry.prep_isce_dem(f'{dem_prefix}_h.tif', lat_limits, lon_limits)
+        isce_dem = geometry.prep_isce_dem(tifs["h"], lat_limits, lon_limits)
 
         io.format_tops_xml(reference, secondary, polarization, isce_dem, orbits)
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'testGeogrid_ISCE.py = hyp3_autorift.vend.testGeogrid_ISCE:main',
         'testautoRIFT.py = hyp3_autorift.vend.testautoRIFT:main',
         'testGeogridOptical.py = hyp3_autorift.vend.testGeogridOptical:main',
-        # FIXME: Only needed for testautoRIFT.py and testautoRIFT_ISCE.py
         'topsinsar_filename.py = hyp3_autorift.io:topsinsar_mat',
         ]
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,11 @@
 import pytest
 from botocore.stub import Stubber
 
-from hyp3_autorift.io import _s3_client, _s3_client_unsigned
+from hyp3_autorift.io import _s3_client
 
 
 @pytest.fixture
 def s3_stub():
     with Stubber(_s3_client) as stubber:
-        yield stubber
-        stubber.assert_no_pending_responses()
-
-
-@pytest.fixture
-def s3_unsigned_stub():
-    with Stubber(_s3_client_unsigned) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from hyp3_autorift import geometry
 
 
@@ -6,3 +8,29 @@ def test_polygon_from_bbox():
     lon_limits = (3, 4)
     assert geometry.polygon_from_bbox(lat_limits, lon_limits).ExportToWkt() \
            == 'POLYGON ((3 1 0,4 1 0,4 2 0,3 2 0,3 1 0))'
+
+
+def test_pol_bounds_in_proj():
+    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(40, 41))
+    assert np.allclose(
+        geometry.poly_bounds_in_proj(polygon, in_epsg=4326, out_epsg=3413),  # NPS
+        (3776365.5697414433, 3899644.3388010086, -340706.3423259673, -264432.19003121805)
+    )
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(-58, -57), lon_limits=(40, 41))
+    assert np.allclose(
+        geometry.poly_bounds_in_proj(polygon, in_epsg=4326, out_epsg=3031),  # SPS
+        (2292512.6214329866, 2416952.768825992, 2691684.1770189586, 2822144.2827928355)
+    )
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(22, 23), lon_limits=(40, 41))
+    assert np.allclose(
+        geometry.poly_bounds_in_proj(polygon, in_epsg=4326, out_epsg=32637),
+        (602485.1663686256, 706472.0593133729, 2433164.428653589, 2544918.1043369616)
+    )
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(-23, -22), lon_limits=(40, 41))
+    assert np.allclose(
+        geometry.poly_bounds_in_proj(polygon, in_epsg=4326, out_epsg=32737),
+        (602485.1663686256, 706472.0593133729, 7455081.895663038, 7566835.5713464115)
+    )

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,6 +1,3 @@
-import pytest
-from hyp3lib import DemError
-
 from hyp3_autorift import geometry
 
 
@@ -9,39 +6,3 @@ def test_polygon_from_bbox():
     lon_limits = (3, 4)
     assert geometry.polygon_from_bbox(lat_limits, lon_limits).ExportToWkt() \
            == 'POLYGON ((3 1 0,4 1 0,4 2 0,3 2 0,3 1 0))'
-
-
-def test_find_jpl_dem():
-    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(40, 41))
-    assert geometry.find_jpl_dem(polygon) == 'NPS_0240m'
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(54, 55), lon_limits=(40, 41))
-    assert geometry.find_jpl_dem(polygon) == 'N37_0240m'
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(54, 55), lon_limits=(-40, -41))
-    assert geometry.find_jpl_dem(polygon) == 'N24_0240m'
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(-54, -55), lon_limits=(-40, -41))
-    assert geometry.find_jpl_dem(polygon) == 'S24_0240m'
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(-55, -56), lon_limits=(40, 41))
-    assert geometry.find_jpl_dem(polygon) == 'S37_0240m'
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(-56, -57), lon_limits=(40, 41))
-    assert geometry.find_jpl_dem(polygon) == 'SPS_0240m'
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(-90, -91), lon_limits=(40, 41))
-    with pytest.raises(DemError):
-        geometry.find_jpl_dem(polygon)
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(90, 91), lon_limits=(40, 41))
-    with pytest.raises(DemError):
-        geometry.find_jpl_dem(polygon)
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(180, 181))
-    with pytest.raises(DemError):
-        geometry.find_jpl_dem(polygon)
-
-    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(-180, -181))
-    with pytest.raises(DemError):
-        geometry.find_jpl_dem(polygon)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -12,46 +12,36 @@ def test_polygon_from_bbox():
 
 
 def test_find_jpl_dem():
-    lat_limits = (55, 56)
-    lon_limits = (40, 41)
-    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'NPS_0240m'
+    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(40, 41))
+    assert geometry.find_jpl_dem(polygon) == 'NPS_0240m'
 
-    lat_limits = (54, 55)
-    lon_limits = (40, 41)
-    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'N37_0240m'
+    polygon = geometry.polygon_from_bbox(lat_limits=(54, 55), lon_limits=(40, 41))
+    assert geometry.find_jpl_dem(polygon) == 'N37_0240m'
 
-    lat_limits = (54, 55)
-    lon_limits = (-40, -41)
-    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'N24_0240m'
+    polygon = geometry.polygon_from_bbox(lat_limits=(54, 55), lon_limits=(-40, -41))
+    assert geometry.find_jpl_dem(polygon) == 'N24_0240m'
 
-    lat_limits = (-54, -55)
-    lon_limits = (-40, -41)
-    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'S24_0240m'
+    polygon = geometry.polygon_from_bbox(lat_limits=(-54, -55), lon_limits=(-40, -41))
+    assert geometry.find_jpl_dem(polygon) == 'S24_0240m'
 
-    lat_limits = (-55, -56)
-    lon_limits = (40, 41)
-    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'S37_0240m'
+    polygon = geometry.polygon_from_bbox(lat_limits=(-55, -56), lon_limits=(40, 41))
+    assert geometry.find_jpl_dem(polygon) == 'S37_0240m'
 
-    lat_limits = (-56, -57)
-    lon_limits = (40, 41)
-    assert geometry.find_jpl_dem(lat_limits, lon_limits) == 'SPS_0240m'
+    polygon = geometry.polygon_from_bbox(lat_limits=(-56, -57), lon_limits=(40, 41))
+    assert geometry.find_jpl_dem(polygon) == 'SPS_0240m'
 
-    lat_limits = (-90, -91)
-    lon_limits = (40, 41)
+    polygon = geometry.polygon_from_bbox(lat_limits=(-90, -91), lon_limits=(40, 41))
     with pytest.raises(DemError):
-        geometry.find_jpl_dem(lat_limits, lon_limits)
+        geometry.find_jpl_dem(polygon)
 
-    lat_limits = (90, 91)
-    lon_limits = (40, 41)
+    polygon = geometry.polygon_from_bbox(lat_limits=(90, 91), lon_limits=(40, 41))
     with pytest.raises(DemError):
-        geometry.find_jpl_dem(lat_limits, lon_limits)
+        geometry.find_jpl_dem(polygon)
 
-    lat_limits = (55, 56)
-    lon_limits = (180, 181)
+    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(180, 181))
     with pytest.raises(DemError):
-        geometry.find_jpl_dem(lat_limits, lon_limits)
+        geometry.find_jpl_dem(polygon)
 
-    lat_limits = (55, 56)
-    lon_limits = (-180, -181)
+    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(-180, -181))
     with pytest.raises(DemError):
-        geometry.find_jpl_dem(lat_limits, lon_limits)
+        geometry.find_jpl_dem(polygon)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,9 @@
 from io import BytesIO
 
-from hyp3_autorift import io
+import pytest
+from hyp3lib import DemError
+
+from hyp3_autorift import geometry, io
 
 
 def test_download_s3_file_requester_pays(tmp_path, s3_stub):
@@ -21,22 +24,43 @@ def test_download_s3_file_requester_pays(tmp_path, s3_stub):
     assert tmp_path / 'foobar.txt' == file
 
 
-def test_get_s3_keys_for_dem():
-    expected = [
-        'Prefix/GRE240m_h.tif',
-        'Prefix/GRE240m_StableSurface.tif',
-        'Prefix/GRE240m_dhdx.tif',
-        'Prefix/GRE240m_dhdy.tif',
-        'Prefix/GRE240m_dhdxs.tif',
-        'Prefix/GRE240m_dhdys.tif',
-        'Prefix/GRE240m_vx0.tif',
-        'Prefix/GRE240m_vy0.tif',
-        'Prefix/GRE240m_vxSearchRange.tif',
-        'Prefix/GRE240m_vySearchRange.tif',
-        'Prefix/GRE240m_xMinChipSize.tif',
-        'Prefix/GRE240m_yMinChipSize.tif',
-        'Prefix/GRE240m_xMaxChipSize.tif',
-        'Prefix/GRE240m_yMaxChipSize.tif',
-        'Prefix/GRE240m_sp.tif',
-    ]
-    assert sorted(io._get_s3_keys_for_dem('Prefix', 'GRE240m')) == sorted(expected)
+def test_find_jpl_dem():
+    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(40, 41))
+    dem_info = io.find_jpl_dem(polygon)
+    assert dem_info['name'] == 'NPS_0240m'
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(54, 55), lon_limits=(40, 41))
+    dem_info = io.find_jpl_dem(polygon)
+    assert dem_info['name'] == 'N37_0240m'
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(54, 55), lon_limits=(-40, -41))
+    dem_info = io.find_jpl_dem(polygon)
+    assert dem_info['name'] == 'N24_0240m'
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(-54, -55), lon_limits=(-40, -41))
+    dem_info = io.find_jpl_dem(polygon)
+    assert dem_info['name'] == 'S24_0240m'
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(-55, -56), lon_limits=(40, 41))
+    dem_info = io.find_jpl_dem(polygon)
+    assert dem_info['name'] == 'S37_0240m'
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(-56, -57), lon_limits=(40, 41))
+    dem_info = io.find_jpl_dem(polygon)
+    assert dem_info['name'] == 'SPS_0240m'
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(-90, -91), lon_limits=(40, 41))
+    with pytest.raises(DemError):
+        io.find_jpl_dem(polygon)
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(90, 91), lon_limits=(40, 41))
+    with pytest.raises(DemError):
+        io.find_jpl_dem(polygon)
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(180, 181))
+    with pytest.raises(DemError):
+        io.find_jpl_dem(polygon)
+
+    polygon = geometry.polygon_from_bbox(lat_limits=(55, 56), lon_limits=(-180, -181))
+    with pytest.raises(DemError):
+        io.find_jpl_dem(polygon)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -40,33 +40,3 @@ def test_get_s3_keys_for_dem():
         'Prefix/GRE240m_sp.tif',
     ]
     assert sorted(io._get_s3_keys_for_dem('Prefix', 'GRE240m')) == sorted(expected)
-
-
-def test_download_s3_files(tmp_path, s3_unsigned_stub):
-    keys = ['foo', 'bar']
-    for key in keys:
-        s3_unsigned_stub.add_response(
-            'head_object',
-            expected_params={
-                'Bucket': 'myBucket',
-                'Key': key,
-            },
-            service_response={
-                'ContentLength': 3,
-            },
-        )
-        s3_unsigned_stub.add_response(
-            'get_object',
-            expected_params={
-                'Bucket': 'myBucket',
-                'Key': key,
-            },
-            service_response={
-                'Body': BytesIO(b'123'),
-            },
-        )
-    downloaded_files = io._download_s3_files(tmp_path, 'myBucket', keys)
-    for key, downloaded_file in zip(keys, downloaded_files):
-        assert (tmp_path / key).exists()
-        assert (tmp_path / key).read_text() == '123'
-        assert str(tmp_path / key) == downloaded_file


### PR DESCRIPTION
For some reason, ISCE wants to do it's stuff on the whole DEM, instead of just the relevant bits. This was causing our S1 jobs to crash with memory errors. 

Also pulls input tifs out of the parameter shapefile. Fixes #51 