### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.4.0...v0.4.1)
+
+### Changed
+* `hyp3_autorift` will determine the polarization of Sentinel-1 scenes based on
+  reference scene to allow for VV in addition to HH processing.
+
+### Removed
+* `autorift_proc_pair` entrypoint no longer accepts a `-p`/`--polarization` option
+* `hyp3_autorift.process.process` no longer accepts a `polarization=` keyword argument
+
+### Fixed
+* ValueError exception when processing scenes with short (23 char) Element 84 Sentinel-2 IDs
+
 ## [0.4.0](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.3.3...v0.4.0)
 
 **HyP3 v1 is no longer supported as of this release.**

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -11,6 +11,7 @@ from hyp3_autorift import process
 def test_get_platform():
     assert process.get_platform('S1B_IW_GRDH_1SSH_20201203T095903_20201203T095928_024536_02EAB3_6D81') == 'S1'
     assert process.get_platform('S1A_IW_SLC__1SDV_20180605T233148_20180605T233215_022228_0267AD_48B2') == 'S1'
+    assert process.get_platform('S2A_1UCR_20210124_0_L1C') == 'S2'
     assert process.get_platform('S2B_22WEB_20200913_0_L2A') == 'S2'
     assert process.get_platform('S2A_11UNA_20201203_0_L2A') == 'S2'
     assert process.get_platform('S2B_MSIL2A_20200913T151809_N0214_R068_T22WEB_20200913T180530') == 'S2'
@@ -98,6 +99,9 @@ def test_get_datetime():
 
     granule = 'S1A_IW_SLC__1SDV_20180605T233148_20180605T233215_022228_0267AD_48B2'
     assert process.get_datetime(granule) == datetime(year=2018, month=6, day=5, hour=23, minute=31, second=48)
+
+    granule = 'S2A_1UCR_20210124_0_L1C'
+    assert process.get_datetime(granule) == datetime(year=2021, month=1, day=24)
 
     granule = 'S2B_22WEB_20200913_0_L2A'
     assert process.get_datetime(granule) == datetime(year=2020, month=9, day=13)
@@ -187,3 +191,23 @@ def test_get_product_name():
     }
     name = process.get_product_name(**payload)
     assert match(r'LC88_20200703T000000_20200820T000000_B8-048_VEL40_A_[0-9A-F]{4}$', name)
+
+
+def test_get_s1_primary_polarization():
+    assert process.get_s1_primary_polarization(
+        'S1B_WV_SLC__1SSV_20200923T184541_20200923T185150_023506_02CA71_AABB') == 'vv'
+    assert process.get_s1_primary_polarization(
+        'S1B_IW_GRDH_1SDV_20200924T092954_20200924T093026_023515_02CABC_6C62') == 'vv'
+    assert process.get_s1_primary_polarization(
+        'S1B_IW_GRDH_1SSH_20200924T112903_20200924T112932_023516_02CAC7_D003') == 'hh'
+    assert process.get_s1_primary_polarization(
+        'S1B_IW_OCN__2SDH_20200924T090450_20200924T090519_023515_02CAB8_917B') == 'hh'
+
+    with pytest.raises(ValueError):
+        process.get_s1_primary_polarization('S1A_EW_GRDM_1SHH_20150513T080355_20150513T080455_005900_007994_35D2')
+    with pytest.raises(ValueError):
+        process.get_s1_primary_polarization('S1A_EW_GRDM_1SHV_20150509T230833_20150509T230912_005851_00787D_3BE5')
+    with pytest.raises(ValueError):
+        process.get_s1_primary_polarization('S1A_IW_SLC__1SVH_20150706T015744_20150706T015814_006684_008EF7_9B69')
+    with pytest.raises(ValueError):
+        process.get_s1_primary_polarization('S1A_IW_GRDH_1SVV_20150706T015720_20150706T015749_006684_008EF7_54BA')


### PR DESCRIPTION
### Changed
* `hyp3_autorift` will determine the polarization of Sentinel-1 scenes based on
  reference scene to allow for VV in addition to HH processing.

### Removed
* `autorift_proc_pair` entrypoint no longer accepts a `-p`/`--polarization` option
* `hyp3_autorift.process.process` no longer accepts a `polarization=` keyword argument

### Fixed
* `ValueError` exception when processing scenes with short (23 char) Element 84 Sentinel-2 IDs

### Developer checklist

- [x] Assigned a reviewer
  <!-- NOTE: Pull requests should only be opened for merges to protected branches (required) and any
   changes which you'd like reviewed. Do not open a pull request to update a feature or personal
   branch -- simply merge with `git`.
   -->
- [x] Indicated the level of changes to this package by affixing one of these labels:
  * major -- Major changes to the API that may break current workflows
  * minor -- Minor changes to the API that do not break current workflows
  * **patch -- Patches and bugfixes for the current version that do not break current workflows**
  * bumpless -- Changes to documentation, CI/CD pipelines, etc. that don't affect the software's version

- [x] ~~(If applicable) Updated the dependencies and indicated any downstream changes that are required~~

- [x] Updated `CHANGELOG.md`
- [x] Added/updated documentation for these changes
- [x] Added/updated tests for these changes

### Reviewer checklist

- [x] Have all dependencies been updated?
- [x] Is the level of changes labeled appropriately?
- [x] Are all the changes described appropriately in `CHANGELOG.md`?
- [ ] Has the documentation been adequately updated?
- [x] Are the test adequate?
