### PR TITLE
Fix out of index errors for Landsat-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.2](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.4.1...v0.4.2)
+
+### Fixed
+* A *partial* fix was implemented to correct out of index errors when processing
+  optical scenes (typically seen with Landsat-8 pairs) due to calculating different
+  overlapping subset sizes when co-registering the images. Currently, only the
+  smallest subset size is used, so the bounding box may be 1px too small in x
+  and/or y, but there shouldn't be any pixel offsets. Full fix will need to be
+  implemented upstream in [autoRIFT](https://github.com/leiyangleon/autoRIFT).
+
 ## [0.4.1](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.4.0...v0.4.1)
 
 ### Changed

--- a/hyp3_autorift/vend/PRE109-PATCH-2.diff
+++ b/hyp3_autorift/vend/PRE109-PATCH-2.diff
@@ -1,0 +1,14 @@
+diff --git a/hyp3_autorift/vend/testGeogridOptical.py b/hyp3_autorift/vend/testGeogridOptical.py
+index 27793bd..eee302c 100755
+--- a/hyp3_autorift/vend/testGeogridOptical.py
++++ b/hyp3_autorift/vend/testGeogridOptical.py
+@@ -126,6 +126,9 @@ def coregisterLoadMetadata(indir_r, indir_s, urlflag):
+ 
+     x1a, y1a, xsize1, ysize1, x2a, y2a, xsize2, ysize2, trans = obj.coregister(indir_r, indir_s, urlflag)
+ 
++    xsize1 = min((xsize1, xsize2))
++    ysize1 = min((ysize1, ysize2))
++
+     if urlflag is 1:
+         DS = gdal.Open('/vsicurl/%s' % (indir_r))
+     else:

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -24,6 +24,12 @@ language.
 
 ## `testGeogrid_ISCE.py` and `testGeogridOptical.py`
 
+---
+*Note: A patch from autoRIFT was applied to these files to prevent out of index
+errors when coregistering optical scenes, which will be included in the next autoRIFT
+release. See `PRE109-PATCH-2.diff` for the changes applied.*
+---
+
 These modules are required for the expected workflow provided to ASF, but are
 not provided in the autoRIFT v1.0.8 release and instead resides in the "sister"
 Geogrid package (https://github.com/leiyangleon/Geogrid). Geogrid and autoRIFT

--- a/hyp3_autorift/vend/testGeogridOptical.py
+++ b/hyp3_autorift/vend/testGeogridOptical.py
@@ -126,6 +126,9 @@ def coregisterLoadMetadata(indir_r, indir_s, urlflag):
 
     x1a, y1a, xsize1, ysize1, x2a, y2a, xsize2, ysize2, trans = obj.coregister(indir_r, indir_s, urlflag)
 
+    xsize1 = min((xsize1, xsize2))
+    ysize1 = min((ysize1, ysize2))
+
     if urlflag is 1:
         DS = gdal.Open('/vsicurl/%s' % (indir_r))
     else:


### PR DESCRIPTION
A partial fix to correct out of index errors when processing optical scenes (typically seen with Landsat-8 pairs) due to calculating different overlapping subset sizes when co-registering the images. 
* only the smallest subset size is used

*Note: this may cause the bounding box may be 1px too small in x and/or y, but there shouldn't be any pixel offsets.*

Full fix will need to be implemented upstream in [autoRIFT](https://github.com/leiyangleon/autoRIFT).

--- 
I've tested this for a failed L8 pair, and for passing S2 and L8 pairs