### PR TITLE
Add workflow for publishing to github container registry

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -177,6 +177,15 @@ jobs:
               ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:latest
           docker push ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:latest
 
+      - name: Publish on github container registry
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "${{ secrets.TOOLS_BOT_PAK }}" | docker login ghcr.io -u tools-bot --password-stdin
+          export SDIST_VERSION=${{ needs.package.outputs.SDIST_VERSION }}
+          docker tag ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:${SDIST_VERSION/+/_} \
+              ghcr.io/${GITHUB_REPOSITORY,,}:${SDIST_VERSION/+/_}
+          docker push ghcr.io/${GITHUB_REPOSITORY,,}:${SDIST_VERSION/+/_}
+
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${HYP3_REGISTRY}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Safety analysis of conda environment
         shell: bash -l {0}
         run: |
-          python -m pip freeze | safety check --full-report --stdin
-          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report --stdin
+          # Ignore Saftey vulnerability #39465, python <= 3.9.1, because python 3.6 is system python in Ubuntu 18.04
+          # Ignore Saftey vulnerability #39462, tornado <= 6.1, because there isn't a new release available
+          python -m pip freeze | safety check --full-report -i 39465 -i 39462 --stdin
+          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report -i 39465 -i 39462 --stdin
 
 
   package:


### PR DESCRIPTION
Container image will show up at the Org level:
![image](https://user-images.githubusercontent.com/7882693/106673931-e9df7880-655e-11eb-9252-68fded9ec96d.png)

And the repo level:
![image](https://user-images.githubusercontent.com/7882693/106673998-054a8380-655f-11eb-849c-a37796729344.png)

This mess `${GITHUB_REPOSITORY,,}` is required because docker can only handle lowercase image names:
```
$ docker tag 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-autorift:0.4.2 ghcr.io/ASFHyP3/hyp3-autorift:0.4.2
Error parsing reference: "ghcr.io/ASFHyP3/hyp3-autorift:0.4.2" is not a valid repository/tag: invalid reference format: repository name must be lowercase
```