### PR TITLE
add log message prior to downloading S2/L8 products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.4.3...v0.4.4)
+
+### Added
+* Log message prior to downloading Sentinel-2 and Landsat 8 products
+
 ## [0.4.3](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.4.2...v0.4.3)
 
 ### Added

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -22,6 +22,7 @@ _s3_client = boto3.client('s3')
 
 
 def download_s3_file_requester_pays(target_path: Union[str, Path], bucket: str, key: str) -> Path:
+    log.info(f'Downloading s3://{bucket}/{key}')
     response = _s3_client.get_object(Bucket=bucket, Key=key, RequestPayer='requester')
     filename = Path(target_path)
     filename.write_bytes(response['Body'].read())


### PR DESCRIPTION
```
download_s3_file_requester_pays('foo.zip', 'usgs-landsat', 'collection02/level-1/standard/oli-tirs/2020/016/008/LC08_L1TP_016008_20200821_20200905_02_T1/LC08_L1TP_016008_20200821_20200905_02_T1_B8.TIF')
2021-02-24 10:50:13,397 - hyp3_autorift.io - INFO - Downloading s3://usgs-landsat/collection02/level-1/standard/oli-tirs/2020/016/008/LC08_L1TP_016008_20200821_20200905_02_T1/LC08_L1TP_016008_20200821_20200905_02_T1_B8.TIF
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/asjohnston/src/hyp3-autorift/hyp3_autorift/io.py", line 26, in download_s3_file_requester_pays
    response = _s3_client.get_object(Bucket=bucket, Key=key, RequestPayer='requester')
  File "/home/asjohnston/miniconda3/envs/hyp3-autorift/lib/python3.8/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/asjohnston/miniconda3/envs/hyp3-autorift/lib/python3.8/site-packages/botocore/client.py", line 676, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.NoSuchKey: An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist.
```