### PR TITLE
Fix missing GDAL drivers

### DIFF
--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -221,6 +221,10 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         meta_s = loadMetadata('secondary')
         geogrid_info = runGeogrid(meta_r, meta_s, epsg=parameter_info['epsg'], **parameter_info['geogrid'])
 
+        # NOTE: After Geogrid is run, all drivers are no longer registered.
+        #       I've got no idea why, or if there are other affects...
+        gdal.AllRegister()
+
         from hyp3_autorift.vend.testautoRIFT_ISCE import generateAutoriftProduct
         netcdf_file = generateAutoriftProduct(
             reference_path, secondary_path, nc_sensor=platform[0], optical_flag=False,


### PR DESCRIPTION
Geogrid somehow wipes out all the GDAL drivers so autoRIFT can't loaddata. This reloads all the drivers, and seems to be all that's needed for autoRIFT to run through successfully, but it's not clear if there are other GDAL things Geogrid affects.

<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/hyp3-autorift/compare/master...develop?template=release.md
 
NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->