### PR TITLE
Update S2 search handling

### DIFF
--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -42,23 +42,25 @@ def get_lc2_metadata(scene_name):
 
 def get_s2_metadata(scene_name):
     response = requests.get(f'{S2_SEARCH_URL}/{scene_name}')
-    response.raise_for_status()
-
-    if response.json().get('code') != 404:
+    try:
+        response.raise_for_status()
         return response.json()
+    except requests.exceptions.HTTPError:
+        if response.status_code != 404:
+            raise
 
-    payload = {
-        'query': {
-            'sentinel:product_id': {
-                'eq': scene_name,
+        payload = {
+            'query': {
+                'sentinel:product_id': {
+                    'eq': scene_name,
+                }
             }
         }
-    }
-    response = requests.post(S2_SEARCH_URL, json=payload)
-    response.raise_for_status()
-    if not response.json().get('numberReturned'):
-        raise ValueError(f'Scene could not be found: {scene_name}')
-    return response.json()['features'][0]
+        response = requests.post(S2_SEARCH_URL, json=payload)
+        response.raise_for_status()
+        if not response.json().get('numberReturned'):
+            raise ValueError(f'Scene could not be found: {scene_name}')
+        return response.json()['features'][0]
 
 
 def least_precise_orbit_of(orbits):

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -49,18 +49,18 @@ def get_s2_metadata(scene_name):
         if response.status_code != 404:
             raise
 
-        payload = {
-            'query': {
-                'sentinel:product_id': {
-                    'eq': scene_name,
-                }
+    payload = {
+        'query': {
+            'sentinel:product_id': {
+                'eq': scene_name,
             }
         }
-        response = requests.post(S2_SEARCH_URL, json=payload)
-        response.raise_for_status()
-        if not response.json().get('numberReturned'):
-            raise ValueError(f'Scene could not be found: {scene_name}')
-        return response.json()['features'][0]
+    }
+    response = requests.post(S2_SEARCH_URL, json=payload)
+    response.raise_for_status()
+    if not response.json().get('numberReturned'):
+        raise ValueError(f'Scene could not be found: {scene_name}')
+    return response.json()['features'][0]
 
 
 def least_precise_orbit_of(orbits):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -28,10 +28,7 @@ def test_get_platform():
 
 @responses.activate
 def test_get_lc2_metadata_not_found():
-    responses.add(
-        responses.GET, f'{process.LC2_SEARCH_URL}/foo',
-        body='{"message": "Item not found"}', status=404,
-    )
+    responses.add(responses.GET, f'{process.LC2_SEARCH_URL}/foo', status=404)
     with pytest.raises(HTTPError):
         process.get_lc2_metadata('foo')
 
@@ -48,10 +45,7 @@ def test_get_lc2_metadata():
 @responses.activate
 def test_get_s2_metadata_not_found():
 
-    responses.add(
-        responses.GET, f'{process.S2_SEARCH_URL}/foo',
-        body='Item not found', status=404,
-    )
+    responses.add(responses.GET, f'{process.S2_SEARCH_URL}/foo', status=404)
     responses.add(
         responses.POST, process.S2_SEARCH_URL,
         body='{"numberReturned": 0}', status=200,
@@ -75,7 +69,7 @@ def test_get_s2_metadata_cog_id():
 def test_get_s2_metadata_esa_id():
     responses.add(
         responses.GET, f'{process.S2_SEARCH_URL}/S2B_MSIL2A_20200913T151809_N0214_R068_T22WEB_20200913T180530',
-        body='Item not found', status=404,
+        status=404,
     )
     responses.add(
         responses.POST, process.S2_SEARCH_URL,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -50,7 +50,7 @@ def test_get_s2_metadata_not_found():
 
     responses.add(
         responses.GET, f'{process.S2_SEARCH_URL}/foo',
-        body='{"code": 404, "message": "Item not found"}', status=200,
+        body='Item not found', status=404,
     )
     responses.add(
         responses.POST, process.S2_SEARCH_URL,
@@ -75,7 +75,7 @@ def test_get_s2_metadata_cog_id():
 def test_get_s2_metadata_esa_id():
     responses.add(
         responses.GET, f'{process.S2_SEARCH_URL}/S2B_MSIL2A_20200913T151809_N0214_R068_T22WEB_20200913T180530',
-        body='{"code": 404, "message": "Item not found"}', status=200,
+        body='Item not found', status=404,
     )
     responses.add(
         responses.POST, process.S2_SEARCH_URL,


### PR DESCRIPTION
Earth Search for Sentinel-2 data now responds with a 404 for missing data (instead of 200, and 404 info inside the response body; see stac-utils/stac-server#54)

This updates our S2 metadata search function for this new behavior. 