### PR TITLE
Add parameter file path as global attribute to netCDF output

### DIFF
--- a/hyp3_autorift/netcdf_output.py
+++ b/hyp3_autorift/netcdf_output.py
@@ -189,7 +189,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
     nc_outfile.setncattr('title', title)
     nc_outfile.setncattr('autoRIFT_software_version', IMG_INFO_DICT["autoRIFT_software_version"])
-    nc_outfile.setncattr('autoRIFT_parameter_file', parameter_file)
+    nc_outfile.setncattr('autoRIFT_parameter_file', parameter_file.replace('/vsicurl/', ''))
     nc_outfile.setncattr('scene_pair_type', pair_type)
     nc_outfile.setncattr('motion_detection_method', detection_method)
     nc_outfile.setncattr('motion_coordinates', coordinates)

--- a/hyp3_autorift/netcdf_output.py
+++ b/hyp3_autorift/netcdf_output.py
@@ -189,7 +189,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
     nc_outfile.setncattr('title', title)
     nc_outfile.setncattr('autoRIFT_software_version', IMG_INFO_DICT["autoRIFT_software_version"])
-    nc_outfile.setncattr('autoRIFT_parameter_file', parameter_file.replace('/vsicurl/', ''))
+    nc_outfile.setncattr('autoRIFT_parameter_file', parameter_file)
     nc_outfile.setncattr('scene_pair_type', pair_type)
     nc_outfile.setncattr('motion_detection_method', detection_method)
     nc_outfile.setncattr('motion_coordinates', coordinates)

--- a/hyp3_autorift/netcdf_output.py
+++ b/hyp3_autorift/netcdf_output.py
@@ -21,7 +21,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
                      offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                      rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
                      detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                     dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector):
+                     dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector, parameter_file):
     vx_mean_shift = offset2vx_1 * dx_mean_shift + offset2vx_2 * dy_mean_shift
     temp = vx_mean_shift
     temp[np.logical_not(SSM)] = np.nan
@@ -189,6 +189,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
     nc_outfile.setncattr('title', title)
     nc_outfile.setncattr('autoRIFT_software_version', IMG_INFO_DICT["autoRIFT_software_version"])
+    nc_outfile.setncattr('autoRIFT_parameter_file', parameter_file)
     nc_outfile.setncattr('scene_pair_type', pair_type)
     nc_outfile.setncattr('motion_detection_method', detection_method)
     nc_outfile.setncattr('motion_coordinates', coordinates)

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -230,7 +230,8 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         from hyp3_autorift.vend.testautoRIFT_ISCE import generateAutoriftProduct
         netcdf_file = generateAutoriftProduct(
             reference_path, secondary_path, nc_sensor=platform[0], optical_flag=False, ncname=None,
-            geogrid_run_info=geogrid_info, **parameter_info['autorift']
+            geogrid_run_info=geogrid_info, **parameter_info['autorift'],
+            parameter_file=parameter_file.replace('/vsicurl/', ''),
         )
 
     else:
@@ -246,7 +247,8 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         netcdf_file = generateAutoriftProduct(
             reference_path, secondary_path, nc_sensor=platform, optical_flag=True, ncname=None,
             reference_metadata=reference_metadata, secondary_metadata=secondary_metadata,
-            geogrid_run_info=geogrid_info, **parameter_info['autorift'], parameter_file=parameter_file,
+            geogrid_run_info=geogrid_info, **parameter_info['autorift'],
+            parameter_file=parameter_file.replace('/vsicurl/', ''),
         )
 
     if netcdf_file is None:

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -246,7 +246,7 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         netcdf_file = generateAutoriftProduct(
             reference_path, secondary_path, nc_sensor=platform, optical_flag=True, ncname=None,
             reference_metadata=reference_metadata, secondary_metadata=secondary_metadata,
-            geogrid_run_info=geogrid_info, **parameter_info['autorift'],
+            geogrid_run_info=geogrid_info, **parameter_info['autorift'], parameter_file=parameter_file,
         )
 
     if netcdf_file is None:

--- a/hyp3_autorift/vend/CHANGES.diff
+++ b/hyp3_autorift/vend/CHANGES.diff
@@ -37,6 +37,16 @@
                      pair_type = 'radar'
                      detection_method = 'feature'
                      coordinates = 'radar'
+@@ -777,7 +778,8 @@
+                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                         rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
+                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
++                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
++                        parameter_file=kwargs['parameter_file'],
+                     )
+
+                 elif nc_sensor == "L":
 @@ -814,7 +815,7 @@
                      master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
                      slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
@@ -46,6 +56,16 @@
                      pair_type = 'optical'
                      detection_method = 'feature'
                      coordinates = 'map'
+@@ -855,7 +857,8 @@
+                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
+                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
++                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
++                        parameter_file=kwargs['parameter_file'],
+                     )
+
+                 elif nc_sensor == "S2":
 @@ -873,8 +874,8 @@
                      master_path = indir_m
                      slave_path = indir_s
@@ -66,6 +86,16 @@
                      pair_type = 'optical'
                      detection_method = 'feature'
                      coordinates = 'map'
+@@ -927,7 +930,8 @@
+                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
+                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
++                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
++                        parameter_file=kwargs['parameter_file'],
+                     )
+
+                 elif nc_sensor is None:
 --- testautoRIFT_ISCE.py	2021-04-15 21:56:06.690237585 -0800
 +++ testautoRIFT_ISCE.py	2021-04-19 11:08:28.349300092 -0800
 @@ -2,6 +2,7 @@
@@ -105,6 +135,16 @@
                      pair_type = 'radar'
                      detection_method = 'feature'
                      coordinates = 'radar'
+@@ -779,7 +780,8 @@
+                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                         rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
+                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
++                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
++                        parameter_file=kwargs['parameter_file'],
+                     )
+
+                 elif nc_sensor == "L":
 @@ -816,7 +817,7 @@
                      master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
                      slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
@@ -114,6 +154,16 @@
                      pair_type = 'optical'
                      detection_method = 'feature'
                      coordinates = 'map'
+@@ -856,7 +858,8 @@
+                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
+                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
++                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
++                        parameter_file=kwargs['parameter_file'],
+                     )
+
+                 elif nc_sensor == "S2":
 @@ -874,8 +875,8 @@
                      master_path = indir_m
                      slave_path = indir_s
@@ -134,6 +184,16 @@
                      pair_type = 'optical'
                      detection_method = 'feature'
                      coordinates = 'map'
+@@ -928,7 +931,8 @@
+                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
+                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
++                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
++                        parameter_file=kwargs['parameter_file'],
+                     )
+
+                 elif nc_sensor is None:
 --- testGeogrid_ISCE.py	2021-04-15 21:56:06.690237585 -0800
 +++ testGeogrid_ISCE.py	2021-04-19 11:08:28.341300071 -0800
 @@ -2,6 +2,7 @@

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -9,5 +9,5 @@ These modules are required for the expected workflow provided to ASF, and are
 provided in autoRIFT, but not distributed as part of the package. These modules
 correspond to release [`v1.2.0`](https://github.com/leiyangleon/autoRIFT/releases/tag/v1.2.0).
 Changes, as listed in `CHANGES.diff`, were done to facilitate better packaging 
-and distribution of these modules and to correctly handle Sentinel-2 Level 1C
-products. 
+and distribution of these modules, to correctly handle Sentinel-2 Level 1C
+products, and to provide better netCDF metadata. 

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -778,7 +778,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
+                        parameter_file=kwargs['parameter_file'],
                     )
 
                 elif nc_sensor == "L":
@@ -856,7 +857,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
+                        parameter_file=kwargs['parameter_file'],
                     )
 
                 elif nc_sensor == "S2":
@@ -928,7 +930,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
+                        parameter_file=kwargs['parameter_file'],
                     )
 
                 elif nc_sensor is None:

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -780,7 +780,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
+                        parameter_file=kwargs['parameter_file'],
                     )
 
                 elif nc_sensor == "L":
@@ -857,7 +858,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
+                        parameter_file=kwargs['parameter_file'],
                     )
 
                 elif nc_sensor == "S2":
@@ -929,7 +931,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector,
+                        parameter_file=kwargs['parameter_file'],
                     )
 
                 elif nc_sensor is None:

--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,6 @@ setup(
     entry_points={'console_scripts': [
         'hyp3_autorift = hyp3_autorift.__main__:main',
         'autorift_proc_pair = hyp3_autorift.process:main',
-        'testautoRIFT_ISCE.py = hyp3_autorift.vend.testautoRIFT_ISCE:main',
-        'testGeogrid_ISCE.py = hyp3_autorift.vend.testGeogrid_ISCE:main',
-        'testautoRIFT.py = hyp3_autorift.vend.testautoRIFT:main',
-        'testGeogridOptical.py = hyp3_autorift.vend.testGeogridOptical:main',
         'topsinsar_filename.py = hyp3_autorift.io:topsinsar_mat',
         ]
     },

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -8,26 +8,6 @@ def test_autorift_proc_pair(script_runner):
     assert ret.success
 
 
-def test_testautorift_isce(script_runner):
-    ret = script_runner.run('testautoRIFT_ISCE.py', '-h')
-    assert ret.success
-
-
-def test_testgeogrid_isce(script_runner):
-    ret = script_runner.run('testGeogrid_ISCE.py', '-h')
-    assert ret.success
-
-
-def test_testautorift(script_runner):
-    ret = script_runner.run('testautoRIFT.py', '-h')
-    assert ret.success
-
-
-def test_testgeogridoptical(script_runner):
-    ret = script_runner.run('testGeogridOptical.py', '-h')
-    assert ret.success
-
-
 def test_topsinsar_filename(script_runner):
     ret = script_runner.run('topsinsar_filename.py', '-h')
     assert ret.success


### PR DESCRIPTION
fixes #64 

In the netCDF global attributes, this will look like:

```
// global attributes:
		...
		:autoRIFT_software_version = "1.2.0" ;
		:autoRIFT_parameter_file = "http://its-live-data.jpl.nasa.gov.s3.amazonaws.com/autorift_parameters/v001/autorift_parameters.shp" ;
		...
````