### PR TITLE
Handle L8 IndexErrors

### DIFF
--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -3,7 +3,19 @@
 This directory contains modules needed for the HyP3 autoRIFT plugin that couldn't
 be easily incorporated from a package manager or installed appropriately.
 
-## `testautoRIFT_ISCE.py`, `testautoRIFT.py`, `testGeogrid_ISCE.py`, and `testGeogridOptical.py`
+## `testautoRIFT_ISCE.py` and `testautoRIFT.py`
+
+These modules are required for the expected workflow provided to ASF, and are
+provided in autoRIFT, but not distributed as part of the package. These modules
+correspond to commit 
+[`b973c1b`](https://github.com/leiyangleon/autoRIFT/commit/b973c1b48b82f3398ece3c34a7cbfca71c4e07cb), 
+which is a [minor patch](https://github.com/leiyangleon/autoRIFT/pull/28)
+to [`v1.2.0`](https://github.com/leiyangleon/autoRIFT/releases/tag/v1.2.0).
+Changes, as listed in `CHANGES.diff`, were done to facilitate better packaging 
+and distribution of these modules, to correctly handle Sentinel-2 Level 1C
+products, and to provide better netCDF metadata.
+
+## `testGeogrid_ISCE.py` and `testGeogridOptical.py`
 
 These modules are required for the expected workflow provided to ASF, and are
 provided in autoRIFT, but not distributed as part of the package. These modules

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -666,8 +666,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 stable_count = np.sum(SSM & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
 
                 V_temp = np.sqrt(VX**2 + VY**2)
-                V_temp_threshold = np.percentile(V_temp[np.logical_not(np.isnan(V_temp))],25)
-                SSM1 = (V_temp <= V_temp_threshold)
+                try:
+                    V_temp_threshold = np.percentile(V_temp[np.logical_not(np.isnan(V_temp))],25)
+                    SSM1 = (V_temp <= V_temp_threshold)
+                except IndexError:
+                    SSM1 = np.zeros(V_temp.shape).astype('bool')
 
                 stable_count1 = np.sum(SSM1 & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
 

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -668,8 +668,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 stable_count = np.sum(SSM & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
 
                 V_temp = np.sqrt(VX**2 + VY**2)
-                V_temp_threshold = np.percentile(V_temp[np.logical_not(np.isnan(V_temp))],25)
-                SSM1 = (V_temp <= V_temp_threshold)
+                try:
+                    V_temp_threshold = np.percentile(V_temp[np.logical_not(np.isnan(V_temp))],25)
+                    SSM1 = (V_temp <= V_temp_threshold)
+                except IndexError:
+                    SSM1 = np.zeros(V_temp.shape).astype('bool')
 
                 stable_count1 = np.sum(SSM1 & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
 


### PR DESCRIPTION
* Applies leiyangleon/autoRIFT#28 to handle L8 IndexErrors

From slack:
>  have checked the IndexError problem when running L8 pairs. It actually appeared when one or two L8 images are completely corrupted (see below the image pair example with the 1st one completely corrupted ), so the ROI is 0. We can let autoRIFT crash in that case, however, I added a condition chheck in autoRIFT to make sure it does not crash and create a final NetCDF output with ROI=0. Please test this version of autoRIFT over those that previously failed and let me know if other changes/errors are encountered. Then, I will update v1.2.0 with the change(s).
> ![image](https://user-images.githubusercontent.com/7882693/116348152-01af4d00-a79a-11eb-8223-80a119ea7559.png)
> ![image](https://user-images.githubusercontent.com/7882693/116348170-0b38b500-a79a-11eb-9c45-af635d73986d.png)
