### PR TITLE
Don't buffer stderr/stdout so that full logs are written

### DIFF
--- a/hyp3_autorift/etc/entrypoint.sh
+++ b/hyp3_autorift/etc/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash --login
 set -e
 conda activate hyp3-autorift
-exec python -u hyp3_autorift "$@"
+exec python -um hyp3_autorift "$@"


### PR DESCRIPTION
Occasionally  in HyP3, the UPLOAD_LOG task will run before the batch job finished flushing it's output to CloudWatch, resulting in an incomplete log in S3.  Job `c97e9e7c-bd35-4d41-be2d-c1e8d24332ec` is an example:
* [step function](https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:230742024655:execution:StepFunction-GZEqFFmoOyWB:c97e9e7c-bd35-4d41-be2d-c1e8d24332ec)
* [cloudwatch log](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Faws$252Fbatch$252Fjob/log-events/Autorift-78e6d073a87af95$252Fdefault$252F68082c32437b4c148f4fd7389d3d9c65)
* [s3 log](https://hyp3-autorift-contentbucket-102baltr3ibfm.s3.us-west-2.amazonaws.com/c97e9e7c-bd35-4d41-be2d-c1e8d24332ec/c97e9e7c-bd35-4d41-be2d-c1e8d24332ec.log)