### PR TITLE
Set GDAL config env variables as well

### DIFF
--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 from datetime import datetime
 from pathlib import Path
 from secrets import token_hex
@@ -178,6 +179,9 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
         gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
         gdal.SetConfigOption('AWS_REGION', 'eu-central-1')
+        os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
+        os.environ['AWS_REQUEST_PAYER'] = 'requester'
+        os.environ['AWS_REGION'] = 'eu-central-1'
 
         reference_metadata = get_s2_metadata(reference)
         reference_path = reference_metadata['assets'][band]['href'].replace('s3://', '/vsis3/')
@@ -193,6 +197,9 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
         gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
         gdal.SetConfigOption('AWS_REGION', 'us-west-2')
+        os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
+        os.environ['AWS_REQUEST_PAYER'] = 'requester'
+        os.environ['AWS_REGION'] = 'us-west-2'
 
         if band == 'B08':
             band = 'B8'

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import shutil
-import sys
 from datetime import datetime
 from pathlib import Path
 from secrets import token_hex
@@ -179,6 +178,7 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
         gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
         gdal.SetConfigOption('AWS_REGION', 'eu-central-1')
+        # Also set for new CXX threads in Geogrid/autoRIFT
         os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
         os.environ['AWS_REQUEST_PAYER'] = 'requester'
         os.environ['AWS_REGION'] = 'eu-central-1'
@@ -197,6 +197,7 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
         gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
         gdal.SetConfigOption('AWS_REGION', 'us-west-2')
+        # Also set for new CXX threads in Geogrid/autoRIFT
         os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
         os.environ['AWS_REQUEST_PAYER'] = 'requester'
         os.environ['AWS_REGION'] = 'us-west-2'


### PR DESCRIPTION
Geogrid/AutoRIFT switched to using CXX bindings instead of python for optical processing [with v1.3.0](https://github.com/leiyangleon/autoRIFT/compare/v1.2.0...v1.3.0) and the CXX GDAL methods called from the CXX binding don't retain config options set via the GDAL python bindings.

Setting them as OS level configs seems to work (must all be new GDAL threads) and we do still need python ones set because we use GDAL later as well. 