### PR TITLE
Bump ISCE to 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 * `conda-env.yml` has been renamed to `environment.yml` in-line with community practice
 * Upgraded to hyp3lib [v1.6.8](https://github.com/ASFHyP3/hyp3-lib/blob/develop/CHANGELOG.md#168) from v1.6.7
+* Upgrade to [ISCE2 v2.5.2 built with autoRIFT v1.3.1](https://anaconda.org/hyp3/isce2)
 
 ## [0.6.1](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.6.0...v0.6.1)
 

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   # For running
   - gdal>=3
   - hyp3lib=1.6.8
-  - isce2=2.5.1.dev7
+  - isce2=2.5.2.dev0
   - autorift=1.3.1
   - boto3
   - matplotlib-base


### PR DESCRIPTION
Should allow us to run on Python 3.9

ISCE 2.5.2.dev0 uploaded here: https://anaconda.org/hyp3/isce2/files