### PR TITLE
Fix version in container

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -53,7 +53,8 @@ jobs:
         shell: bash -l {0}
         run: |
           git fetch origin +refs/tags/*:refs/tags/*
-          echo "SDIST_VERSION=$(python setup.py --version)" >> $GITHUB_ENV
+          export SDIST_VERSION=$(python setup.py --version)
+          echo "SDIST_VERSION=${SDIST_VERSION/+/_}" >> $GITHUB_ENV
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -19,12 +19,8 @@ env:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    outputs:
-      SDIST_VERSION: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -39,25 +35,25 @@ jobs:
           python -m pip install .[develop]
           pytest --cov=hyp3_autorift
 
-      - name: Determine SDIST_VERSION
-        id: version
+  dockerize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          mamba-version: "*"
+          python-version: 3.9
+          activate-environment: hyp3-autorift
+          environment-file: environment.yml
+
+      - name: set environment variables
         shell: bash -l {0}
         run: |
           git fetch origin +refs/tags/*:refs/tags/*
-          export SDIST_VERSION=$(python setup.py --version)
-          echo "::set-output name=version::${SDIST_VERSION/+/_}"
-
-
-  dockerize:
-    runs-on: ubuntu-latest
-    needs: pytest
-    env:
-      SDIST_VERSION: ${{ needs.pytest.outputs.SDIST_VERSION }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: set environment variables
-        run: |
+          echo "SDIST_VERSION=$(python setup.py --version)" >> $GITHUB_ENV
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Version incorrectly specified because the tags aren't checked out before copying the repo into the container. 

---

Also, we could just bring pytest inside the dockerize job at this point... but I think I like them having separate names...