### PR TITLE
Fix push to GitHub Container Registry

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -103,13 +103,17 @@ jobs:
           username: tools-bot
           password: ${{ secrets.TOOLS_BOT_PAK }}
 
+      - name: Lowercase repo for Github Container Registry
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
       - name: Publish on github container registry
         if: github.ref == 'refs/heads/main'
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ${{ env.HYP3_REGISTRY }}/${{ github.event.repository.name }}:${{ env.SDIST_VERSION }}
-          dst: ghcr.io//${{ github.event.repository.name }}:${{ env.SDIST_VERSION }}
-
+          dst: ghcr.io/${{ env.REPO }}:${{ env.SDIST_VERSION }}
 
       - name: Logout of Amazon ECR
         if: always()


### PR DESCRIPTION
[Action](https://github.com/ASFHyP3/hyp3-autorift/runs/3033348019?check_suite_focus=true) failed due to missing owner in GitHub Container Registry image name. This add the owner name and keeps owner/repository name generalized.