### PR TITLE
Update metadata collection for Landsat-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.6.3](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.6.2...v0.6.3)
+
+### Changed
+* `process.get_lc2_metadata()` now attempts to fetch STAC metadata from the
+  https://landsatlook.usgs.gov/ API and falls back the STAC json in the S3 bucket
+
+### Removed
+* `hyp3_autorift.process` and the associated `autorift_proc_pair` entrypoint no longer
+  accept the `band` argument, which wasn't being used.
+
 ## [0.6.2](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.6.1...v0.6.2)
 
 ### Changed

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -5,7 +5,6 @@ import logging
 import os
 import textwrap
 
-import boto3
 from hyp3lib import DemError
 from isce.applications.topsApp import TopsInSAR
 from osgeo import gdal
@@ -15,8 +14,6 @@ from scipy.io import savemat
 from hyp3_autorift.geometry import flip_point_coordinates
 
 log = logging.getLogger(__name__)
-
-_s3_client = boto3.client('s3')
 
 
 def find_jpl_parameter_info(polygon: ogr.Geometry, parameter_file: str) -> dict:

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -111,7 +111,7 @@ def get_datetime(scene_name):
     raise ValueError(f'Unsupported scene format: {scene_name}')
 
 
-def get_product_name(reference_name, secondary_name, orbit_files=None, pixel_spacing=240, band=None):
+def get_product_name(reference_name, secondary_name, orbit_files=None, pixel_spacing=240):
     mission = reference_name[0:2]
     plat1 = reference_name.split('_')[0][-1]
     plat2 = secondary_name.split('_')[0][-1]
@@ -129,7 +129,7 @@ def get_product_name(reference_name, secondary_name, orbit_files=None, pixel_spa
         orbit = least_precise_orbit_of(orbit_files)
         misc = polarization1 + polarization2 + orbit
     else:
-        misc = band.ljust(3, '-')
+        misc = 'B08'
 
     product_id = token_hex(2).upper()
 
@@ -289,7 +289,7 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
     elif naming_scheme == 'ASF':
         product_name = get_product_name(
             reference, secondary, orbit_files=(reference_state_vec, secondary_state_vec),
-            band=band, pixel_spacing=parameter_info['xsize'],
+            pixel_spacing=parameter_info['xsize'],
         )
         product_file = Path(f'{product_name}.nc')
         shutil.move(netcdf_file, str(product_file))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 from botocore.stub import Stubber
 
-from hyp3_autorift.io import _s3_client
+from hyp3_autorift.process import S3_CLIENT
 
 
 @pytest.fixture
-def s3_stub():
-    with Stubber(_s3_client) as stubber:
+def s3_stubber():
+    with Stubber(S3_CLIENT) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -46,7 +46,18 @@ def test_get_lc2_stac_json_key():
 
 
 @responses.activate
-def test_get_lc2_metadata(s3_stubber):
+def test_get_lc2_metadata():
+    responses.add(
+        responses.GET, f'{process.LC2_SEARCH_URL}/LC08_L1TP_009011_20200703_20200913_02_T1',
+        body='{"foo": "bar"}', status=200,
+    )
+
+    assert process.get_lc2_metadata('LC08_L1TP_009011_20200703_20200913_02_T1') == {'foo': 'bar'}
+
+
+@responses.activate
+def test_get_lc2_metadata_fallback(s3_stubber):
+    responses.add(responses.GET, f'{process.LC2_SEARCH_URL}/LC08_L1TP_009011_20200703_20200913_02_T1', status=404)
     params = {
         'Bucket': process.LANDSAT_BUCKET,
         'Key': 'foo.json',
@@ -172,29 +183,18 @@ def test_get_product_name():
     payload = {
         'reference_name': 'S2B_MSIL2A_20200903T151809_N0214_R068_T22WEB_20200903T194353',
         'secondary_name': 'S2B_MSIL2A_20200913T151809_N0214_R068_T22WEB_20200913T180530',
-        'band': 'B08',
         'pixel_spacing': 40,
     }
     name = process.get_product_name(**payload)
     assert match(r'S2BB_20200903T151809_20200913T151809_B08010_VEL40_A_[0-9A-F]{4}$', name)
 
     payload = {
-        'reference_name': 'LE07_L2SP_233095_20200306_20200822_02_T2',
-        'secondary_name': 'LE07_L2SP_233095_20190115_20200827_02_T2',
-        'band': 'B7',
-        'pixel_spacing': 40,
-    }
-    name = process.get_product_name(**payload)
-    assert match(r'LE77_20200306T000000_20190115T000000_B7-416_VEL40_A_[0-9A-F]{4}$', name)
-
-    payload = {
         'reference_name': 'LC08_L1TP_009011_20200703_20200913_02_T1',
         'secondary_name': 'LC08_L1TP_009011_20200820_20200905_02_T1',
-        'band': 'B8',
         'pixel_spacing': 40,
     }
     name = process.get_product_name(**payload)
-    assert match(r'LC88_20200703T000000_20200820T000000_B8-048_VEL40_A_[0-9A-F]{4}$', name)
+    assert match(r'LC88_20200703T000000_20200820T000000_B08048_VEL40_A_[0-9A-F]{4}$', name)
 
 
 def test_get_s1_primary_polarization():

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -5,16 +5,8 @@ from unittest import mock
 
 import pytest
 import responses
-from botocore.stub import Stubber
 
 from hyp3_autorift import process
-
-
-@pytest.fixture
-def s3_stubber():
-    with Stubber(process.S3_CLIENT) as stubber:
-        yield stubber
-        stubber.assert_no_pending_responses()
 
 
 def test_get_platform():


### PR DESCRIPTION
Currently, looking up the metadata from the `*.json` in the USGS product bucket can fail because USGS is changing the "assets" name for bands to be more descriptive. E.g.,`B8.TIF` --> `pan` for  for "Collection 2 Level-1 Panchromatic Band". 

This appears to be part of a STAC catalog update as the current catalog still has the old asset names and is reporting an older STAC version than the JSONs in the bucket. 

This makes it so we:
* query the API first and fall back to the JSON
* attempt to access the `B8.TIF` asset and fall back to the `pan` asset