### PR TITLE
Apply radar reference velocity fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.1](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.6.3...v0.7.0)
+
+### Changed
+* Applied a fix to the autoRIFT packaging script that updates the reference velocity
+  fields for projected velocity, as described in the [vendored software README.md](hyp3_autorift/vend/README.md).
+
 ## [0.7.0](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.6.3...v0.7.0)
 
 ### Changed

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -27,7 +27,12 @@ Landsat-8/Sentintel-2 acquisition times and their respective center date.
 **Note:** The `topsinsar_filename.py` included here is not used, but retained for reference.
 We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`. 
 
-Additionally, the changes listed in `DATE_DT.diff` were applied to report the
-`img_pair_info.date_dt` attribute in the netCDF product as fractional days, instead
-of rounding down to the nearest whole day. These changes should be included in the
-next autoRIFT release.
+## Additional Patches
+
+1. The changes listed in `DATE_DT.diff` were applied to report the
+   `img_pair_info.date_dt` attribute in the netCDF product as fractional days, instead
+   of rounding down to the nearest whole day. These changes should be included in the
+   next autoRIFT release.
+2. The changes listed in `REF_VEL.diff` were applied to update the reference velocity
+   fields for projected velocity. These changes are expected to be a temporary measure
+   until better estimates of the velocity fields are generated. 

--- a/hyp3_autorift/vend/REF_VEL.diff
+++ b/hyp3_autorift/vend/REF_VEL.diff
@@ -1,0 +1,25 @@
+diff --git a/netcdf_output.py b/netcdf_output.py
+--- a/netcdf_output.py
++++ b/netcdf_output.py
+@@ -312,12 +312,19 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         VXR[angle_df_R < angle_threshold_R] = np.nan
+         VYR[angle_df_R < angle_threshold_R] = np.nan
+ 
++        #   obsolete fusion routine using the sp mask file to distinguish pure smoothed slopes and reference velocity fields
+ #        VXP = VXS
+ #        VXP[MM == 1] = VXR[MM == 1]
+ #        VYP = VYS
+ #        VYP[MM == 1] = VYR[MM == 1]
+-        VXP = VXR
+-        VYP = VYR
++
++        #   by default, use the updated dhdxs and dhdys input files that combine the velocity fields and smoothed slopes; should be turned off when better estimates of velocity fields are available
++        VXP = VXS
++        VYP = VYS
++        
++#        #   use the updated (better) estimates of velocity fields; by default, is turned off; should be turned on after generating the new velocity fields
++#        VXP = VXR
++#        VYP = VYR
+ 
+         VXP = VXP.astype(np.float32)
+         VYP = VYP.astype(np.float32)

--- a/hyp3_autorift/vend/netcdf_output.py
+++ b/hyp3_autorift/vend/netcdf_output.py
@@ -289,12 +289,19 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         VXR[angle_df_R < angle_threshold_R] = np.nan
         VYR[angle_df_R < angle_threshold_R] = np.nan
 
+        #   obsolete fusion routine using the sp mask file to distinguish pure smoothed slopes and reference velocity fields
 #        VXP = VXS
 #        VXP[MM == 1] = VXR[MM == 1]
 #        VYP = VYS
 #        VYP[MM == 1] = VYR[MM == 1]
-        VXP = VXR
-        VYP = VYR
+
+        #   by default, use the updated dhdxs and dhdys input files that combine the velocity fields and smoothed slopes; should be turned off when better estimates of velocity fields are available
+        VXP = VXS
+        VYP = VYS
+        
+#        #   use the updated (better) estimates of velocity fields; by default, is turned off; should be turned on after generating the new velocity fields
+#        VXP = VXR
+#        VYP = VYR
 
         VXP = VXP.astype(np.float32)
         VYP = VYP.astype(np.float32)


### PR DESCRIPTION
This is a change requested by JPL that only affects the netCDF packaging part of the S1 campaign. Once there is a better understanding of the velocity fields (from the mini-campaign data), new velocity field estimates will be generated and this patch will likely be removed. 