### PR TITLE
NetCDF packaging refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.7.4](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.7.3...v0.7.4)
 
 ### Changed
-* A patch was applied to clean up some netCDF variable attributes, as described
+* Patches were applied to clean up some netCDF variable attributes, as described
   in the [vendored software README.md](hyp3_autorift/vend/README.md)
 
 ## [0.7.3](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.7.2...v0.7.3)

--- a/hyp3_autorift/vend/CHANGES-METADATA-3.diff
+++ b/hyp3_autorift/vend/CHANGES-METADATA-3.diff
@@ -1,0 +1,2272 @@
+--- netcdf_output.py
++++ netcdf_output.py
+@@ -1,17 +1,17 @@
+-#!/usr/bin/env python3
++# Yang Lei, Jet Propulsion Laboratory
++# November 2017
+
+-########
+-#Yang Lei, Jet Propulsion Laboratory
+-#November 2017
+-
+-import numpy as np
+-import subprocess
+-import os
+ import datetime
++import os
++import subprocess
++
+ import netCDF4
++import numpy as np
++import pandas as pd
+
+ import hyp3_autorift
+
++
+ def v_error_cal(vx_error, vy_error):
+     vx = np.random.normal(0, vx_error, 1000000)
+     vy = np.random.normal(0, vy_error, 1000000)
+@@ -19,174 +19,110 @@ def v_error_cal(vx_error, vy_error):
+     return np.std(v)
+
+
+-def netCDF_packaging_intermediate(Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask, filename='./autoRIFT_intermediate.nc'):
+-
+-
+-    title = 'autoRIFT intermediate results'
+-    author = 'Alex S. Gardner, JPL/NASA; Yang Lei, GPS/Caltech'
+-    institution = 'NASA Jet Propulsion Laboratory (JPL), California Institute of Technology'
++def netCDF_packaging_intermediate(Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX,
++                                  SearchLimitY, origSize, noDataMask, filename='./autoRIFT_intermediate.nc'):
+
+-
+-    clobber = True     # overwrite existing output nc file
+-
+-    nc_outfile = netCDF4.Dataset(filename,'w',clobber=clobber,format='NETCDF4')
++    nc_outfile = netCDF4.Dataset(filename, 'w', clobber=True, format='NETCDF4')
+
+     # First set global attributes that GDAL uses when it reads netCFDF files
+-    nc_outfile.setncattr('date_created',datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
+-    nc_outfile.setncattr('title',title)
+-    nc_outfile.setncattr('author',author)
+-    nc_outfile.setncattr('institution',institution)
+-
+-
++    nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
++    nc_outfile.setncattr('title', 'autoRIFT intermediate results')
++    nc_outfile.setncattr('author', 'Alex S. Gardner, JPL/NASA; Yang Lei, GPS/Caltech')
++    nc_outfile.setncattr('institution', 'NASA Jet Propulsion Laboratory (JPL), California Institute of Technology')
+
+     # set dimensions
+     dimidY, dimidX = Dx.shape
+-    nc_outfile.createDimension('x',dimidX)
+-    nc_outfile.createDimension('y',dimidY)
+-    #    pdb.set_trace()
+-    x = np.arange(0,dimidX,1)
+-    y = np.arange(0,dimidY,1)
+-    #    pdb.set_trace()
+-    chunk_lines = np.min([np.ceil(8192/dimidY)*128, dimidY])
+-    #    ChunkSize = [dimidX, chunk_lines]
+-    ChunkSize = [chunk_lines, dimidX]
+-
+-    nc_outfile.createDimension('x1',noDataMask.shape[1])
+-    nc_outfile.createDimension('y1',noDataMask.shape[0])
++    nc_outfile.createDimension('x', dimidX)
++    nc_outfile.createDimension('y', dimidY)
+
++    x = np.arange(0, dimidX, 1)
++    y = np.arange(0, dimidY, 1)
+
++    chunk_lines = np.min([np.ceil(8192/dimidY)*128, dimidY])
++    ChunkSize = [chunk_lines, dimidX]
+
++    nc_outfile.createDimension('x1', noDataMask.shape[1])
++    nc_outfile.createDimension('y1', noDataMask.shape[0])
+
+-    varname='x'
+-    datatype=np.dtype('int32')
+-    dimensions=('x')
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','x_index')
+-    var.setncattr('description','x index')
++    var = nc_outfile.createVariable('x', np.dtype('int32'), ('x',), fill_value=None)
++    var.setncattr('standard_name', 'x_index')
++    var.setncattr('description', 'x index')
+     var[:] = x
+
+-    varname='y'
+-    datatype=np.dtype('int32')
+-    dimensions=('y')
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','y_index')
+-    var.setncattr('description','y index')
++    var = nc_outfile.createVariable('y', np.dtype('int32'), ('y',), fill_value=None)
++    var.setncattr('standard_name', 'y_index')
++    var.setncattr('description', 'y index')
+     var[:] = y
+
+-
+-
+-    NoDataValue = np.nan
+-
+-    varname='Dx'
+-    datatype=np.dtype('float32')
+-    dimensions=('y','x')
+-    FillValue=NoDataValue
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize, fill_value=FillValue)
+-    var.setncattr('standard_name','x_offset')
+-    var.setncattr('description','x offset')
++    var = nc_outfile.createVariable('Dx', np.dtype('float32'), ('y', 'x'), fill_value=np.nan,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'x_offset')
++    var.setncattr('description', 'x offset')
+     var[:] = Dx.astype(np.float32)
+
+-    varname='Dy'
+-    datatype=np.dtype('float32')
+-    dimensions=('y','x')
+-    FillValue=NoDataValue
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize, fill_value=FillValue)
+-    var.setncattr('standard_name','y_offset')
+-    var.setncattr('description','y offset')
++    var = nc_outfile.createVariable('Dy', np.dtype('float32'), ('y', 'x'), fill_value=np.nan,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'y_offset')
++    var.setncattr('description', 'y offset')
+     var[:] = Dy.astype(np.float32)
+
+-    varname='InterpMask'
+-    datatype=np.dtype('uint8')
+-    dimensions=('y','x')
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-    var.setncattr('standard_name','interpolated_value_mask')
+-    var.setncattr('description','light interpolation mask')
++    var = nc_outfile.createVariable('InterpMask', np.dtype('uint8'), ('y', 'x'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'interpolated_value_mask')
++    var.setncattr('description', 'light interpolation mask')
+     var[:] = np.round(np.clip(InterpMask, 0, 255)).astype('uint8')
+
+-    varname='ChipSizeX'
+-    datatype=np.dtype('uint16')
+-    dimensions=('y','x')
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-    var.setncattr('standard_name','chip_size_x')
+-    var.setncattr('description','width of search window')
++    var = nc_outfile.createVariable('ChipSizeX', np.dtype('uint16'), ('y', 'x'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'chip_size_x')
++    var.setncattr('description', 'width of search window')
+     var[:] = np.round(np.clip(ChipSizeX, 0, 65535)).astype('uint16')
+
+-    varname='SearchLimitX'
+-    datatype=np.dtype('uint8')
+-    dimensions=('y','x')
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-    var.setncattr('standard_name','search_limit_x')
+-    var.setncattr('description','search limit x')
++    var = nc_outfile.createVariable('SearchLimitX', np.dtype('uint8'), ('y', 'x'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'search_limit_x')
++    var.setncattr('description', 'search limit x')
+     var[:] = np.round(np.clip(SearchLimitX, 0, 255)).astype('uint8')
+
+-    varname='SearchLimitY'
+-    datatype=np.dtype('uint8')
+-    dimensions=('y','x')
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-    var.setncattr('standard_name','search_limit_y')
+-    var.setncattr('description','search limit y')
++    var = nc_outfile.createVariable('SearchLimitY', np.dtype('uint8'), ('y', 'x'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'search_limit_y')
++    var.setncattr('description', 'search limit y')
+     var[:] = np.round(np.clip(SearchLimitY, 0, 255)).astype('uint8')
+
+-    varname='noDataMask'
+-    datatype=np.dtype('uint8')
+-    dimensions=('y1','x1')
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-    var.setncattr('standard_name','nodata_value_mask')
+-    var.setncattr('description','nodata value mask')
++    var = nc_outfile.createVariable('noDataMask', np.dtype('uint8'), ('y1', 'x1'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'nodata_value_mask')
++    var.setncattr('description', 'nodata value mask')
+     var[:] = np.round(np.clip(noDataMask, 0, 255)).astype('uint8')
+
+-    varname='GridSpacingX'
+-    datatype=np.dtype('uint16')
+-    dimensions=()
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','GridSpacingX')
+-    var.setncattr('description','grid spacing x')
++    var = nc_outfile.createVariable('GridSpacingX', np.dtype('uint16'), (), fill_value=None)
++    var.setncattr('standard_name', 'GridSpacingX')
++    var.setncattr('description', 'grid spacing x')
+     var[0] = GridSpacingX
+
+-    varname='ScaleChipSizeY'
+-    datatype=np.dtype('float32')
+-    dimensions=()
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','ScaleChipSizeY')
+-    var.setncattr('description','scale of chip size in y to chip size in x')
++    var = nc_outfile.createVariable('ScaleChipSizeY', np.dtype('float32'), (), fill_value=None)
++    var.setncattr('standard_name', 'ScaleChipSizeY')
++    var.setncattr('description', 'scale of chip size in y to chip size in x')
+     var[0] = ScaleChipSizeY
+
+-    varname='origSizeX'
+-    datatype=np.dtype('uint16')
+-    dimensions=()
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','origSizeX')
+-    var.setncattr('description','original array size x')
++    var = nc_outfile.createVariable('origSizeX', np.dtype('uint16'), (), fill_value=None)
++    var.setncattr('standard_name', 'origSizeX')
++    var.setncattr('description', 'original array size x')
+     var[0] = origSize[1]
+
+-    varname='origSizeY'
+-    datatype=np.dtype('uint16')
+-    dimensions=()
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','origSizeY')
+-    var.setncattr('description','original array size y')
++    var = nc_outfile.createVariable('origSizeY', np.dtype('uint16'), (), fill_value=None)
++    var.setncattr('standard_name', 'origSizeY')
++    var.setncattr('description', 'original array size y')
+     var[0] = origSize[0]
+
+-
+-    nc_outfile.sync() # flush data to disk
++    nc_outfile.sync()  # flush data to disk
+     nc_outfile.close()
+
+
+ def netCDF_read_intermediate(filename='./autoRIFT_intermediate.nc'):
+
+-    from netCDF4 import Dataset
+-    inter_file = Dataset(filename, mode='r')
++    inter_file = netCDF4.Dataset(filename, mode='r')
+     Dx = inter_file.variables['Dx'][:].data
+     Dy = inter_file.variables['Dy'][:].data
+     InterpMask = inter_file.variables['InterpMask'][:].data
+@@ -197,7 +133,7 @@ def netCDF_read_intermediate(filename='./autoRIFT_intermediate.nc'):
+     noDataMask = noDataMask.astype('bool')
+     GridSpacingX = inter_file.variables['GridSpacingX'][:].data
+     ScaleChipSizeY = inter_file.variables['ScaleChipSizeY'][:].data
+-    origSize = (inter_file.variables['origSizeY'][:].data,inter_file.variables['origSizeX'][:].data)
++    origSize = (inter_file.variables['origSizeY'][:].data, inter_file.variables['origSizeX'][:].data)
+
+     return Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask
+
+@@ -207,61 +143,64 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+                      DXref, DYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
+                      detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+                      dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector, parameter_file):
++
+     vx_mean_shift = offset2vx_1 * dx_mean_shift + offset2vx_2 * dy_mean_shift
+     temp = vx_mean_shift
+     temp[np.logical_not(SSM)] = np.nan
+-#        vx_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
++    # vx_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+     vx_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
++
+     vy_mean_shift = offset2vy_1 * dx_mean_shift + offset2vy_2 * dy_mean_shift
+     temp = vy_mean_shift
+     temp[np.logical_not(SSM)] = np.nan
+-#        vy_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
++    # vy_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+     vy_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
+
+-
+     vx_mean_shift1 = offset2vx_1 * dx_mean_shift1 + offset2vx_2 * dy_mean_shift1
+     temp = vx_mean_shift1
+     temp[np.logical_not(SSM1)] = np.nan
+     vx_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
++
+     vy_mean_shift1 = offset2vy_1 * dx_mean_shift1 + offset2vy_2 * dy_mean_shift1
+     temp = vy_mean_shift1
+     temp[np.logical_not(SSM1)] = np.nan
+     vy_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
+
+-
+-
+     V = np.sqrt(VX**2+VY**2)
+
+     if pair_type is 'radar':
+         dr_2_vr_factor = np.median(offset2vr[np.logical_not(np.isnan(offset2vr))])
+-        SlantRangePixelSize = np.median(offset2vr[np.logical_not(np.isnan(offset2vr))]) *dt/365.0/24.0/3600.0
+-        azimuthPixelSize = np.median(offset2va[np.logical_not(np.isnan(offset2va))]) *dt/365.0/24.0/3600.0
+-#        VR = DX * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
+-#        VA = (DY) * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
++        SlantRangePixelSize = np.median(offset2vr[np.logical_not(np.isnan(offset2vr))]) * dt/365.0/24.0/3600.0
++        azimuthPixelSize = np.median(offset2va[np.logical_not(np.isnan(offset2va))]) * dt/365.0/24.0/3600.0
++
++        # VR = DX * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
+         VR = DX * offset2vr
+-        VA = (DY) * offset2va
+         VR = VR.astype(np.float32)
++
++        # VA = DY * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
++        VA = DY * offset2va
+         VA = VA.astype(np.float32)
+
+         VRref = DXref * offset2vr
+-        VAref = (DYref) * offset2va
+         VRref = VRref.astype(np.float32)
+-        VAref = VAref.astype(np.float32)
+
++        VAref = DYref * offset2va
++        VAref = VAref.astype(np.float32)
+
+-#        vr_mean_shift = dx_mean_shift * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
+-#        va_mean_shift = (dy_mean_shift) * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
+-#
+-#        vr_mean_shift1 = dx_mean_shift1 * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
+-#        va_mean_shift1 = (dy_mean_shift1) * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
++        # vr_mean_shift = dx_mean_shift * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
+         vr_mean_shift = dx_mean_shift * offset2vr
+-        va_mean_shift = (dy_mean_shift) * offset2va
+         vr_mean_shift = np.median(vr_mean_shift[np.logical_not(np.isnan(vr_mean_shift))])
++
++        # va_mean_shift = dy_mean_shift * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
++        va_mean_shift = dy_mean_shift * offset2va
+         va_mean_shift = np.median(va_mean_shift[np.logical_not(np.isnan(va_mean_shift))])
+
++        # vr_mean_shift1 = dx_mean_shift1 * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
+         vr_mean_shift1 = dx_mean_shift1 * offset2vr
+-        va_mean_shift1 = (dy_mean_shift1) * offset2va
+         vr_mean_shift1 = np.median(vr_mean_shift1[np.logical_not(np.isnan(vr_mean_shift1))])
++
++        # va_mean_shift1 = dy_mean_shift1 * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
++        va_mean_shift1 = dy_mean_shift1 * offset2va
+         va_mean_shift1 = np.median(va_mean_shift1[np.logical_not(np.isnan(va_mean_shift1))])
+
+         # create the (slope parallel & reference) flow-based range-projected result
+@@ -272,8 +211,8 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         VXR = alpha_ref * VXref
+         VYR = alpha_ref * VYref
+
+-        zero_flag_sp = (SX == 0)&(SY == 0)
+-        zero_flag_ref = (VXref == 0)&(VYref == 0)
++        zero_flag_sp = (SX == 0) & (SY == 0)
++        zero_flag_ref = (VXref == 0) & (VYref == 0)
+         VXS[zero_flag_sp] = np.nan
+         VYS[zero_flag_sp] = np.nan
+         VXR[zero_flag_ref] = np.nan
+@@ -294,19 +233,20 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         VXR[angle_df_R < angle_threshold_R] = np.nan
+         VYR[angle_df_R < angle_threshold_R] = np.nan
+
+-        #   obsolete fusion routine using the sp mask file to distinguish pure smoothed slopes and reference velocity fields
+-#        VXP = VXS
+-#        VXP[MM == 1] = VXR[MM == 1]
+-#        VYP = VYS
+-#        VYP[MM == 1] = VYR[MM == 1]
++        # obsolete fusion routine using the sp mask file to distinguish pure
++        # smoothed slopes and reference velocity fields
++        # VXP = VXS
++        # VXP[MM == 1] = VXR[MM == 1]
++        # VYP = VYS
++        # VYP[MM == 1] = VYR[MM == 1]
+
+-        #   by default, use the updated dhdxs and dhdys input files that combine the velocity fields and smoothed slopes; should be turned off when better estimates of velocity fields are available
++        # FIXME: Switch to using the updated (better) estimates of velocity fields when available
++        # Use the updated dhdxs and dhdys input files that combine the velocity fields and smoothed slopes
+         VXP = VXS
+         VYP = VYS
+-
+-#        #   use the updated (better) estimates of velocity fields; by default, is turned off; should be turned on after generating the new velocity fields
+-#        VXP = VXR
+-#        VYP = VYR
++        # use the updated (better) estimates of velocity fields
++        # VXP = VXR
++        # VYP = VYR
+
+         VXP = VXP.astype(np.float32)
+         VYP = VYP.astype(np.float32)
+@@ -319,33 +259,34 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         stable_count1_p = np.sum(SSM1 & np.logical_not(np.isnan(VXP)))
+
+         vxp_mean_shift = 0.0
+-        vyp_mean_shift = 0.0
+         vxp_mean_shift1 = 0.0
++
++        vyp_mean_shift = 0.0
+         vyp_mean_shift1 = 0.0
+
+         if stable_count_p != 0:
+             temp = VXP.copy() - VX.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
+             vxp_mean_shift = vx_mean_shift + bias_mean_shift / 1
+
+             temp = VYP.copy() - VY.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
+             vyp_mean_shift = vy_mean_shift + bias_mean_shift / 1
+
+         if stable_count1_p != 0:
+             temp = VXP.copy() - VX.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
+             vxp_mean_shift1 = vx_mean_shift1 + bias_mean_shift1 / 1
+
+             temp = VYP.copy() - VY.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
+             vyp_mean_shift1 = vy_mean_shift1 + bias_mean_shift1 / 1
+
+@@ -357,21 +298,18 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         else:
+             stable_shift_applied_p = 1
+
+-
+-
+     CHIPSIZEX = CHIPSIZEX * rangePixelSize
+     CHIPSIZEY = CHIPSIZEY * azimuthPixelSize
+
+     NoDataValue = -32767
+     noDataMask = np.isnan(VX) | np.isnan(VY)
+
++    # VXref[noDataMask] = NoDataValue
++    # VYref[noDataMask] = NoDataValue
+
+-#    VXref[noDataMask] = NoDataValue
+-#    VYref[noDataMask] = NoDataValue
+-
+-#    if pair_type is 'radar':
+-#        VRref[noDataMask] = NoDataValue
+-#        VAref[noDataMask] = NoDataValue
++    # if pair_type is 'radar':
++    #     VRref[noDataMask] = NoDataValue
++    #     VAref[noDataMask] = NoDataValue
+
+     CHIPSIZEX[noDataMask] = 0
+     CHIPSIZEY[noDataMask] = 0
+@@ -381,15 +319,15 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+     author = 'Alex S. Gardner, JPL/NASA; Yang Lei, GPS/Caltech'
+     institution = 'NASA Jet Propulsion Laboratory (JPL), California Institute of Technology'
+
+-#    VX = np.round(np.clip(VX, -32768, 32767)).astype(np.int16)
+-#    VY = np.round(np.clip(VY, -32768, 32767)).astype(np.int16)
+-#    V = np.round(np.clip(V, -32768, 32767)).astype(np.int16)
+-#    if pair_type is 'radar':
+-#        VR = np.round(np.clip(VR, -32768, 32767)).astype(np.int16)
+-#        VA = np.round(np.clip(VA, -32768, 32767)).astype(np.int16)
+-#    CHIPSIZEX = np.round(np.clip(CHIPSIZEX, 0, 65535)).astype(np.uint16)
+-#    CHIPSIZEY = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype(np.uint16)
+-#    INTERPMASK = np.round(np.clip(INTERPMASK, 0, 255)).astype(np.uint8)
++    # VX = np.round(np.clip(VX, -32768, 32767)).astype(np.int16)
++    # VY = np.round(np.clip(VY, -32768, 32767)).astype(np.int16)
++    # V = np.round(np.clip(V, -32768, 32767)).astype(np.int16)
++    # if pair_type is 'radar':
++    #     VR = np.round(np.clip(VR, -32768, 32767)).astype(np.int16)
++    #     VA = np.round(np.clip(VA, -32768, 32767)).astype(np.int16)
++    # CHIPSIZEX = np.round(np.clip(CHIPSIZEX, 0, 65535)).astype(np.uint16)
++    # CHIPSIZEY = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype(np.uint16)
++    # INTERPMASK = np.round(np.clip(INTERPMASK, 0, 255)).astype(np.uint8)
+
+     source = f'NASA MEaSUREs ITS_LIVE project. Processed by ASF DAAC HyP3 {datetime.datetime.now().year} using the ' \
+              f'{hyp3_autorift.__name__} plugin version {hyp3_autorift.__version__} running autoRIFT version ' \
+@@ -419,204 +357,129 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+
+     clobber = True     # overwrite existing output nc file
+
+-    nc_outfile = netCDF4.Dataset(out_nc_filename,'w',clobber=clobber,format='NETCDF4')
++    nc_outfile = netCDF4.Dataset(out_nc_filename, 'w', clobber=clobber, format='NETCDF4')
+
+     # First set global attributes that GDAL uses when it reads netCFDF files
+-    nc_outfile.setncattr('GDAL_AREA_OR_POINT','Area')
+-    nc_outfile.setncattr('Conventions','CF-1.6')
+-    nc_outfile.setncattr('date_created',datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
+-    nc_outfile.setncattr('title',title)
++    nc_outfile.setncattr('GDAL_AREA_OR_POINT', 'Area')
++    nc_outfile.setncattr('Conventions', 'CF-1.6')
++    nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
++    nc_outfile.setncattr('title', title)
+     nc_outfile.setncattr('autoRIFT_software_version', IMG_INFO_DICT["autoRIFT_software_version"])
+     nc_outfile.setncattr('autoRIFT_parameter_file', parameter_file)
+-    nc_outfile.setncattr('scene_pair_type',pair_type)
+-    nc_outfile.setncattr('motion_detection_method',detection_method)
+-    nc_outfile.setncattr('motion_coordinates',coordinates)
++    nc_outfile.setncattr('scene_pair_type', pair_type)
++    nc_outfile.setncattr('motion_detection_method', detection_method)
++    nc_outfile.setncattr('motion_coordinates', coordinates)
+     nc_outfile.setncattr('author', author)
+     nc_outfile.setncattr('institution', institution)
+     nc_outfile.setncattr('source', source)
+     nc_outfile.setncattr('references', references)
+
+-    varname='img_pair_info'
+-#    datatype=np.dtype('S1')
+-    datatype='U1'
+-    dimensions=()
+-    FillValue=None
+-
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    # variable made, now add attributes
+-
+-#    var.setncattr('mission_img1',master_split[0][0])
+-#    var.setncattr('sensor_img1','C')
+-#    var.setncattr('satellite_img1',master_split[0][1:3])
+-#    var.setncattr('acquisition_img1',master_split[5][0:8])
+-#    var.setncattr('absolute_orbit_number_img1',master_split[7])
+-#    var.setncattr('mission_data_take_ID_img1',master_split[8])
+-#    var.setncattr('product_unique_ID_img1',master_split[9][0:4])
+-#
+-#    var.setncattr('mission_img2',slave_split[0][0])
+-#    var.setncattr('sensor_img2','C')
+-#    var.setncattr('satellite_img2',slave_split[0][1:3])
+-#    var.setncattr('acquisition_img2',slave_split[5][0:8])
+-#    var.setncattr('absolute_orbit_number_img2',slave_split[7])
+-#    var.setncattr('mission_data_take_ID_img2',slave_split[8])
+-#    var.setncattr('product_unique_ID_img2',slave_split[9][0:4])
+-#
+-#    from datetime import date
+-#    d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
+-#    d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
+-#    date_dt = d1 - d0
+-#    var.setncattr('date_dt',np.float64(np.abs(date_dt.days)))
+-#    if date_dt.days < 0:
+-#        date_ct = d1 + (d0 - d1)/2
+-#        var.setncattr('date_center',date_ct.strftime("%Y%m%d"))
+-#    else:
+-#        date_ct = d0 + (d1 - d0)/2
+-#        var.setncattr('date_center',date_ct.strftime("%Y%m%d"))
+-##    var.setncattr('date_center',np.abs(np.int(slave_split[5][0:8])+np.int(master_split[5][0:8]))/2)
+-#
+-#    var.setncattr('roi_valid_percentage',roi_valid_percentage)
+-#    var.setncattr('autoRIFT_software_version',version)
+
++    var = nc_outfile.createVariable('img_pair_info', 'U1', (), fill_value=None)
+     for key in IMG_INFO_DICT:
+         if key == 'autoRIFT_software_version':
+             continue
+-        var.setncattr(key,IMG_INFO_DICT[key])
+-
+-
+-
++        var.setncattr(key, IMG_INFO_DICT[key])
+
+     # set dimensions
+     dimidY, dimidX = VX.shape
+-    nc_outfile.createDimension('x',dimidX)
+-    nc_outfile.createDimension('y',dimidY)
+-#    pdb.set_trace()
+-    x = np.arange(tran[0],tran[0]+tran[1]*(dimidX),tran[1])
+-    y = np.arange(tran[3],tran[3]+tran[5]*(dimidY),tran[5])
+-#    pdb.set_trace()
++    nc_outfile.createDimension('x', dimidX)
++    nc_outfile.createDimension('y', dimidY)
++
++    x = np.arange(tran[0], tran[0] + tran[1] * dimidX, tran[1])
++    y = np.arange(tran[3], tran[3] + tran[5] * dimidY, tran[5])
++
+     chunk_lines = np.min([np.ceil(8192/dimidY)*128, dimidY])
+-#    ChunkSize = [dimidX, chunk_lines]
+     ChunkSize = [chunk_lines, dimidX]
+
+
+-    varname='x'
+-    datatype=np.dtype('float64')
+-    dimensions=('x')
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','projection_x_coordinate')
+-    var.setncattr('description','x coordinate of projection')
+-    var.setncattr('units','m')
+-#    var.setncattr('scene_pair_type',pair_type)
+-#    var.setncattr('motion_detection_method',detection_method)
+-#    var.setncattr('motion_coordinates',coordinates)
+-#    pdb.set_trace()
++    var = nc_outfile.createVariable('x', np.dtype('float64'), 'x', fill_value=None)
++    var.setncattr('standard_name', 'projection_x_coordinate')
++    var.setncattr('description', 'x coordinate of projection')
++    var.setncattr('units', 'm')
++    # var.setncattr('scene_pair_type', pair_type)
++    # var.setncattr('motion_detection_method', detection_method)
++    # var.setncattr('motion_coordinates', coordinates)
++    # pdb.set_trace()
+     var[:] = x
+
+-    varname='y'
+-    datatype=np.dtype('float64')
+-    dimensions=('y')
+-    FillValue=None
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
+-    var.setncattr('standard_name','projection_y_coordinate')
+-    var.setncattr('description','y coordinate of projection')
+-    var.setncattr('units','m')
+-#    var.setncattr('scene_pair_type',pair_type)
+-#    var.setncattr('motion_detection_method',detection_method)
+-#    var.setncattr('motion_coordinates',coordinates)
+-    var[:] = y
+-
+-
+-
+-    if (srs.GetAttrValue('PROJECTION') == 'Polar_Stereographic'):
+
+-#        mapping_name='Polar_Stereographic'
+-        mapping_name='mapping'
+-        grid_mapping='polar_stereographic'  # need to set this as an attribute for the image variables
+-#        datatype=np.dtype('S1')
+-        datatype='U1'
+-        dimensions=()
+-        FillValue=None
+-
+-        var = nc_outfile.createVariable(mapping_name,datatype,dimensions, fill_value=FillValue)
+-        # variable made, now add attributes
+-
+-        var.setncattr('grid_mapping_name',grid_mapping)
+-        var.setncattr('straight_vertical_longitude_from_pole',srs.GetProjParm('central_meridian'))
+-        var.setncattr('false_easting',srs.GetProjParm('false_easting'))
+-        var.setncattr('false_northing',srs.GetProjParm('false_northing'))
+-        var.setncattr('latitude_of_projection_origin',np.sign(srs.GetProjParm('latitude_of_origin'))*90.0)  # could hardcode this to be -90 for landsat - just making it more general, maybe...
+-        var.setncattr('latitude_of_origin',srs.GetProjParm('latitude_of_origin'))
+-#        var.setncattr('longitude_of_prime_meridian',float(srs.GetAttrValue('GEOGCS|PRIMEM',1)))
+-        var.setncattr('semi_major_axis',float(srs.GetAttrValue('GEOGCS|SPHEROID',1)))
+-#        var.setncattr('semi_minor_axis',float(6356.752))
+-        var.setncattr('scale_factor_at_projection_origin',1)
+-        var.setncattr('inverse_flattening',float(srs.GetAttrValue('GEOGCS|SPHEROID',2)))
+-        var.setncattr('spatial_ref',srs.ExportToWkt())
+-        var.setncattr('spatial_proj4',srs.ExportToProj4())
+-        var.setncattr('spatial_epsg',epsg)
+-        var.setncattr('GeoTransform',' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
+-
+-    elif (srs.GetAttrValue('PROJECTION') == 'Transverse_Mercator'):
+-
+-#        mapping_name='UTM_projection'
+-        mapping_name='mapping'
+-        grid_mapping='universal_transverse_mercator'  # need to set this as an attribute for the image variables
+-#        datatype=np.dtype('S1')
+-        datatype='U1'
+-        dimensions=()
+-        FillValue=None
++    var = nc_outfile.createVariable('y', np.dtype('float64'), 'y', fill_value=None)
++    var.setncattr('standard_name', 'projection_y_coordinate')
++    var.setncattr('description', 'y coordinate of projection')
++    var.setncattr('units', 'm')
++    # var.setncattr('scene_pair_type', pair_type)
++    # var.setncattr('motion_detection_method', detection_method)
++    # var.setncattr('motion_coordinates', coordinates)
++    var[:] = y
+
+-        var = nc_outfile.createVariable(mapping_name,datatype,dimensions, fill_value=FillValue)
+-        # variable made, now add attributes
+
++    var = nc_outfile.createVariable('mapping', 'U1', (), fill_value=None)
++    if srs.GetAttrValue('PROJECTION') == 'Polar_Stereographic':
++        grid_mapping = 'polar_stereographic'  # need to set this as an attribute for the image variables
++        var.setncattr('grid_mapping_name', grid_mapping)
++
++        var.setncattr('straight_vertical_longitude_from_pole', srs.GetProjParm('central_meridian'))
++        var.setncattr('false_easting', srs.GetProjParm('false_easting'))
++        var.setncattr('false_northing', srs.GetProjParm('false_northing'))
++        var.setncattr('latitude_of_projection_origin', np.sign(srs.GetProjParm('latitude_of_origin'))*90.0)  # could hardcode this to be -90 for landsat - just making it more general, maybe...
++        var.setncattr('latitude_of_origin', srs.GetProjParm('latitude_of_origin'))
++        # var.setncattr('longitude_of_prime_meridian', float(srs.GetAttrValue('GEOGCS|PRIMEM', 1)))
++        var.setncattr('semi_major_axis', float(srs.GetAttrValue('GEOGCS|SPHEROID', 1)))
++        # var.setncattr('semi_minor_axis', float(6356.752))
++        var.setncattr('scale_factor_at_projection_origin', 1)
++        var.setncattr('inverse_flattening', float(srs.GetAttrValue('GEOGCS|SPHEROID', 2)))
++        var.setncattr('spatial_ref', srs.ExportToWkt())
++        var.setncattr('spatial_proj4', srs.ExportToProj4())
++        var.setncattr('spatial_epsg', epsg)
++        var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
++
++    elif srs.GetAttrValue('PROJECTION') == 'Transverse_Mercator':
++        grid_mapping = 'universal_transverse_mercator'  # need to set this as an attribute for the image variables
++        var.setncattr('grid_mapping_name', grid_mapping)
+
+-        var.setncattr('grid_mapping_name',grid_mapping)
+         zone = epsg - np.floor(epsg/100)*100
+-        var.setncattr('utm_zone_number',zone)
+-        var.setncattr('CoordinateTransformType','Projection')
+-        var.setncattr('CoordinateAxisTypes','GeoX GeoY')
+-#        var.setncattr('longitude_of_central_meridian',srs.GetProjParm('central_meridian'))
+-#        var.setncattr('false_easting',srs.GetProjParm('false_easting'))
+-#        var.setncattr('false_northing',srs.GetProjParm('false_northing'))
+-#        var.setncattr('latitude_of_projection_origin',srs.GetProjParm('latitude_of_origin'))
+-#        var.setncattr('scale_factor_at_central_meridian',srs.GetProjParm('scale_factor'))
+-#        var.setncattr('longitude_of_prime_meridian',float(srs.GetAttrValue('GEOGCS|PRIMEM',1)))
+-        var.setncattr('semi_major_axis',float(srs.GetAttrValue('GEOGCS|SPHEROID',1)))
+-        var.setncattr('inverse_flattening',float(srs.GetAttrValue('GEOGCS|SPHEROID',2)))
+-        var.setncattr('spatial_ref',srs.ExportToWkt())
+-        var.setncattr('spatial_proj4',srs.ExportToProj4())
+-        var.setncattr('spatial_epsg',epsg)
+-        var.setncattr('GeoTransform',' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
++        var.setncattr('utm_zone_number', zone)
++        var.setncattr('CoordinateTransformType', 'Projection')
++        var.setncattr('CoordinateAxisTypes', 'GeoX GeoY')
++        # var.setncattr('longitude_of_central_meridian', srs.GetProjParm('central_meridian'))
++        # var.setncattr('false_easting', srs.GetProjParm('false_easting'))
++        # var.setncattr('false_northing', srs.GetProjParm('false_northing'))
++        # var.setncattr('latitude_of_projection_origin', srs.GetProjParm('latitude_of_origin'))
++        # var.setncattr('scale_factor_at_central_meridian', srs.GetProjParm('scale_factor'))
++        # var.setncattr('longitude_of_prime_meridian', float(srs.GetAttrValue('GEOGCS|PRIMEM', 1)))
++        var.setncattr('semi_major_axis', float(srs.GetAttrValue('GEOGCS|SPHEROID', 1)))
++        var.setncattr('inverse_flattening', float(srs.GetAttrValue('GEOGCS|SPHEROID', 2)))
++        var.setncattr('spatial_ref', srs.ExportToWkt())
++        var.setncattr('spatial_proj4', srs.ExportToProj4())
++        var.setncattr('spatial_epsg', epsg)
++        var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
++
+     else:
+         raise Exception('Projection {0} not recognized for this program'.format(srs.GetAttrValue('PROJECTION')))
+
+
+-    varname='vx'
+-    datatype=np.dtype('int16')
+-    dimensions=('y','x')
+-    FillValue=NoDataValue
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize, fill_value=FillValue)
+-
+-
+-    var.setncattr('standard_name','x_velocity')
++    var = nc_outfile.createVariable('vx', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'x_velocity')
+     if pair_type is 'radar':
+-        var.setncattr('description','velocity component in x direction from radar range and azimuth measurements')
++        var.setncattr('description', 'velocity component in x direction from radar range and azimuth measurements')
+     else:
+-        var.setncattr('description','velocity component in x direction')
+-    var.setncattr('units','m/y')
+-
++        var.setncattr('description', 'velocity component in x direction')
++    var.setncattr('units', 'm/y')
++    var.setncattr('grid_mapping', grid_mapping)
+
+     if stable_count != 0:
+         temp = VX.copy() - VXref.copy()
+         temp[np.logical_not(SSM)] = np.nan
+-#        vx_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++        # vx_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+         vx_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+     else:
+         vx_error_mask = np.nan
+     if stable_count1 != 0:
+         temp = VX.copy() - VXref.copy()
+         temp[np.logical_not(SSM1)] = np.nan
+-#        vx_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++        # vx_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+         vx_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+     else:
+         vx_error_slow = np.nan
+@@ -630,76 +493,79 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         vx_error = vx_error_slow
+     else:
+         vx_error = vx_error_mod
+-    var.setncattr('error',int(round(vx_error*10))/10)
+-    var.setncattr('error_description','best estimate of x_velocity error: vx_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+-
+-    if stable_shift_applied == 2:
+-        var.setncattr('stable_shift',int(round(vx_mean_shift1*10))/10)
+-    elif stable_shift_applied == 1:
+-        var.setncattr('stable_shift',int(round(vx_mean_shift*10))/10)
+-    else:
+-        var.setncattr('stable_shift',np.nan)
+-    var.setncattr('stable_shift_flag',stable_shift_applied)
+-    var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
+
++    var.setncattr('error', int(round(vx_error*10))/10)
++    var.setncattr('error_description', 'best estimate of x_velocity error: vx_error is populated '
++                                       'according to the approach used for the velocity bias '
++                                       'correction as indicated in "stable_shift_flag"')
+
+-    var.setncattr('stable_count_mask',stable_count)
+-    var.setncattr('stable_count_slow',stable_count1)
+     if stable_count != 0:
+-        var.setncattr('stable_shift_mask',int(round(vx_mean_shift*10))/10)
++        var.setncattr('error_mask', int(round(vx_error_mask*10))/10)
+     else:
+-        var.setncattr('stable_shift_mask',np.nan)
++        var.setncattr('error_mask', np.nan)
++    var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing '
++                                            'surfaces with velocity < 15 m/yr identified from an external mask')
++
++    var.setncattr('error_modeled', int(round(vx_error_mod*10))/10)
++    var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
++
+     if stable_count1 != 0:
+-        var.setncattr('stable_shift_slow',int(round(vx_mean_shift1*10))/10)
++        var.setncattr('error_slow', int(round(vx_error_slow*10))/10)
++    else:
++        var.setncattr('error_slow', np.nan)
++    var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
++
++    if stable_shift_applied == 2:
++        var.setncattr('stable_shift', int(round(vx_mean_shift1*10))/10)
++    elif stable_shift_applied == 1:
++        var.setncattr('stable_shift', int(round(vx_mean_shift*10))/10)
+     else:
+-        var.setncattr('stable_shift_slow',np.nan)
++        var.setncattr('stable_shift', np.nan)
++    var.setncattr('stable_shift_flag', stable_shift_applied)
++    var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
++                                                   '1 = correction from overlapping stable surface mask (stationary '
++                                                   'or slow-flowing surfaces with velocity < 15 m/yr)(top priority); '
++                                                   '2 = correction from slowest 25% of overlapping velocities '
++                                                   '(second priority)')
+
+     if stable_count != 0:
+-        var.setncattr('error_mask',int(round(vx_error_mask*10))/10)
++        var.setncattr('stable_shift_mask', int(round(vx_mean_shift*10))/10)
+     else:
+-        var.setncattr('error_mask',np.nan)
+-    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
++        var.setncattr('stable_shift_mask', np.nan)
++    var.setncattr('stable_count_mask', stable_count)
++
+     if stable_count1 != 0:
+-        var.setncattr('error_slow',int(round(vx_error_slow*10))/10)
++        var.setncattr('stable_shift_slow', int(round(vx_mean_shift1*10))/10)
+     else:
+-        var.setncattr('error_slow',np.nan)
+-    var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+-    var.setncattr('error_modeled',int(round(vx_error_mod*10))/10)
+-    var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+-
+-    var.setncattr('grid_mapping',mapping_name)
++        var.setncattr('stable_shift_slow', np.nan)
++    var.setncattr('stable_count_slow', stable_count1)
+
+     VX[noDataMask] = NoDataValue
+     var[:] = np.round(np.clip(VX, -32768, 32767)).astype(np.int16)
+-#    var.setncattr('_FillValue',np.int16(FillValue))
++    # var.setncattr('_FillValue', np.int16(FillValue))
+
+
+-
+-    varname='vy'
+-    datatype=np.dtype('int16')
+-    dimensions=('y','x')
+-    FillValue=NoDataValue
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-
+-    var.setncattr('standard_name','y_velocity')
++    var = nc_outfile.createVariable('vy', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'y_velocity')
+     if pair_type is 'radar':
+-        var.setncattr('description','velocity component in y direction from radar range and azimuth measurements')
++        var.setncattr('description', 'velocity component in y direction from radar range and azimuth measurements')
+     else:
+-        var.setncattr('description','velocity component in y direction')
+-    var.setncattr('units','m/y')
+-
++        var.setncattr('description', 'velocity component in y direction')
++    var.setncattr('units', 'm/y')
++    var.setncattr('grid_mapping', grid_mapping)
+
+     if stable_count != 0:
+         temp = VY.copy() - VYref.copy()
+         temp[np.logical_not(SSM)] = np.nan
+-#        vy_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++        # vy_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+         vy_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+     else:
+         vy_error_mask = np.nan
+     if stable_count1 != 0:
+         temp = VY.copy() - VYref.copy()
+         temp[np.logical_not(SSM1)] = np.nan
+-#        vy_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++        # vy_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+         vy_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+     else:
+         vy_error_slow = np.nan
+@@ -713,124 +579,111 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         vy_error = vy_error_slow
+     else:
+         vy_error = vy_error_mod
+-    var.setncattr('error',int(round(vy_error*10))/10)
+-    var.setncattr('error_description','best estimate of y_velocity error: vy_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
++    var.setncattr('error', int(round(vy_error*10))/10)
++    var.setncattr('error_description', 'best estimate of y_velocity error: vy_error is populated according '
++                                       'to the approach used for the velocity bias correction as indicated '
++                                       'in "stable_shift_flag"')
+
++    if stable_count != 0:
++        var.setncattr('error_mask', int(round(vy_error_mask*10))/10)
++    else:
++        var.setncattr('error_mask', np.nan)
++    var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces '
++                                            'with velocity < 15 m/yr identified from an external mask')
++
++    var.setncattr('error_modeled', int(round(vy_error_mod * 10)) / 10)
++    var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
++
++    if stable_count1 != 0:
++        var.setncattr('error_slow', int(round(vy_error_slow * 10)) / 10)
++    else:
++        var.setncattr('error_slow', np.nan)
++    var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
+
+     if stable_shift_applied == 2:
+-        var.setncattr('stable_shift',int(round(vy_mean_shift1*10))/10)
++        var.setncattr('stable_shift', int(round(vy_mean_shift1*10))/10)
+     elif stable_shift_applied == 1:
+-        var.setncattr('stable_shift',int(round(vy_mean_shift*10))/10)
++        var.setncattr('stable_shift', int(round(vy_mean_shift*10))/10)
+     else:
+-        var.setncattr('stable_shift',np.nan)
+-    var.setncattr('stable_shift_flag',stable_shift_applied)
+-    var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
++        var.setncattr('stable_shift', np.nan)
+
++    var.setncattr('stable_shift_flag', stable_shift_applied)
++    var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
++                                                   '1 = correction from overlapping stable surface mask (stationary '
++                                                   'or slow-flowing surfaces with velocity < 15 m/yr)(top priority); '
++                                                   '2 = correction from slowest 25% of overlapping velocities '
++                                                   '(second priority)')
+
+-    var.setncattr('stable_count_mask',stable_count)
+-    var.setncattr('stable_count_slow',stable_count1)
+     if stable_count != 0:
+-        var.setncattr('stable_shift_mask',int(round(vy_mean_shift*10))/10)
++        var.setncattr('stable_shift_mask', int(round(vy_mean_shift*10))/10)
+     else:
+-        var.setncattr('stable_shift_mask',np.nan)
+-    if stable_count1 != 0:
+-        var.setncattr('stable_shift_slow',int(round(vy_mean_shift1*10))/10)
+-    else:
+-        var.setncattr('stable_shift_slow',np.nan)
++        var.setncattr('stable_shift_mask', np.nan)
++    var.setncattr('stable_count_mask', stable_count)
+
+-    if stable_count != 0:
+-        var.setncattr('error_mask',int(round(vy_error_mask*10))/10)
+-    else:
+-        var.setncattr('error_mask',np.nan)
+-    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+     if stable_count1 != 0:
+-        var.setncattr('error_slow',int(round(vy_error_slow*10))/10)
++        var.setncattr('stable_shift_slow', int(round(vy_mean_shift1*10))/10)
+     else:
+-        var.setncattr('error_slow',np.nan)
+-    var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+-    var.setncattr('error_modeled',int(round(vy_error_mod*10))/10)
+-    var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+-
+-
+-    var.setncattr('grid_mapping',mapping_name)
++        var.setncattr('stable_shift_slow', np.nan)
++    var.setncattr('stable_count_slow', stable_count1)
+
+     VY[noDataMask] = NoDataValue
+     var[:] = np.round(np.clip(VY, -32768, 32767)).astype(np.int16)
+-#    var.setncattr('missing_value',np.int16(NoDataValue))
+-
+-
++    # var.setncattr('missing_value', np.int16(NoDataValue))
+
+
+-    varname='v'
+-    datatype=np.dtype('int16')
+-    dimensions=('y','x')
+-    FillValue=NoDataValue
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-    var.setncattr('standard_name','velocity')
++    var = nc_outfile.createVariable('v', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'velocity')
+     if pair_type is 'radar':
+-        var.setncattr('description','velocity magnitude from radar range and azimuth measurements')
++        var.setncattr('description', 'velocity magnitude from radar range and azimuth measurements')
+     else:
+-        var.setncattr('description','velocity magnitude')
+-    var.setncattr('units','m/y')
+-
+-    var.setncattr('grid_mapping',mapping_name)
++        var.setncattr('description', 'velocity magnitude')
++    var.setncattr('units', 'm/y')
++    var.setncattr('grid_mapping', grid_mapping)
+
+     V[noDataMask] = NoDataValue
+     var[:] = np.round(np.clip(V, -32768, 32767)).astype(np.int16)
+-#    var.setncattr('missing_value',np.int16(NoDataValue))
+-
++    # var.setncattr('missing_value',np.int16(NoDataValue))
+
+
+-
+-    v_error = v_error_cal(vx_error, vy_error)
+-    varname='v_error'
+-    datatype=np.dtype('int16')
+-    dimensions=('y','x')
+-    FillValue=NoDataValue
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-    var.setncattr('standard_name','velocity_error')
++    var = nc_outfile.createVariable('v_error', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'velocity_error')
+     if pair_type is 'radar':
+-        var.setncattr('description','velocity magnitude error from radar range and azimuth measurements')
++        var.setncattr('description', 'velocity magnitude error from radar range and azimuth measurements')
+     else:
+-        var.setncattr('description','velocity magnitude error')
+-    var.setncattr('units','m/y')
+-
+-    var.setncattr('grid_mapping',mapping_name)
++        var.setncattr('description', 'velocity magnitude error')
++    var.setncattr('units', 'm/y')
++    var.setncattr('grid_mapping', grid_mapping)
+
++    v_error = v_error_cal(vx_error, vy_error)
+     V_error = np.sqrt((vx_error * VX / V)**2 + (vy_error * VY / V)**2)
+-    V_error[V==0] = v_error
++    V_error[V == 0] = v_error
+     V_error[noDataMask] = NoDataValue
+     var[:] = np.round(np.clip(V_error, -32768, 32767)).astype(np.int16)
+ #    var.setncattr('missing_value',np.int16(NoDataValue))
+
+
+-
+-
+-
+     if pair_type is 'radar':
++        var = nc_outfile.createVariable('vr', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+
+-        varname='vr'
+-        datatype=np.dtype('int16')
+-        dimensions=('y','x')
+-        FillValue=NoDataValue
+-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-
+-
+-        var.setncattr('standard_name','range_velocity')
+-        var.setncattr('description','velocity in radar range direction')
+-        var.setncattr('units','m/y')
++        var.setncattr('standard_name', 'range_velocity')
++        var.setncattr('description', 'velocity in radar range direction')
++        var.setncattr('units', 'm/y')
++        var.setncattr('grid_mapping', grid_mapping)
+
+         if stable_count != 0:
+             temp = VR.copy() - VRref.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            vr_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++            # vr_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+             vr_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+         else:
+             vr_error_mask = np.nan
+         if stable_count1 != 0:
+             temp = VR.copy() - VRref.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            vr_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++            # vr_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+             vr_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+         else:
+             vr_error_slow = np.nan
+@@ -841,76 +694,76 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+             vr_error = vr_error_slow
+         else:
+             vr_error = vr_error_mod
+-        var.setncattr('error',int(round(vr_error*10))/10)
+-        var.setncattr('error_description','best estimate of range_velocity error: vr_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+
++        var.setncattr('error', int(round(vr_error*10))/10)
++        var.setncattr('error_description', 'best estimate of range_velocity error: vr_error is populated '
++                                           'according to the approach used for the velocity bias correction '
++                                           'as indicated in "stable_shift_flag"')
+
+-        if stable_shift_applied == 2:
+-            var.setncattr('stable_shift',int(round(vr_mean_shift1*10))/10)
+-        elif stable_shift_applied == 1:
+-            var.setncattr('stable_shift',int(round(vr_mean_shift*10))/10)
++        if stable_count != 0:
++            var.setncattr('error_mask', int(round(vr_error_mask*10))/10)
+         else:
+-            var.setncattr('stable_shift',np.nan)
+-        var.setncattr('stable_shift_flag',stable_shift_applied)
+-        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
++            var.setncattr('error_mask', np.nan)
++        var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing '
++                                                'surfaces with velocity < 15 m/yr identified from an external mask')
+
++        var.setncattr('error_modeled', int(round(vr_error_mod*10))/10)
++        var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
+
+-        var.setncattr('stable_count_mask',stable_count)
+-        var.setncattr('stable_count_slow',stable_count1)
+-        if stable_count != 0:
+-            var.setncattr('stable_shift_mask',int(round(vr_mean_shift*10))/10)
+-        else:
+-            var.setncattr('stable_shift_mask',np.nan)
+         if stable_count1 != 0:
+-            var.setncattr('stable_shift_slow',int(round(vr_mean_shift1*10))/10)
++            var.setncattr('error_slow', int(round(vr_error_slow*10))/10)
++        else:
++            var.setncattr('error_slow', np.nan)
++        var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
++
++        if stable_shift_applied == 2:
++            var.setncattr('stable_shift', int(round(vr_mean_shift1*10))/10)
++        elif stable_shift_applied == 1:
++            var.setncattr('stable_shift', int(round(vr_mean_shift*10))/10)
+         else:
+-            var.setncattr('stable_shift_slow',np.nan)
++            var.setncattr('stable_shift', np.nan)
++        var.setncattr('stable_shift_flag', stable_shift_applied)
++        var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
++                                                       '1 = correction from overlapping stable surface mask '
++                                                       '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
++                                                       '(top priority); 2 = correction from slowest 25% of overlapping '
++                                                       'velocities (second priority)')
+
+         if stable_count != 0:
+-            var.setncattr('error_mask',int(round(vr_error_mask*10))/10)
++            var.setncattr('stable_shift_mask', int(round(vr_mean_shift*10))/10)
+         else:
+-            var.setncattr('error_mask',np.nan)
+-        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
++            var.setncattr('stable_shift_mask', np.nan)
++        var.setncattr('stable_count_mask', stable_count)
++
+         if stable_count1 != 0:
+-            var.setncattr('error_slow',int(round(vr_error_slow*10))/10)
++            var.setncattr('stable_shift_slow', int(round(vr_mean_shift1*10))/10)
+         else:
+-            var.setncattr('error_slow',np.nan)
+-        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+-        var.setncattr('error_modeled',int(round(vr_error_mod*10))/10)
+-        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+-
+-
+-        var.setncattr('grid_mapping',mapping_name)
++            var.setncattr('stable_shift_slow', np.nan)
++        var.setncattr('stable_count_slow', stable_count1)
+
+         VR[noDataMask] = NoDataValue
+         var[:] = np.round(np.clip(VR, -32768, 32767)).astype(np.int16)
+-#        var.setncattr('missing_value',np.int16(NoDataValue))
+-
+-
+-
+-        varname='va'
+-        datatype=np.dtype('int16')
+-        dimensions=('y','x')
+-        FillValue=NoDataValue
+-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        # var.setncattr('missing_value', np.int16(NoDataValue))
+
+
+-        var.setncattr('standard_name','azimuth_velocity')
+-        var.setncattr('description','velocity in radar azimuth direction')
+-        var.setncattr('units','m/y')
+-
++        var = nc_outfile.createVariable('va', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        var.setncattr('standard_name', 'azimuth_velocity')
++        var.setncattr('description', 'velocity in radar azimuth direction')
++        var.setncattr('units', 'm/y')
++        var.setncattr('grid_mapping', grid_mapping)
+
+         if stable_count != 0:
+             temp = VA.copy() - VAref.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            va_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++            # va_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+             va_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+         else:
+             va_error_mask = np.nan
+         if stable_count1 != 0:
+             temp = VA.copy() - VAref.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            va_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++            # va_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+             va_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+         else:
+             va_error_slow = np.nan
+@@ -921,75 +774,76 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+             va_error = va_error_slow
+         else:
+             va_error = va_error_mod
+-        var.setncattr('error',int(round(va_error*10))/10)
+-        var.setncattr('error_description','best estimate of azimuth_velocity error: va_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+
++        var.setncattr('error', int(round(va_error*10))/10)
++        var.setncattr('error_description', 'best estimate of azimuth_velocity error: va_error is populated '
++                                           'according to the approach used for the velocity bias correction '
++                                           'as indicated in "stable_shift_flag"')
+
+-        if stable_shift_applied == 2:
+-            var.setncattr('stable_shift',int(round(va_mean_shift1*10))/10)
+-        elif stable_shift_applied == 1:
+-            var.setncattr('stable_shift',int(round(va_mean_shift*10))/10)
++        if stable_count != 0:
++            var.setncattr('error_mask', int(round(va_error_mask*10))/10)
+         else:
+-            var.setncattr('stable_shift',np.nan)
+-        var.setncattr('stable_shift_flag',stable_shift_applied)
+-        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
++            var.setncattr('error_mask', np.nan)
++        var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+
++        var.setncattr('error_modeled', int(round(va_error_mod*10))/10)
++        var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
+
+-        var.setncattr('stable_count_mask',stable_count)
+-        var.setncattr('stable_count_slow',stable_count1)
+-        if stable_count != 0:
+-            var.setncattr('stable_shift_mask',int(round(va_mean_shift*10))/10)
+-        else:
+-            var.setncattr('stable_shift_mask',np.nan)
+         if stable_count1 != 0:
+-            var.setncattr('stable_shift_slow',int(round(va_mean_shift1*10))/10)
++            var.setncattr('error_slow', int(round(va_error_slow*10))/10)
+         else:
+-            var.setncattr('stable_shift_slow',np.nan)
++            var.setncattr('error_slow', np.nan)
++        var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
++
++        if stable_shift_applied == 2:
++            var.setncattr('stable_shift', int(round(va_mean_shift1*10))/10)
++        elif stable_shift_applied == 1:
++            var.setncattr('stable_shift', int(round(va_mean_shift*10))/10)
++        else:
++            var.setncattr('stable_shift', np.nan)
++        var.setncattr('stable_shift_flag', stable_shift_applied)
++        var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
++                                                       '1 = correction from overlapping stable surface mask '
++                                                       '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
++                                                       '(top priority); 2 = correction from slowest 25% of overlapping '
++                                                       'velocities (second priority)')
+
+         if stable_count != 0:
+-            var.setncattr('error_mask',int(round(va_error_mask*10))/10)
++            var.setncattr('stable_shift_mask', int(round(va_mean_shift*10))/10)
+         else:
+-            var.setncattr('error_mask',np.nan)
+-        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
++            var.setncattr('stable_shift_mask', np.nan)
++        var.setncattr('stable_count_mask', stable_count)
++
+         if stable_count1 != 0:
+-            var.setncattr('error_slow',int(round(va_error_slow*10))/10)
++            var.setncattr('stable_shift_slow', int(round(va_mean_shift1*10))/10)
+         else:
+-            var.setncattr('error_slow',np.nan)
+-        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+-        var.setncattr('error_modeled',int(round(va_error_mod*10))/10)
+-        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+-
+-
+-        var.setncattr('grid_mapping',mapping_name)
++            var.setncattr('stable_shift_slow', np.nan)
++        var.setncattr('stable_count_slow', stable_count1)
+
+         VA[noDataMask] = NoDataValue
+         var[:] = np.round(np.clip(VA, -32768, 32767)).astype(np.int16)
+-#        var.setncattr('missing_value',np.int16(NoDataValue))
+-
+-
+-
+-
++        # var.setncattr('missing_value', np.int16(NoDataValue))
+
+         # fuse the (slope parallel & reference) flow-based range-projected result with the raw observed range/azimuth-based result
+         if stable_count_p != 0:
+             temp = VXP.copy() - VXref.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++            # vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+             vxp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+
+             temp = VYP.copy() - VYref.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++            # vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+             vyp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+         if stable_count1_p != 0:
+             temp = VXP.copy() - VXref.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++            # vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+             vxp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+
+             temp = VYP.copy() - VYref.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++            # vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+             vyp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+         vxp_error_mod = (error_vector[0][4]*IMG_INFO_DICT['date_dt']+error_vector[1][4])/IMG_INFO_DICT['date_dt']*365
+         vyp_error_mod = (error_vector[0][5]*IMG_INFO_DICT['date_dt']+error_vector[1][5])/IMG_INFO_DICT['date_dt']*365
+@@ -1006,14 +860,12 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+
+         VP_error = np.sqrt((vxp_error * VXP / VP)**2 + (vyp_error * VYP / VP)**2)
+
+-
+         VXPP[V_error > VP_error] = VXP[V_error > VP_error]
+         VYPP[V_error > VP_error] = VYP[V_error > VP_error]
+         VXP = VXPP.astype(np.float32)
+         VYP = VYPP.astype(np.float32)
+         VP = np.sqrt(VXP**2+VYP**2)
+
+-
+         stable_count_p = np.sum(SSM & np.logical_not(np.isnan(VXP)))
+         stable_count1_p = np.sum(SSM1 & np.logical_not(np.isnan(VXP)))
+
+@@ -1025,26 +877,26 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         if stable_count_p != 0:
+             temp = VXP.copy() - VX.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
+             vxp_mean_shift = vx_mean_shift + bias_mean_shift / 1
+
+             temp = VYP.copy() - VY.copy()
+             temp[np.logical_not(SSM)] = np.nan
+-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
+             vyp_mean_shift = vy_mean_shift + bias_mean_shift / 1
+
+         if stable_count1_p != 0:
+             temp = VXP.copy() - VX.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
+             vxp_mean_shift1 = vx_mean_shift1 + bias_mean_shift1 / 1
+
+             temp = VYP.copy() - VY.copy()
+             temp[np.logical_not(SSM1)] = np.nan
+-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
++            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
+             vyp_mean_shift1 = vy_mean_shift1 + bias_mean_shift1 / 1
+
+@@ -1057,213 +909,207 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+             stable_shift_applied_p = 1
+
+
+-
+-
+-
+-
+-
+-#        varname='vxp'
+-#        datatype=np.dtype('int16')
+-#        dimensions=('y','x')
+-#        FillValue=NoDataValue
+-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-#
+-#
+-#        var.setncattr('standard_name','projected_x_velocity')
+-#        var.setncattr('description','x-direction velocity determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected vx estimates are used')
+-#        var.setncattr('units','m/y')
+-#
+-#
+-#        if stable_count_p != 0:
+-#            temp = VXP.copy() - VXref.copy()
+-#            temp[np.logical_not(SSM)] = np.nan
+-##            vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+-#            vxp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+-#        else:
+-#            vxp_error_mask = np.nan
+-#        if stable_count1_p != 0:
+-#            temp = VXP.copy() - VXref.copy()
+-#            temp[np.logical_not(SSM1)] = np.nan
+-##            vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+-#            vxp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+-#        else:
+-#            vxp_error_slow = np.nan
+-#        if stable_shift_applied_p == 1:
+-#            vxp_error = vxp_error_mask
+-#        elif stable_shift_applied_p == 2:
+-#            vxp_error = vxp_error_slow
+-#        else:
+-#            vxp_error = vxp_error_mod
+-#        var.setncattr('error',int(round(vxp_error*10))/10)
+-#        var.setncattr('error_description','best estimate of projected_x_velocity error: vxp_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+-#
+-#
+-#        if stable_shift_applied_p == 2:
+-#            var.setncattr('stable_shift',int(round(vxp_mean_shift1*10))/10)
+-#        elif stable_shift_applied_p == 1:
+-#            var.setncattr('stable_shift',int(round(vxp_mean_shift*10))/10)
+-#        else:
+-#            var.setncattr('stable_shift',np.nan)
+-#        var.setncattr('stable_shift_flag',stable_shift_applied_p)
+-#        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
+-#
+-#
+-#        var.setncattr('stable_count_mask',stable_count_p)
+-#        var.setncattr('stable_count_slow',stable_count1_p)
+-#        if stable_count_p != 0:
+-#            var.setncattr('stable_shift_mask',int(round(vxp_mean_shift*10))/10)
+-#        else:
+-#            var.setncattr('stable_shift_mask',np.nan)
+-#        if stable_count1_p != 0:
+-#            var.setncattr('stable_shift_slow',int(round(vxp_mean_shift1*10))/10)
+-#        else:
+-#            var.setncattr('stable_shift_slow',np.nan)
+-#
+-#        if stable_count_p != 0:
+-#            var.setncattr('error_mask',int(round(vxp_error_mask*10))/10)
+-#        else:
+-#            var.setncattr('error_mask',np.nan)
+-#        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+-#        if stable_count1_p != 0:
+-#            var.setncattr('error_slow',int(round(vxp_error_slow*10))/10)
+-#        else:
+-#            var.setncattr('error_slow',np.nan)
+-#        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+-#        var.setncattr('error_modeled',int(round(vxp_error_mod*10))/10)
+-#        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+-#
+-#
+-#        var.setncattr('grid_mapping',mapping_name)
+-#
+-#        VXP[noDataMask] = NoDataValue
+-#        var[:] = np.round(np.clip(VXP, -32768, 32767)).astype(np.int16)
+-##        var.setncattr('missing_value',np.int16(NoDataValue))
+-#
+-#
+-#
+-#
+-#
+-#
+-#        varname='vyp'
+-#        datatype=np.dtype('int16')
+-#        dimensions=('y','x')
+-#        FillValue=NoDataValue
+-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-#
+-#
+-#        var.setncattr('standard_name','projected_y_velocity')
+-#        var.setncattr('description','y-direction velocity determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected vy estimates are used')
+-#        var.setncattr('units','m/y')
+-#
+-#
+-#        if stable_count_p != 0:
+-#            temp = VYP.copy() - VYref.copy()
+-#            temp[np.logical_not(SSM)] = np.nan
+-##            vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+-#            vyp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+-#        else:
+-#            vyp_error_mask = np.nan
+-#        if stable_count1_p != 0:
+-#            temp = VYP.copy() - VYref.copy()
+-#            temp[np.logical_not(SSM1)] = np.nan
+-##            vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+-#            vyp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+-#        else:
+-#            vyp_error_slow = np.nan
+-#        if stable_shift_applied_p == 1:
+-#            vyp_error = vyp_error_mask
+-#        elif stable_shift_applied_p == 2:
+-#            vyp_error = vyp_error_slow
+-#        else:
+-#            vyp_error = vyp_error_mod
+-#        var.setncattr('error',int(round(vyp_error*10))/10)
+-#        var.setncattr('error_description','best estimate of projected_y_velocity error: vyp_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+-#
+-#
+-#        if stable_shift_applied_p == 2:
+-#            var.setncattr('stable_shift',int(round(vyp_mean_shift1*10))/10)
+-#        elif stable_shift_applied_p == 1:
+-#            var.setncattr('stable_shift',int(round(vyp_mean_shift*10))/10)
+-#        else:
+-#            var.setncattr('stable_shift',np.nan)
+-#        var.setncattr('stable_shift_flag',stable_shift_applied_p)
+-#        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
+-#
+-#
+-#        var.setncattr('stable_count_mask',stable_count_p)
+-#        var.setncattr('stable_count_slow',stable_count1_p)
+-#        if stable_count_p != 0:
+-#            var.setncattr('stable_shift_mask',int(round(vyp_mean_shift*10))/10)
+-#        else:
+-#            var.setncattr('stable_shift_mask',np.nan)
+-#        if stable_count1_p != 0:
+-#            var.setncattr('stable_shift_slow',int(round(vyp_mean_shift1*10))/10)
+-#        else:
+-#            var.setncattr('stable_shift_slow',np.nan)
+-#
+-#        if stable_count_p != 0:
+-#            var.setncattr('error_mask',int(round(vyp_error_mask*10))/10)
+-#        else:
+-#            var.setncattr('error_mask',np.nan)
+-#        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+-#        if stable_count1_p != 0:
+-#            var.setncattr('error_slow',int(round(vyp_error_slow*10))/10)
+-#        else:
+-#            var.setncattr('error_slow',np.nan)
+-#        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+-#        var.setncattr('error_modeled',int(round(vyp_error_mod*10))/10)
+-#        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+-#
+-#
+-#        var.setncattr('grid_mapping',mapping_name)
+-#
+-#        VYP[noDataMask] = NoDataValue
+-#        var[:] = np.round(np.clip(VYP, -32768, 32767)).astype(np.int16)
+-##        var.setncattr('missing_value',np.int16(NoDataValue))
+-#
+-#
+-#
+-#
+-#
+-#
+-#        varname='vp'
+-#        datatype=np.dtype('int16')
+-#        dimensions=('y','x')
+-#        FillValue=NoDataValue
+-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-#        var.setncattr('standard_name','projected_velocity')
+-#        var.setncattr('description','velocity magnitude determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected v estimates are used')
+-#        var.setncattr('units','m/y')
+-#
+-#        var.setncattr('grid_mapping',mapping_name)
+-#
+-#        VP[noDataMask] = NoDataValue
+-#        var[:] = np.round(np.clip(VP, -32768, 32767)).astype(np.int16)
+-##        var.setncattr('missing_value',np.int16(NoDataValue))
+-#
+-#
+-#
+-#
+-#
+-#        vp_error = v_error_cal(vxp_error, vyp_error)
+-#        varname='vp_error'
+-#        datatype=np.dtype('int16')
+-#        dimensions=('y','x')
+-#        FillValue=NoDataValue
+-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-#        var.setncattr('standard_name','projected_velocity_error')
+-#        var.setncattr('description','velocity magnitude error determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected v_error estimates are used')
+-#        var.setncattr('units','m/y')
+-#
+-#        var.setncattr('grid_mapping',mapping_name)
+-#
+-#        VP_error = np.sqrt((vxp_error * VXP / VP)**2 + (vyp_error * VYP / VP)**2)
+-#        VP_error[VP==0] = vp_error
+-#        VP_error[noDataMask] = NoDataValue
+-#        var[:] = np.round(np.clip(VP_error, -32768, 32767)).astype(np.int16)
+-##        var.setncattr('missing_value',np.int16(NoDataValue))
+-
+-
++        # var = nc_outfile.createVariable('vxp',np.dtype('int16'),('y', 'x'), fill_value=NoDataValue,
++        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        # var.setncattr('standard_name', 'projected_x_velocity')
++        # var.setncattr('description', 'x-direction velocity determined by projecting radar range measurements '
++        #                              'onto an a priori flow vector. Where projected errors are larger than those '
++        #                              'determined from range and azimuth measurements, unprojected vx estimates are used')
++        # var.setncattr('units', 'm/y')
++        # var.setncattr('grid_mapping', grid_mapping)
++        #
++        # if stable_count_p != 0:
++        #     temp = VXP.copy() - VXref.copy()
++        #     temp[np.logical_not(SSM)] = np.nan
++        #     # vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++        #     vxp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
++        # else:
++        #     vxp_error_mask = np.nan
++        # if stable_count1_p != 0:
++        #     temp = VXP.copy() - VXref.copy()
++        #     temp[np.logical_not(SSM1)] = np.nan
++        #     # vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++        #     vxp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
++        # else:
++        #     vxp_error_slow = np.nan
++        # if stable_shift_applied_p == 1:
++        #     vxp_error = vxp_error_mask
++        # elif stable_shift_applied_p == 2:
++        #     vxp_error = vxp_error_slow
++        # else:
++        #     vxp_error = vxp_error_mod
++        # var.setncattr('error', int(round(vxp_error*10))/10)
++        # var.setncattr('error_description', 'best estimate of projected_x_velocity error: vxp_error is populated '
++        #                                    'according to the approach used for the velocity bias correction as '
++        #                                    'indicated in "stable_shift_flag"')
++        #
++        # if stable_count_p != 0:
++        #     var.setncattr('error_mask', int(round(vxp_error_mask*10))/10)
++        # else:
++        #     var.setncattr('error_mask', np.nan)
++        # var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces '
++        #                                         'with velocity < 15 m/yr identified from an external mask')
++        #
++        # var.setncattr('error_modeled', int(round(vxp_error_mod * 10)) / 10)
++        # var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
++        #
++        # if stable_count1_p != 0:
++        #     var.setncattr('error_slow', int(round(vxp_error_slow * 10)) / 10)
++        # else:
++        #     var.setncattr('error_slow', np.nan)
++        # var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
++        #
++        # if stable_shift_applied_p == 2:
++        #     var.setncattr('stable_shift', int(round(vxp_mean_shift1*10))/10)
++        # elif stable_shift_applied_p == 1:
++        #     var.setncattr('stable_shift', int(round(vxp_mean_shift*10))/10)
++        # else:
++        #     var.setncattr('stable_shift', np.nan)
++        # var.setncattr('stable_shift_flag', stable_shift_applied_p)
++        # var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
++        #                                                '1 = correction from overlapping stable surface mask '
++        #                                                '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
++        #                                                '(top priority); 2 = correction from slowest 25% of overlapping '
++        #                                                'velocities (second priority)')
++        #
++        # if stable_count_p != 0:
++        #     var.setncattr('stable_shift_mask',int(round(vxp_mean_shift*10))/10)
++        # else:
++        #     var.setncattr('stable_shift_mask',np.nan)
++        # var.setncattr('stable_count_mask',stable_count_p)
++        #
++        # if stable_count1_p != 0:
++        #     var.setncattr('stable_shift_slow',int(round(vxp_mean_shift1*10))/10)
++        # else:
++        #     var.setncattr('stable_shift_slow',np.nan)
++        # var.setncattr('stable_count_slow',stable_count1_p)
++        #
++        # VXP[noDataMask] = NoDataValue
++        # var[:] = np.round(np.clip(VXP, -32768, 32767)).astype(np.int16)
++        # # var.setncattr('missing_value', np.int16(NoDataValue))
++        #
++        #
++        # var = nc_outfile.createVariable('vyp', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        # var.setncattr('standard_name', 'projected_y_velocity')
++        # var.setncattr('description', 'y-direction velocity determined by projecting radar range measurements '
++        #                              'onto an a priori flow vector. Where projected errors are larger than those '
++        #                              'determined from range and azimuth measurements, unprojected vy estimates are used')
++        # var.setncattr('units', 'm/y')
++        # var.setncattr('grid_mapping', grid_mapping)
++        #
++        # if stable_count_p != 0:
++        #     temp = VYP.copy() - VYref.copy()
++        #     temp[np.logical_not(SSM)] = np.nan
++        #     # vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
++        #     vyp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
++        # else:
++        #     vyp_error_mask = np.nan
++        # if stable_count1_p != 0:
++        #     temp = VYP.copy() - VYref.copy()
++        #     temp[np.logical_not(SSM1)] = np.nan
++        #     # vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
++        #     vyp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
++        # else:
++        #     vyp_error_slow = np.nan
++        # if stable_shift_applied_p == 1:
++        #     vyp_error = vyp_error_mask
++        # elif stable_shift_applied_p == 2:
++        #     vyp_error = vyp_error_slow
++        # else:
++        #     vyp_error = vyp_error_mod
++        # var.setncattr('error', int(round(vyp_error*10))/10)
++        # var.setncattr('error_description', 'best estimate of projected_y_velocity error: vyp_error is populated '
++        #                                    'according to the approach used for the velocity bias correction as '
++        #                                    'indicated in "stable_shift_flag"')
++        #
++        # if stable_count_p != 0:
++        #     var.setncattr('error_mask', int(round(vyp_error_mask*10))/10)
++        # else:
++        #     var.setncattr('error_mask', np.nan)
++        # var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces '
++        #                                         'with velocity < 15 m/yr identified from an external mask')
++        #
++        # var.setncattr('error_modeled', int(round(vyp_error_mod * 10)) / 10)
++        # var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
++        #
++        # if stable_count1_p != 0:
++        #     var.setncattr('error_slow', int(round(vyp_error_slow*10))/10)
++        # else:
++        #     var.setncattr('error_slow', np.nan)
++        # var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
++        #
++        # if stable_shift_applied_p == 2:
++        #     var.setncattr('stable_shift', int(round(vyp_mean_shift1*10))/10)
++        # elif stable_shift_applied_p == 1:
++        #     var.setncattr('stable_shift', int(round(vyp_mean_shift*10))/10)
++        # else:
++        #     var.setncattr('stable_shift', np.nan)
++        # var.setncattr('stable_shift_flag', stable_shift_applied_p)
++        # var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
++        #                                                '1 = correction from overlapping stable surface mask '
++        #                                                '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
++        #                                                '(top priority); 2 = correction from slowest 25% of overlapping '
++        #                                                'velocities (second priority)')
++        #
++        # if stable_count_p != 0:
++        #     var.setncattr('stable_shift_mask', int(round(vyp_mean_shift*10))/10)
++        # else:
++        #     var.setncattr('stable_shift_mask', np.nan)
++        # var.setncattr('stable_count_mask', stable_count_p)
++        #
++        # if stable_count1_p != 0:
++        #     var.setncattr('stable_shift_slow',int(round(vyp_mean_shift1*10))/10)
++        # else:
++        #     var.setncattr('stable_shift_slow',np.nan)
++        # var.setncattr('stable_count_slow', stable_count1_p)
++        #
++        # VYP[noDataMask] = NoDataValue
++        # var[:] = np.round(np.clip(VYP, -32768, 32767)).astype(np.int16)
++        # # var.setncattr('missing_value', np.int16(NoDataValue))
++        #
++        #
++        # var = nc_outfile.createVariable('vp', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        # var.setncattr('standard_name', 'projected_velocity')
++        # var.setncattr('description', 'velocity magnitude determined by projecting radar range measurements '
++        #                              'onto an a priori flow vector. Where projected errors are larger than those '
++        #                              'determined from range and azimuth measurements, unprojected v estimates are used')
++        # var.setncattr('units', 'm/y')
++        # var.setncattr('grid_mapping', grid_mapping)
++        #
++        # VP[noDataMask] = NoDataValue
++        # var[:] = np.round(np.clip(VP, -32768, 32767)).astype(np.int16)
++        # # var.setncattr('missing_value',np.int16(NoDataValue))
++        #
++        #
++        # var = nc_outfile.createVariable('vp_error', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        # var.setncattr('standard_name', 'projected_velocity_error')
++        # var.setncattr('description', 'velocity magnitude error determined by projecting radar range measurements '
++        #                              'onto an a priori flow vector. Where projected errors are larger than those '
++        #                              'determined from range and azimuth measurements, unprojected v_error estimates are used')
++        # var.setncattr('units', 'm/y')
++        # var.setncattr('grid_mapping', grid_mapping)
++        #
++        # vp_error = v_error_cal(vxp_error, vyp_error)
++        # VP_error = np.sqrt((vxp_error * VXP / VP)**2 + (vyp_error * VYP / VP)**2)
++        # VP_error[VP==0] = vp_error
++        # VP_error[noDataMask] = NoDataValue
++        # var[:] = np.round(np.clip(VP_error, -32768, 32767)).astype(np.int16)
++        # # var.setncattr('missing_value', np.int16(NoDataValue))
++
++
++        var = nc_outfile.createVariable('M11', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        var.setncattr('standard_name', 'conversion_matrix_element_11')
++        var.setncattr('description', 'conversion matrix element (1st row, 1st column) that can be multiplied with vx '
++                                     'to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
++        var.setncattr('units', 'pixel/(m/y)')
++        var.setncattr('grid_mapping', grid_mapping)
++        var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
++        var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
++                                                     'pixel displacement dr to slant range velocity vr')
+
+         M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
+
+@@ -1273,32 +1119,29 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         y2 = 50
+
+         C = [(y2-y1)/(x2-x1), y1-x1*(y2-y1)/(x2-x1)]
+-#        M11 = C[0]*M11+C[1]
+-
+-        varname='M11'
+-        datatype=np.dtype('int16')
+-        dimensions=('y','x')
+-        FillValue=NoDataValue
+-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-        var.setncattr('standard_name','conversion_matrix_element_11')
+-        var.setncattr('description','conversion matrix element (1st row, 1st column) that can be multiplied with vx to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
+-        var.setncattr('units','pixel/(m/y)')
+-
+-        var.setncattr('grid_mapping',mapping_name)
+-        var.setncattr('dr_to_vr_factor',dr_2_vr_factor)
+-        var.setncattr('dr_to_vr_factor_description','multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr')
+-
+-        var.setncattr('scale_factor',np.float32(1/C[0]))
+-        var.setncattr('add_offset',np.float32(-C[1]/C[0]))
++        # M11 = C[0]*M11+C[1]
++        var.setncattr('scale_factor', np.float32(1/C[0]))
++        var.setncattr('add_offset', np.float32(-C[1]/C[0]))
+
+         M11[noDataMask] = NoDataValue * np.float32(1/C[0]) + np.float32(-C[1]/C[0])
+-#        M11[noDataMask] = NoDataValue
++        # M11[noDataMask] = NoDataValue
+         var[:] = M11
+-#        var[:] = np.round(np.clip(M11, -32768, 32767)).astype(np.int16)
+-#        var[:] = np.clip(M11, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
+-#        var.setncattr('missing_value',np.int16(NoDataValue))
++        # var[:] = np.round(np.clip(M11, -32768, 32767)).astype(np.int16)
++        # var[:] = np.clip(M11, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
++        # var.setncattr('missing_value',np.int16(NoDataValue))
++
+
++        var = nc_outfile.createVariable('M12', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
++                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++        var.setncattr('standard_name', 'conversion_matrix_element_12')
++        var.setncattr('description', 'conversion matrix element (1st row, 2nd column) that can be multiplied with vy '
++                                     'to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
++        var.setncattr('units', 'pixel/(m/y)')
++        var.setncattr('grid_mapping', grid_mapping)
+
++        var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
++        var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
++                                                     'pixel displacement dr to slant range velocity vr')
+
+         M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
+
+@@ -1307,133 +1150,87 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         y1 = -50
+         y2 = 50
+
+-        C = [(y2-y1)/(x2-x1), y1-x1*(y2-y1)/(x2-x1)]
+-#        M12 = C[0]*M12+C[1]
+-
+-        varname='M12'
+-        datatype=np.dtype('int16')
+-        dimensions=('y','x')
+-        FillValue=NoDataValue
+-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-        var.setncattr('standard_name','conversion_matrix_element_12')
+-        var.setncattr('description','conversion matrix element (1st row, 2nd column) that can be multiplied with vy to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
+-        var.setncattr('units','pixel/(m/y)')
+-
+-        var.setncattr('grid_mapping',mapping_name)
+-        var.setncattr('dr_to_vr_factor',dr_2_vr_factor)
+-        var.setncattr('dr_to_vr_factor_description','multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr')
+-
+-        var.setncattr('scale_factor',np.float32(1/C[0]))
+-        var.setncattr('add_offset',np.float32(-C[1]/C[0]))
++        C = [(y2 - y1) / (x2 - x1), y1 - x1 * (y2 - y1) / (x2 - x1)]
++        # M12 = C[0]*M12+C[1]
++        var.setncattr('scale_factor', np.float32(1/C[0]))
++        var.setncattr('add_offset', np.float32(-C[1]/C[0]))
+
+         M12[noDataMask] = NoDataValue * np.float32(1/C[0]) + np.float32(-C[1]/C[0])
+-#        M12[noDataMask] = NoDataValue
++        # M12[noDataMask] = NoDataValue
+         var[:] = M12
+-#        var[:] = np.round(np.clip(M12, -32768, 32767)).astype(np.int16)
+-#        var[:] = np.clip(M12, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
+-#        var.setncattr('missing_value',np.int16(NoDataValue))
+-
+-
++        # var[:] = np.round(np.clip(M12, -32768, 32767)).astype(np.int16)
++        # var[:] = np.clip(M12, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
++        # var.setncattr('missing_value',np.int16(NoDataValue))
+
+
+-
+-
+-    varname='chip_size_width'
+-    datatype=np.dtype('uint16')
+-    dimensions=('y','x')
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-
+-    var.setncattr('standard_name','chip_size_width')
+-    var.setncattr('description','width of search template (chip)')
+-    var.setncattr('units','m')
++    var = nc_outfile.createVariable('chip_size_width', np.dtype('uint16'), ('y', 'x'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'chip_size_width')
++    var.setncattr('description', 'width of search template (chip)')
++    var.setncattr('units', 'm')
++    var.setncattr('grid_mapping', grid_mapping)
+
+     if pair_type is 'radar':
+-        var.setncattr('range_pixel_size',rangePixelSize)
+-        var.setncattr('chip_size_coordinates','radar geometry: width = range, height = azimuth')
++        var.setncattr('range_pixel_size', rangePixelSize)
++        var.setncattr('chip_size_coordinates', 'radar geometry: width = range, height = azimuth')
+     else:
+-        var.setncattr('x_pixel_size',rangePixelSize)
+-        var.setncattr('chip_size_coordinates','image projection geometry: width = x, height = y')
++        var.setncattr('x_pixel_size', rangePixelSize)
++        var.setncattr('chip_size_coordinates', 'image projection geometry: width = x, height = y')
+
+-    var.setncattr('grid_mapping',mapping_name)
+     # var[:] = np.flipud(vx_nomask).astype('float32')
+     var[:] = np.round(np.clip(CHIPSIZEX, 0, 65535)).astype('uint16')
+-#    var.setncattr('missing_value',np.uint16(0))
+-
+-
+-
++    # var.setncattr('missing_value', np.uint16(0))
+
+
+-    varname='chip_size_height'
+-    datatype=np.dtype('uint16')
+-    dimensions=('y','x')
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+-
+-    var.setncattr('standard_name','chip_size_height')
+-    var.setncattr('description','height of search template (chip)')
+-    var.setncattr('units','m')
++    var = nc_outfile.createVariable('chip_size_height', np.dtype('uint16'), ('y', 'x'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'chip_size_height')
++    var.setncattr('description', 'height of search template (chip)')
++    var.setncattr('units', 'm')
++    var.setncattr('grid_mapping', grid_mapping)
+
+     if pair_type is 'radar':
+-        var.setncattr('azimuth_pixel_size',azimuthPixelSize)
+-        var.setncattr('chip_size_coordinates','radar geometry: width = range, height = azimuth')
++        var.setncattr('azimuth_pixel_size', azimuthPixelSize)
++        var.setncattr('chip_size_coordinates', 'radar geometry: width = range, height = azimuth')
+     else:
+-        var.setncattr('y_pixel_size',azimuthPixelSize)
+-        var.setncattr('chip_size_coordinates','image projection geometry: width = x, height = y')
+-
+-    var.setncattr('grid_mapping',mapping_name)
++        var.setncattr('y_pixel_size', azimuthPixelSize)
++        var.setncattr('chip_size_coordinates', 'image projection geometry: width = x, height = y')
+
+     # var[:] = np.flipud(vx_nomask).astype('float32')
+     var[:] = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype('uint16')
+-#    var.setncattr('missing_value',np.uint16(0))
+-
+-
+-
+-
++    # var.setncattr('missing_value', np.uint16(0))
+
+-    varname='interp_mask'
+-    datatype=np.dtype('uint8')
+-    dimensions=('y','x')
+-#    FillValue=None
+-    FillValue=0
+-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+
+-    var.setncattr('standard_name','interpolated_value_mask')
+-    var.setncattr('description','light interpolation mask')
+-    var.setncattr('units','binary')
+-
+-    var.setncattr('grid_mapping',mapping_name)
++    var = nc_outfile.createVariable('interp_mask', np.dtype('uint8'), ('y', 'x'), fill_value=0,
++                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
++    var.setncattr('standard_name', 'interpolated_value_mask')
++    var.setncattr('description', 'light interpolation mask')
++    var.setncattr('units', 'binary')
++    var.setncattr('grid_mapping', grid_mapping)
+
+     # var[:] = np.flipud(vx_nomask).astype('float32')
+     var[:] = np.round(np.clip(INTERPMASK, 0, 255)).astype('uint8')
+-#    var.setncattr('missing_value',np.uint8(0))
++    # var.setncattr('missing_value', np.uint8(0))
++
+
+-    nc_outfile.sync() # flush data to disk
++    nc_outfile.sync()  # flush data to disk
+     nc_outfile.close()
+
+     return out_nc_filename
+
+
+ def rotate_vel2radar(rngind, azmind, vel_x, vel_y, swath_border, swath_border_full, GridSpacingX, ScaleChipSizeY, flag):
+-    from osgeo import gdal
+-    import numpy as np
+-    import scipy.io as sio
+-    import pandas as pd
+-
+-
+     ncols = np.nanmax(rngind)+1
+     nrows = np.nanmax(azmind)+1
+
+-#    pdb.set_trace()
+-
+     skipSample_x = GridSpacingX
+     skipSample_y = int(np.round(GridSpacingX*ScaleChipSizeY))
+-    xGrid = np.arange(0,ncols,skipSample_x)
+-    yGrid = np.arange(0,nrows,skipSample_y)
++    xGrid = np.arange(0, ncols, skipSample_x)
++    yGrid = np.arange(0, nrows, skipSample_y)
+     nd = xGrid.__len__()
+     md = yGrid.__len__()
+-    rngind1 = np.int32(np.dot(np.ones((md,1)),np.reshape(xGrid,(1,xGrid.__len__()))))
+-    azmind1 = np.int32(np.dot(np.reshape(yGrid,(yGrid.__len__(),1)),np.ones((1,nd))))
++    rngind1 = np.int32(np.dot(np.ones((md, 1)), np.reshape(xGrid, (1, xGrid.__len__()))))
++    azmind1 = np.int32(np.dot(np.reshape(yGrid, (yGrid.__len__(), 1)), np.ones((1, nd))))
+
+     rngind1 = rngind1.astype(np.float32)
+     azmind1 = azmind1.astype(np.float32)
+@@ -1441,55 +1238,53 @@ def rotate_vel2radar(rngind, azmind, vel_x, vel_y, swath_border, swath_border_fu
+     output_vel_x = np.zeros(rngind1.shape)*np.nan
+     output_vel_y = np.zeros(rngind1.shape)*np.nan
+
+-#    pdb.set_trace()
+-
+     for irow in range(rngind.shape[0]):
+         for icol in range(rngind.shape[1]):
+-            tempcol = rngind[irow,icol]
+-            temprow = azmind[irow,icol]
+-            if ((~np.isnan(tempcol))&(~np.isnan(temprow))):
+-                tempcol = np.argmin(np.abs(xGrid-rngind[irow,icol]))
+-                temprow = np.argmin(np.abs(yGrid-azmind[irow,icol]))
+-                output_vel_x[temprow,tempcol] = vel_x[irow,icol]
+-                output_vel_y[temprow,tempcol] = vel_y[irow,icol]
++            tempcol = rngind[irow, icol]
++            temprow = azmind[irow, icol]
++            if (~np.isnan(tempcol)) & (~np.isnan(temprow)):
++                tempcol = np.argmin(np.abs(xGrid-rngind[irow, icol]))
++                temprow = np.argmin(np.abs(yGrid-azmind[irow, icol]))
++                output_vel_x[temprow, tempcol] = vel_x[irow, icol]
++                output_vel_y[temprow, tempcol] = vel_y[irow, icol]
+
+     shift = 500
+
+     if flag == 0:
+-        mask = (rngind1 > swath_border[0]-shift)&(rngind1 < swath_border[0]+shift)
+-#        mask = (rngind1 > swath_border_full[0])&(rngind1 < swath_border_full[1])
++        mask = (rngind1 > swath_border[0]-shift) & (rngind1 < swath_border[0]+shift)
++        # mask = (rngind1 > swath_border_full[0]) & (rngind1 < swath_border_full[1])
+         output_vel_x[mask] = np.nan
+         output_vel_y[mask] = np.nan
+
+     if flag == 1:
+-        mask = (rngind1 > swath_border[1]-shift)&(rngind1 < swath_border[1]+shift)
+-#        mask = (rngind1 > swath_border_full[2])&(rngind1 < swath_border_full[3])
++        mask = (rngind1 > swath_border[1]-shift) & (rngind1 < swath_border[1]+shift)
++        # mask = (rngind1 > swath_border_full[2]) & (rngind1 < swath_border_full[3])
+         output_vel_x[mask] = np.nan
+         output_vel_y[mask] = np.nan
+
+     df = pd.DataFrame(output_vel_x)
+-    df = df.interpolate(method='linear',axis=1)
++    df = df.interpolate(method='linear', axis=1)
+     output_vel_x = df.to_numpy()
+
+     df = pd.DataFrame(output_vel_y)
+-    df = df.interpolate(method='linear',axis=1)
++    df = df.interpolate(method='linear', axis=1)
+     output_vel_y = df.to_numpy()
+
+-    output_vel_x=output_vel_x.astype('float32')
+-    output_vel_y=output_vel_y.astype('float32')
++    output_vel_x = output_vel_x.astype('float32')
++    output_vel_y = output_vel_y.astype('float32')
+
+     output_vel_x1 = vel_x.copy()
+     output_vel_y1 = vel_y.copy()
+
+     for irow in range(rngind.shape[0]):
+         for icol in range(rngind.shape[1]):
+-            tempcol = rngind[irow,icol]
+-            temprow = azmind[irow,icol]
+-            if ((~np.isnan(tempcol))&(~np.isnan(temprow))):
+-                tempcol = np.argmin(np.abs(xGrid-rngind[irow,icol]))
+-                temprow = np.argmin(np.abs(yGrid-azmind[irow,icol]))
+-                output_vel_x1[irow,icol] = output_vel_x[temprow,tempcol]
+-                output_vel_y1[irow,icol] = output_vel_y[temprow,tempcol]
++            tempcol = rngind[irow, icol]
++            temprow = azmind[irow, icol]
++            if (~np.isnan(tempcol)) & (~np.isnan(temprow)):
++                tempcol = np.argmin(np.abs(xGrid-rngind[irow, icol]))
++                temprow = np.argmin(np.abs(yGrid-azmind[irow, icol]))
++                output_vel_x1[irow, icol] = output_vel_x[temprow, tempcol]
++                output_vel_y1[irow, icol] = output_vel_y[temprow, tempcol]
+
+     output_vel_x1[np.isnan(vel_x)] = np.nan
+     output_vel_y1[np.isnan(vel_y)] = np.nan
+@@ -1498,10 +1293,9 @@ def rotate_vel2radar(rngind, azmind, vel_x, vel_y, swath_border, swath_border_fu
+
+
+ def loadProduct(xmlname):
+-    '''
+-        Load the product using Product Manager.
+-        '''
+-    import isce
++    """
++    Load the product using Product Manager.
++    """
+     from iscesys.Component.ProductManager import ProductManager as PM
+
+     pm = PM()
+@@ -1512,16 +1306,14 @@ def loadProduct(xmlname):
+     return obj
+
+
+-
+ def loadMetadata(indir):
+-    '''
+-        Input file.
+-        '''
++    """
++    Input file.
++    """
+     import os
+-    import numpy as np
+
+     frames = []
+-    for swath in range(1,4):
++    for swath in range(1, 4):
+         inxml = os.path.join(indir, 'IW{0}.xml'.format(swath))
+         if os.path.exists(inxml):
+             ifg = loadProduct(inxml)
+@@ -1530,16 +1322,8 @@ def loadMetadata(indir):
+     return frames, flight_direction
+
+
+-
+-
+-def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran, proj, GridSpacingX, ScaleChipSizeY, output_ref=[0.0,0.0,0.0,0.0]):
+-    from osgeo import gdal
+-    import numpy as np
+-
+-    frames =  None
+-    flight_direction = None
+-    frames_s =  None
+-    flight_direction_s = None
++def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata,
++                          tran, proj, GridSpacingX, ScaleChipSizeY, output_ref=[0.0, 0.0, 0.0, 0.0]):
+
+     frames, flight_direction = loadMetadata(os.path.dirname(indir_m)[:-6]+'fine_coreg')
+     frames_s, flight_direction_s = loadMetadata(os.path.dirname(indir_m)[:-6]+'secondary')
+@@ -1571,30 +1355,28 @@ def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran,
+     flag21 = 0
+     flag32 = 0
+
+-
+-
+     rngind = rngind.astype(np.float32)
+     azmind = azmind.astype(np.float32)
+     rngind[rngind == nodata] = np.nan
+     azmind[azmind == nodata] = np.nan
+
+-#    pdb.set_trace()
+-    ncols = int( np.round( (frames[2].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
++    ncols = int(np.round((frames[2].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+
+-    ind2 = int( np.round( (frames[0].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
++    ind2 = int(np.round((frames[0].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+
+-    ind1 = int( np.round( (frames[1].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
++    ind1 = int(np.round((frames[1].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+
+     swath_border.append((ind1+ind2)/2)
+     swath_border_full.append(ind1)
+     swath_border_full.append(ind2)
+
+-    mask1 = (rngind > ind1-500)&(rngind < ind1)
+-    mask2 = (rngind > ind2)&(rngind < ind2+500)
++    mask1 = (rngind > ind1-500) & (rngind < ind1)
++    mask2 = (rngind > ind2) & (rngind < ind2+500)
+
+-    if (np.nanstd(VX[mask2])<25)&(np.nanstd(VX[mask1])<25)&(np.nanstd(VY[mask2])<25)&(np.nanstd(VY[mask1])<25):
+-#        output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
+-#        output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
++    if (np.nanstd(VX[mask2]) < 25) & (np.nanstd(VX[mask1]) < 25) \
++            & (np.nanstd(VY[mask2]) < 25) & (np.nanstd(VY[mask1]) < 25):
++        # output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
++        # output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
+         output.append(output_ref[0])
+         output.append(output_ref[1])
+         flag21 = 1
+@@ -1602,23 +1384,20 @@ def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran,
+         output.append(output_ref[0])
+         output.append(output_ref[1])
+
+-#    pdb.set_trace()
+-
+-    ind2 = int( np.round( (frames[1].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+-
+-    ind1 = int( np.round( (frames[2].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
++    ind2 = int(np.round((frames[1].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
++    ind1 = int(np.round((frames[2].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+
+     swath_border.append((ind1+ind2)/2)
+     swath_border_full.append(ind1)
+     swath_border_full.append(ind2)
+
+-    mask1 = (rngind > ind1-500)&(rngind < ind1)
+-    mask2 = (rngind > ind2)&(rngind < ind2+500)
+-
++    mask1 = (rngind > ind1-500) & (rngind < ind1)
++    mask2 = (rngind > ind2) & (rngind < ind2+500)
+
+-    if (np.nanstd(VX[mask2])<25)&(np.nanstd(VX[mask1])<25)&(np.nanstd(VY[mask2])<25)&(np.nanstd(VY[mask1])<25):
+-#        output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
+-#        output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
++    if (np.nanstd(VX[mask2]) < 25) & (np.nanstd(VX[mask1]) < 25) \
++            & (np.nanstd(VY[mask2]) < 25) & (np.nanstd(VY[mask1]) < 25):
++        # output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
++        # output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
+         output.append(output_ref[2])
+         output.append(output_ref[3])
+         flag32 = 1
+@@ -1626,52 +1405,23 @@ def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran,
+         output.append(output_ref[2])
+         output.append(output_ref[3])
+
+-
+-
+-
+-#    pdb.set_trace()
+-
+-    mask1 = (rngind > swath_border[1])&(rngind < ncols)
++    mask1 = (rngind > swath_border[1]) & (rngind < ncols)
+     DX[mask1] = DX[mask1] - output[2]
+     DY[mask1] = DY[mask1] - output[3]
+
+-    mask2 = (rngind > swath_border[0])&(rngind < ncols)
++    mask2 = (rngind > swath_border[0]) & (rngind < ncols)
+     DX[mask2] = DX[mask2] - output[0]
+     DY[mask2] = DY[mask2] - output[1]
+
+-    if (flag21 == 1):
++    if flag21 == 1:
+         DX, DY = rotate_vel2radar(rngind, azmind, DX, DY, swath_border, swath_border_full, GridSpacingX, ScaleChipSizeY, 0)
+         print('sharp peaks corrected at subswath 2 and 1 borders')
+-    if (flag32 == 1):
++    if flag32 == 1:
+         DX, DY = rotate_vel2radar(rngind, azmind, DX, DY, swath_border, swath_border_full, GridSpacingX, ScaleChipSizeY, 1)
+         print('sharp peaks corrected at subswath 3 and 2 borders')
+
+-
+-    print('subswath offset bias between subswath 2 and 1: {0} {1}'.format(output[0],output[1]))
+-    print('subswath offset bias between subswath 3 and 2: {0} {1}'.format(output[2],output[3]))
+-    print('subswath border index: {0} {1}'.format(swath_border[0],swath_border[1]))
++    print('subswath offset bias between subswath 2 and 1: {0} {1}'.format(output[0], output[1]))
++    print('subswath offset bias between subswath 3 and 2: {0} {1}'.format(output[2], output[3]))
++    print('subswath border index: {0} {1}'.format(swath_border[0], swath_border[1]))
+
+     return DX, DY, flight_direction, flight_direction_s
+-
+-
+-
+-
+-#if __name__ == '__main__':
+-#
+-#        inps = cmdLineParse()
+-#
+-#        print (time.strftime("%H:%M:%S"))
+-#        from topsApp import TopsInSAR
+-#        insar = TopsInSAR(name="topsApp")
+-#
+-#
+-##        pdb.set_trace()
+-#
+-#        rangePixelSize = float(str.split(runCmd('fgrep "Range:" testGeogrid.txt'))[2])
+-#        prf = float(str.split(runCmd('fgrep "Azimuth:" testGeogrid.txt'))[2])
+-#        dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
+-#        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+-#        satv = np.array([float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[3]), float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[4]), float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[5])])
+-#        print (str(rangePixelSize)+"      "+str(prf)+"      "+str(satv)+"      "+str(dt))
+-#        azimuthPixelSize = np.sqrt(np.sum(satv**2)) / prf
+-#        print (str(rangePixelSize)+"      "+str(azimuthPixelSize))

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -33,8 +33,8 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
 1. The changes listed in `CHANGES-METADATA.diff` were applied to
    * correct `aquisition_img*` to `acquisition_date_img*` in the NETCDF metadata
      for Sentinel-1 products
-   * provide `sensor_img*=MSI` in the NETCDF metadata for Sentinel-2 products;
-     these changes should be included in the next autoRIFT release.
+   * provide `sensor_img*=MSI` in the NETCDF metadata for Sentinel-2 products
+   These changes should be included in the next autoRIFT release.
 2. The changes listed in `CHANGES-METADATA-2.diff` were applied to
    * alphabetize the sensor attributes for the `img_pair_info` variable 
    * change the `flag_stable_shift*` netCDF attributes to `stable_shift_flag*` so
@@ -42,4 +42,8 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
    * change `*_error*` netCDF attributes to `error*` as the prefix is redundant
      because these attributes are attached to the variable (e.g., `vx_error` is
      an attribute of the `vx` variable).
+   These changes should be included in the next autoRIFT release.
+3. The changes listed in `CHANGES-METADATA-3.diff` were applied to
+   * uniformly order all data variable attributes, loosely in alphabetical order
+   * significantly improve the codestyle (e.g., PEP8) of `netcdf_output.py`
    These changes should be included in the next autoRIFT release.

--- a/hyp3_autorift/vend/netcdf_output.py
+++ b/hyp3_autorift/vend/netcdf_output.py
@@ -597,14 +597,13 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     FillValue=NoDataValue
     var = nc_outfile.createVariable(varname,datatype,dimensions, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize, fill_value=FillValue)
 
-
     var.setncattr('standard_name','x_velocity')
     if pair_type is 'radar':
         var.setncattr('description','velocity component in x direction from radar range and azimuth measurements')
     else:
         var.setncattr('description','velocity component in x direction')
     var.setncattr('units','m/y')
-
+    var.setncattr('grid_mapping',mapping_name)
 
     if stable_count != 0:
         temp = VX.copy() - VXref.copy()
@@ -630,8 +629,24 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         vx_error = vx_error_slow
     else:
         vx_error = vx_error_mod
+
     var.setncattr('error',int(round(vx_error*10))/10)
     var.setncattr('error_description','best estimate of x_velocity error: vx_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+
+    if stable_count != 0:
+        var.setncattr('error_mask',int(round(vx_error_mask*10))/10)
+    else:
+        var.setncattr('error_mask',np.nan)
+    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+
+    var.setncattr('error_modeled',int(round(vx_error_mod*10))/10)
+    var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+
+    if stable_count1 != 0:
+        var.setncattr('error_slow',int(round(vx_error_slow*10))/10)
+    else:
+        var.setncattr('error_slow',np.nan)
+    var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
 
     if stable_shift_applied == 2:
         var.setncattr('stable_shift',int(round(vx_mean_shift1*10))/10)
@@ -642,37 +657,21 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     var.setncattr('stable_shift_flag',stable_shift_applied)
     var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
 
-
-    var.setncattr('stable_count_mask',stable_count)
-    var.setncattr('stable_count_slow',stable_count1)
     if stable_count != 0:
         var.setncattr('stable_shift_mask',int(round(vx_mean_shift*10))/10)
     else:
         var.setncattr('stable_shift_mask',np.nan)
+    var.setncattr('stable_count_mask',stable_count)
+
     if stable_count1 != 0:
         var.setncattr('stable_shift_slow',int(round(vx_mean_shift1*10))/10)
     else:
         var.setncattr('stable_shift_slow',np.nan)
-
-    if stable_count != 0:
-        var.setncattr('error_mask',int(round(vx_error_mask*10))/10)
-    else:
-        var.setncattr('error_mask',np.nan)
-    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
-    if stable_count1 != 0:
-        var.setncattr('error_slow',int(round(vx_error_slow*10))/10)
-    else:
-        var.setncattr('error_slow',np.nan)
-    var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
-    var.setncattr('error_modeled',int(round(vx_error_mod*10))/10)
-    var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
-
-    var.setncattr('grid_mapping',mapping_name)
+    var.setncattr('stable_count_slow', stable_count1)
 
     VX[noDataMask] = NoDataValue
     var[:] = np.round(np.clip(VX, -32768, 32767)).astype(np.int16)
 #    var.setncattr('_FillValue',np.int16(FillValue))
-
 
 
     varname='vy'
@@ -687,7 +686,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     else:
         var.setncattr('description','velocity component in y direction')
     var.setncattr('units','m/y')
-
+    var.setncattr('grid_mapping',mapping_name)
 
     if stable_count != 0:
         temp = VY.copy() - VYref.copy()
@@ -716,6 +715,20 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     var.setncattr('error',int(round(vy_error*10))/10)
     var.setncattr('error_description','best estimate of y_velocity error: vy_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
 
+    if stable_count != 0:
+        var.setncattr('error_mask',int(round(vy_error_mask*10))/10)
+    else:
+        var.setncattr('error_mask',np.nan)
+    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+
+    var.setncattr('error_modeled', int(round(vy_error_mod * 10)) / 10)
+    var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
+
+    if stable_count1 != 0:
+        var.setncattr('error_slow', int(round(vy_error_slow * 10)) / 10)
+    else:
+        var.setncattr('error_slow', np.nan)
+    var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
 
     if stable_shift_applied == 2:
         var.setncattr('stable_shift',int(round(vy_mean_shift1*10))/10)
@@ -723,36 +736,21 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('stable_shift',int(round(vy_mean_shift*10))/10)
     else:
         var.setncattr('stable_shift',np.nan)
+
     var.setncattr('stable_shift_flag',stable_shift_applied)
     var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
 
-
-    var.setncattr('stable_count_mask',stable_count)
-    var.setncattr('stable_count_slow',stable_count1)
     if stable_count != 0:
         var.setncattr('stable_shift_mask',int(round(vy_mean_shift*10))/10)
     else:
         var.setncattr('stable_shift_mask',np.nan)
+    var.setncattr('stable_count_mask',stable_count)
+
     if stable_count1 != 0:
         var.setncattr('stable_shift_slow',int(round(vy_mean_shift1*10))/10)
     else:
         var.setncattr('stable_shift_slow',np.nan)
-
-    if stable_count != 0:
-        var.setncattr('error_mask',int(round(vy_error_mask*10))/10)
-    else:
-        var.setncattr('error_mask',np.nan)
-    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
-    if stable_count1 != 0:
-        var.setncattr('error_slow',int(round(vy_error_slow*10))/10)
-    else:
-        var.setncattr('error_slow',np.nan)
-    var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
-    var.setncattr('error_modeled',int(round(vy_error_mod*10))/10)
-    var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
-
-
-    var.setncattr('grid_mapping',mapping_name)
+    var.setncattr('stable_count_slow', stable_count1)
 
     VY[noDataMask] = NoDataValue
     var[:] = np.round(np.clip(VY, -32768, 32767)).astype(np.int16)
@@ -815,10 +813,10 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         FillValue=NoDataValue
         var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
 
-
         var.setncattr('standard_name','range_velocity')
         var.setncattr('description','velocity in radar range direction')
         var.setncattr('units','m/y')
+        var.setncattr('grid_mapping',mapping_name)
 
         if stable_count != 0:
             temp = VR.copy() - VRref.copy()
@@ -841,9 +839,24 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
             vr_error = vr_error_slow
         else:
             vr_error = vr_error_mod
+
         var.setncattr('error',int(round(vr_error*10))/10)
         var.setncattr('error_description','best estimate of range_velocity error: vr_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
 
+        if stable_count != 0:
+            var.setncattr('error_mask',int(round(vr_error_mask*10))/10)
+        else:
+            var.setncattr('error_mask',np.nan)
+        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+
+        var.setncattr('error_modeled',int(round(vr_error_mod*10))/10)
+        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+
+        if stable_count1 != 0:
+            var.setncattr('error_slow',int(round(vr_error_slow*10))/10)
+        else:
+            var.setncattr('error_slow',np.nan)
+        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
 
         if stable_shift_applied == 2:
             var.setncattr('stable_shift',int(round(vr_mean_shift1*10))/10)
@@ -854,38 +867,21 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('stable_shift_flag',stable_shift_applied)
         var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
 
-
-        var.setncattr('stable_count_mask',stable_count)
-        var.setncattr('stable_count_slow',stable_count1)
         if stable_count != 0:
             var.setncattr('stable_shift_mask',int(round(vr_mean_shift*10))/10)
         else:
             var.setncattr('stable_shift_mask',np.nan)
+        var.setncattr('stable_count_mask',stable_count)
+
         if stable_count1 != 0:
             var.setncattr('stable_shift_slow',int(round(vr_mean_shift1*10))/10)
         else:
             var.setncattr('stable_shift_slow',np.nan)
-
-        if stable_count != 0:
-            var.setncattr('error_mask',int(round(vr_error_mask*10))/10)
-        else:
-            var.setncattr('error_mask',np.nan)
-        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
-        if stable_count1 != 0:
-            var.setncattr('error_slow',int(round(vr_error_slow*10))/10)
-        else:
-            var.setncattr('error_slow',np.nan)
-        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
-        var.setncattr('error_modeled',int(round(vr_error_mod*10))/10)
-        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
-
-
-        var.setncattr('grid_mapping',mapping_name)
+        var.setncattr('stable_count_slow',stable_count1)
 
         VR[noDataMask] = NoDataValue
         var[:] = np.round(np.clip(VR, -32768, 32767)).astype(np.int16)
 #        var.setncattr('missing_value',np.int16(NoDataValue))
-
 
 
         varname='va'
@@ -894,11 +890,10 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         FillValue=NoDataValue
         var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
 
-
         var.setncattr('standard_name','azimuth_velocity')
         var.setncattr('description','velocity in radar azimuth direction')
         var.setncattr('units','m/y')
-
+        var.setncattr('grid_mapping',mapping_name)
 
         if stable_count != 0:
             temp = VA.copy() - VAref.copy()
@@ -921,9 +916,24 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
             va_error = va_error_slow
         else:
             va_error = va_error_mod
+
         var.setncattr('error',int(round(va_error*10))/10)
         var.setncattr('error_description','best estimate of azimuth_velocity error: va_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
 
+        if stable_count != 0:
+            var.setncattr('error_mask',int(round(va_error_mask*10))/10)
+        else:
+            var.setncattr('error_mask',np.nan)
+        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+
+        var.setncattr('error_modeled',int(round(va_error_mod*10))/10)
+        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+
+        if stable_count1 != 0:
+            var.setncattr('error_slow',int(round(va_error_slow*10))/10)
+        else:
+            var.setncattr('error_slow',np.nan)
+        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
 
         if stable_shift_applied == 2:
             var.setncattr('stable_shift',int(round(va_mean_shift1*10))/10)
@@ -934,40 +944,21 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('stable_shift_flag',stable_shift_applied)
         var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
 
-
-        var.setncattr('stable_count_mask',stable_count)
-        var.setncattr('stable_count_slow',stable_count1)
         if stable_count != 0:
             var.setncattr('stable_shift_mask',int(round(va_mean_shift*10))/10)
         else:
             var.setncattr('stable_shift_mask',np.nan)
+        var.setncattr('stable_count_mask',stable_count)
+
         if stable_count1 != 0:
             var.setncattr('stable_shift_slow',int(round(va_mean_shift1*10))/10)
         else:
             var.setncattr('stable_shift_slow',np.nan)
-
-        if stable_count != 0:
-            var.setncattr('error_mask',int(round(va_error_mask*10))/10)
-        else:
-            var.setncattr('error_mask',np.nan)
-        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
-        if stable_count1 != 0:
-            var.setncattr('error_slow',int(round(va_error_slow*10))/10)
-        else:
-            var.setncattr('error_slow',np.nan)
-        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
-        var.setncattr('error_modeled',int(round(va_error_mod*10))/10)
-        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
-
-
-        var.setncattr('grid_mapping',mapping_name)
+        var.setncattr('stable_count_slow',stable_count1)
 
         VA[noDataMask] = NoDataValue
         var[:] = np.round(np.clip(VA, -32768, 32767)).astype(np.int16)
 #        var.setncattr('missing_value',np.int16(NoDataValue))
-
-
-
 
 
         # fuse the (slope parallel & reference) flow-based range-projected result with the raw observed range/azimuth-based result
@@ -1055,11 +1046,6 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
                 stable_shift_applied_p = 2
         else:
             stable_shift_applied_p = 1
-
-
-
-
-
 
 
 #        varname='vxp'
@@ -1318,8 +1304,8 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('standard_name','conversion_matrix_element_12')
         var.setncattr('description','conversion matrix element (1st row, 2nd column) that can be multiplied with vy to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
         var.setncattr('units','pixel/(m/y)')
-
         var.setncattr('grid_mapping',mapping_name)
+
         var.setncattr('dr_to_vr_factor',dr_2_vr_factor)
         var.setncattr('dr_to_vr_factor_description','multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr')
 
@@ -1334,10 +1320,6 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
 #        var.setncattr('missing_value',np.int16(NoDataValue))
 
 
-
-
-
-
     varname='chip_size_width'
     datatype=np.dtype('uint16')
     dimensions=('y','x')
@@ -1347,6 +1329,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     var.setncattr('standard_name','chip_size_width')
     var.setncattr('description','width of search template (chip)')
     var.setncattr('units','m')
+    var.setncattr('grid_mapping',mapping_name)
 
     if pair_type is 'radar':
         var.setncattr('range_pixel_size',rangePixelSize)
@@ -1355,13 +1338,9 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('x_pixel_size',rangePixelSize)
         var.setncattr('chip_size_coordinates','image projection geometry: width = x, height = y')
 
-    var.setncattr('grid_mapping',mapping_name)
     # var[:] = np.flipud(vx_nomask).astype('float32')
     var[:] = np.round(np.clip(CHIPSIZEX, 0, 65535)).astype('uint16')
 #    var.setncattr('missing_value',np.uint16(0))
-
-
-
 
 
     varname='chip_size_height'
@@ -1373,6 +1352,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     var.setncattr('standard_name','chip_size_height')
     var.setncattr('description','height of search template (chip)')
     var.setncattr('units','m')
+    var.setncattr('grid_mapping',mapping_name)
 
     if pair_type is 'radar':
         var.setncattr('azimuth_pixel_size',azimuthPixelSize)
@@ -1381,14 +1361,9 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('y_pixel_size',azimuthPixelSize)
         var.setncattr('chip_size_coordinates','image projection geometry: width = x, height = y')
 
-    var.setncattr('grid_mapping',mapping_name)
-
     # var[:] = np.flipud(vx_nomask).astype('float32')
     var[:] = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype('uint16')
 #    var.setncattr('missing_value',np.uint16(0))
-
-
-
 
 
     varname='interp_mask'
@@ -1401,7 +1376,6 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     var.setncattr('standard_name','interpolated_value_mask')
     var.setncattr('description','light interpolation mask')
     var.setncattr('units','binary')
-
     var.setncattr('grid_mapping',mapping_name)
 
     # var[:] = np.flipud(vx_nomask).astype('float32')

--- a/hyp3_autorift/vend/netcdf_output.py
+++ b/hyp3_autorift/vend/netcdf_output.py
@@ -1,16 +1,16 @@
-#!/usr/bin/env python3
+# Yang Lei, Jet Propulsion Laboratory
+# November 2017
 
-########
-#Yang Lei, Jet Propulsion Laboratory
-#November 2017
-
-import numpy as np
-import subprocess
-import os
 import datetime
+import os
+import subprocess
+
 import netCDF4
+import numpy as np
+import pandas as pd
 
 import hyp3_autorift
+
 
 def v_error_cal(vx_error, vy_error):
     vx = np.random.normal(0, vx_error, 1000000)
@@ -19,174 +19,110 @@ def v_error_cal(vx_error, vy_error):
     return np.std(v)
 
 
-def netCDF_packaging_intermediate(Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask, filename='./autoRIFT_intermediate.nc'):
+def netCDF_packaging_intermediate(Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX,
+                                  SearchLimitY, origSize, noDataMask, filename='./autoRIFT_intermediate.nc'):
 
-
-    title = 'autoRIFT intermediate results'
-    author = 'Alex S. Gardner, JPL/NASA; Yang Lei, GPS/Caltech'
-    institution = 'NASA Jet Propulsion Laboratory (JPL), California Institute of Technology'
-
-
-    clobber = True     # overwrite existing output nc file
-
-    nc_outfile = netCDF4.Dataset(filename,'w',clobber=clobber,format='NETCDF4')
+    nc_outfile = netCDF4.Dataset(filename, 'w', clobber=True, format='NETCDF4')
 
     # First set global attributes that GDAL uses when it reads netCFDF files
-    nc_outfile.setncattr('date_created',datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
-    nc_outfile.setncattr('title',title)
-    nc_outfile.setncattr('author',author)
-    nc_outfile.setncattr('institution',institution)
-
-
+    nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
+    nc_outfile.setncattr('title', 'autoRIFT intermediate results')
+    nc_outfile.setncattr('author', 'Alex S. Gardner, JPL/NASA; Yang Lei, GPS/Caltech')
+    nc_outfile.setncattr('institution', 'NASA Jet Propulsion Laboratory (JPL), California Institute of Technology')
 
     # set dimensions
     dimidY, dimidX = Dx.shape
-    nc_outfile.createDimension('x',dimidX)
-    nc_outfile.createDimension('y',dimidY)
-    #    pdb.set_trace()
-    x = np.arange(0,dimidX,1)
-    y = np.arange(0,dimidY,1)
-    #    pdb.set_trace()
+    nc_outfile.createDimension('x', dimidX)
+    nc_outfile.createDimension('y', dimidY)
+
+    x = np.arange(0, dimidX, 1)
+    y = np.arange(0, dimidY, 1)
+
     chunk_lines = np.min([np.ceil(8192/dimidY)*128, dimidY])
-    #    ChunkSize = [dimidX, chunk_lines]
     ChunkSize = [chunk_lines, dimidX]
 
-    nc_outfile.createDimension('x1',noDataMask.shape[1])
-    nc_outfile.createDimension('y1',noDataMask.shape[0])
+    nc_outfile.createDimension('x1', noDataMask.shape[1])
+    nc_outfile.createDimension('y1', noDataMask.shape[0])
 
-
-
-
-    varname='x'
-    datatype=np.dtype('int32')
-    dimensions=('x')
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','x_index')
-    var.setncattr('description','x index')
+    var = nc_outfile.createVariable('x', np.dtype('int32'), ('x',), fill_value=None)
+    var.setncattr('standard_name', 'x_index')
+    var.setncattr('description', 'x index')
     var[:] = x
 
-    varname='y'
-    datatype=np.dtype('int32')
-    dimensions=('y')
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','y_index')
-    var.setncattr('description','y index')
+    var = nc_outfile.createVariable('y', np.dtype('int32'), ('y',), fill_value=None)
+    var.setncattr('standard_name', 'y_index')
+    var.setncattr('description', 'y index')
     var[:] = y
 
-
-
-    NoDataValue = np.nan
-
-    varname='Dx'
-    datatype=np.dtype('float32')
-    dimensions=('y','x')
-    FillValue=NoDataValue
-    var = nc_outfile.createVariable(varname,datatype,dimensions, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize, fill_value=FillValue)
-    var.setncattr('standard_name','x_offset')
-    var.setncattr('description','x offset')
+    var = nc_outfile.createVariable('Dx', np.dtype('float32'), ('y', 'x'), fill_value=np.nan,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'x_offset')
+    var.setncattr('description', 'x offset')
     var[:] = Dx.astype(np.float32)
 
-    varname='Dy'
-    datatype=np.dtype('float32')
-    dimensions=('y','x')
-    FillValue=NoDataValue
-    var = nc_outfile.createVariable(varname,datatype,dimensions, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize, fill_value=FillValue)
-    var.setncattr('standard_name','y_offset')
-    var.setncattr('description','y offset')
+    var = nc_outfile.createVariable('Dy', np.dtype('float32'), ('y', 'x'), fill_value=np.nan,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'y_offset')
+    var.setncattr('description', 'y offset')
     var[:] = Dy.astype(np.float32)
 
-    varname='InterpMask'
-    datatype=np.dtype('uint8')
-    dimensions=('y','x')
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-    var.setncattr('standard_name','interpolated_value_mask')
-    var.setncattr('description','light interpolation mask')
+    var = nc_outfile.createVariable('InterpMask', np.dtype('uint8'), ('y', 'x'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'interpolated_value_mask')
+    var.setncattr('description', 'light interpolation mask')
     var[:] = np.round(np.clip(InterpMask, 0, 255)).astype('uint8')
 
-    varname='ChipSizeX'
-    datatype=np.dtype('uint16')
-    dimensions=('y','x')
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-    var.setncattr('standard_name','chip_size_x')
-    var.setncattr('description','width of search window')
+    var = nc_outfile.createVariable('ChipSizeX', np.dtype('uint16'), ('y', 'x'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'chip_size_x')
+    var.setncattr('description', 'width of search window')
     var[:] = np.round(np.clip(ChipSizeX, 0, 65535)).astype('uint16')
 
-    varname='SearchLimitX'
-    datatype=np.dtype('uint8')
-    dimensions=('y','x')
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-    var.setncattr('standard_name','search_limit_x')
-    var.setncattr('description','search limit x')
+    var = nc_outfile.createVariable('SearchLimitX', np.dtype('uint8'), ('y', 'x'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'search_limit_x')
+    var.setncattr('description', 'search limit x')
     var[:] = np.round(np.clip(SearchLimitX, 0, 255)).astype('uint8')
 
-    varname='SearchLimitY'
-    datatype=np.dtype('uint8')
-    dimensions=('y','x')
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-    var.setncattr('standard_name','search_limit_y')
-    var.setncattr('description','search limit y')
+    var = nc_outfile.createVariable('SearchLimitY', np.dtype('uint8'), ('y', 'x'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'search_limit_y')
+    var.setncattr('description', 'search limit y')
     var[:] = np.round(np.clip(SearchLimitY, 0, 255)).astype('uint8')
 
-    varname='noDataMask'
-    datatype=np.dtype('uint8')
-    dimensions=('y1','x1')
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-    var.setncattr('standard_name','nodata_value_mask')
-    var.setncattr('description','nodata value mask')
+    var = nc_outfile.createVariable('noDataMask', np.dtype('uint8'), ('y1', 'x1'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'nodata_value_mask')
+    var.setncattr('description', 'nodata value mask')
     var[:] = np.round(np.clip(noDataMask, 0, 255)).astype('uint8')
 
-    varname='GridSpacingX'
-    datatype=np.dtype('uint16')
-    dimensions=()
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','GridSpacingX')
-    var.setncattr('description','grid spacing x')
+    var = nc_outfile.createVariable('GridSpacingX', np.dtype('uint16'), (), fill_value=None)
+    var.setncattr('standard_name', 'GridSpacingX')
+    var.setncattr('description', 'grid spacing x')
     var[0] = GridSpacingX
 
-    varname='ScaleChipSizeY'
-    datatype=np.dtype('float32')
-    dimensions=()
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','ScaleChipSizeY')
-    var.setncattr('description','scale of chip size in y to chip size in x')
+    var = nc_outfile.createVariable('ScaleChipSizeY', np.dtype('float32'), (), fill_value=None)
+    var.setncattr('standard_name', 'ScaleChipSizeY')
+    var.setncattr('description', 'scale of chip size in y to chip size in x')
     var[0] = ScaleChipSizeY
 
-    varname='origSizeX'
-    datatype=np.dtype('uint16')
-    dimensions=()
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','origSizeX')
-    var.setncattr('description','original array size x')
+    var = nc_outfile.createVariable('origSizeX', np.dtype('uint16'), (), fill_value=None)
+    var.setncattr('standard_name', 'origSizeX')
+    var.setncattr('description', 'original array size x')
     var[0] = origSize[1]
 
-    varname='origSizeY'
-    datatype=np.dtype('uint16')
-    dimensions=()
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','origSizeY')
-    var.setncattr('description','original array size y')
+    var = nc_outfile.createVariable('origSizeY', np.dtype('uint16'), (), fill_value=None)
+    var.setncattr('standard_name', 'origSizeY')
+    var.setncattr('description', 'original array size y')
     var[0] = origSize[0]
 
-
-    nc_outfile.sync() # flush data to disk
+    nc_outfile.sync()  # flush data to disk
     nc_outfile.close()
 
 
 def netCDF_read_intermediate(filename='./autoRIFT_intermediate.nc'):
 
-    from netCDF4 import Dataset
-    inter_file = Dataset(filename, mode='r')
+    inter_file = netCDF4.Dataset(filename, mode='r')
     Dx = inter_file.variables['Dx'][:].data
     Dy = inter_file.variables['Dy'][:].data
     InterpMask = inter_file.variables['InterpMask'][:].data
@@ -197,7 +133,7 @@ def netCDF_read_intermediate(filename='./autoRIFT_intermediate.nc'):
     noDataMask = noDataMask.astype('bool')
     GridSpacingX = inter_file.variables['GridSpacingX'][:].data
     ScaleChipSizeY = inter_file.variables['ScaleChipSizeY'][:].data
-    origSize = (inter_file.variables['origSizeY'][:].data,inter_file.variables['origSizeX'][:].data)
+    origSize = (inter_file.variables['origSizeY'][:].data, inter_file.variables['origSizeX'][:].data)
 
     return Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask
 
@@ -207,61 +143,64 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
                      DXref, DYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
                      detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
                      dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector, parameter_file):
+
     vx_mean_shift = offset2vx_1 * dx_mean_shift + offset2vx_2 * dy_mean_shift
     temp = vx_mean_shift
     temp[np.logical_not(SSM)] = np.nan
-#        vx_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+    # vx_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
     vx_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
+
     vy_mean_shift = offset2vy_1 * dx_mean_shift + offset2vy_2 * dy_mean_shift
     temp = vy_mean_shift
     temp[np.logical_not(SSM)] = np.nan
-#        vy_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+    # vy_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
     vy_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
-
 
     vx_mean_shift1 = offset2vx_1 * dx_mean_shift1 + offset2vx_2 * dy_mean_shift1
     temp = vx_mean_shift1
     temp[np.logical_not(SSM1)] = np.nan
     vx_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
+
     vy_mean_shift1 = offset2vy_1 * dx_mean_shift1 + offset2vy_2 * dy_mean_shift1
     temp = vy_mean_shift1
     temp[np.logical_not(SSM1)] = np.nan
     vy_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
 
-
-
     V = np.sqrt(VX**2+VY**2)
 
     if pair_type is 'radar':
         dr_2_vr_factor = np.median(offset2vr[np.logical_not(np.isnan(offset2vr))])
-        SlantRangePixelSize = np.median(offset2vr[np.logical_not(np.isnan(offset2vr))]) *dt/365.0/24.0/3600.0
-        azimuthPixelSize = np.median(offset2va[np.logical_not(np.isnan(offset2va))]) *dt/365.0/24.0/3600.0
-#        VR = DX * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
-#        VA = (DY) * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
+        SlantRangePixelSize = np.median(offset2vr[np.logical_not(np.isnan(offset2vr))]) * dt/365.0/24.0/3600.0
+        azimuthPixelSize = np.median(offset2va[np.logical_not(np.isnan(offset2va))]) * dt/365.0/24.0/3600.0
+
+        # VR = DX * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
         VR = DX * offset2vr
-        VA = (DY) * offset2va
         VR = VR.astype(np.float32)
+
+        # VA = DY * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
+        VA = DY * offset2va
         VA = VA.astype(np.float32)
 
         VRref = DXref * offset2vr
-        VAref = (DYref) * offset2va
         VRref = VRref.astype(np.float32)
+
+        VAref = DYref * offset2va
         VAref = VAref.astype(np.float32)
 
-
-#        vr_mean_shift = dx_mean_shift * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
-#        va_mean_shift = (dy_mean_shift) * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
-#
-#        vr_mean_shift1 = dx_mean_shift1 * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
-#        va_mean_shift1 = (dy_mean_shift1) * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
+        # vr_mean_shift = dx_mean_shift * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
         vr_mean_shift = dx_mean_shift * offset2vr
-        va_mean_shift = (dy_mean_shift) * offset2va
         vr_mean_shift = np.median(vr_mean_shift[np.logical_not(np.isnan(vr_mean_shift))])
+
+        # va_mean_shift = dy_mean_shift * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
+        va_mean_shift = dy_mean_shift * offset2va
         va_mean_shift = np.median(va_mean_shift[np.logical_not(np.isnan(va_mean_shift))])
 
+        # vr_mean_shift1 = dx_mean_shift1 * rangePixelSize / dt * 365.0 * 24.0 * 3600.0
         vr_mean_shift1 = dx_mean_shift1 * offset2vr
-        va_mean_shift1 = (dy_mean_shift1) * offset2va
         vr_mean_shift1 = np.median(vr_mean_shift1[np.logical_not(np.isnan(vr_mean_shift1))])
+
+        # va_mean_shift1 = dy_mean_shift1 * azimuthPixelSize / dt * 365.0 * 24.0 * 3600.0
+        va_mean_shift1 = dy_mean_shift1 * offset2va
         va_mean_shift1 = np.median(va_mean_shift1[np.logical_not(np.isnan(va_mean_shift1))])
 
         # create the (slope parallel & reference) flow-based range-projected result
@@ -272,8 +211,8 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         VXR = alpha_ref * VXref
         VYR = alpha_ref * VYref
 
-        zero_flag_sp = (SX == 0)&(SY == 0)
-        zero_flag_ref = (VXref == 0)&(VYref == 0)
+        zero_flag_sp = (SX == 0) & (SY == 0)
+        zero_flag_ref = (VXref == 0) & (VYref == 0)
         VXS[zero_flag_sp] = np.nan
         VYS[zero_flag_sp] = np.nan
         VXR[zero_flag_ref] = np.nan
@@ -294,19 +233,20 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         VXR[angle_df_R < angle_threshold_R] = np.nan
         VYR[angle_df_R < angle_threshold_R] = np.nan
 
-        #   obsolete fusion routine using the sp mask file to distinguish pure smoothed slopes and reference velocity fields
-#        VXP = VXS
-#        VXP[MM == 1] = VXR[MM == 1]
-#        VYP = VYS
-#        VYP[MM == 1] = VYR[MM == 1]
+        # obsolete fusion routine using the sp mask file to distinguish pure
+        # smoothed slopes and reference velocity fields
+        # VXP = VXS
+        # VXP[MM == 1] = VXR[MM == 1]
+        # VYP = VYS
+        # VYP[MM == 1] = VYR[MM == 1]
 
-        #   by default, use the updated dhdxs and dhdys input files that combine the velocity fields and smoothed slopes; should be turned off when better estimates of velocity fields are available
+        # FIXME: Switch to using the updated (better) estimates of velocity fields when available
+        # Use the updated dhdxs and dhdys input files that combine the velocity fields and smoothed slopes
         VXP = VXS
         VYP = VYS
-
-#        #   use the updated (better) estimates of velocity fields; by default, is turned off; should be turned on after generating the new velocity fields
-#        VXP = VXR
-#        VYP = VYR
+        # use the updated (better) estimates of velocity fields
+        # VXP = VXR
+        # VYP = VYR
 
         VXP = VXP.astype(np.float32)
         VYP = VYP.astype(np.float32)
@@ -319,33 +259,34 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         stable_count1_p = np.sum(SSM1 & np.logical_not(np.isnan(VXP)))
 
         vxp_mean_shift = 0.0
-        vyp_mean_shift = 0.0
         vxp_mean_shift1 = 0.0
+
+        vyp_mean_shift = 0.0
         vyp_mean_shift1 = 0.0
 
         if stable_count_p != 0:
             temp = VXP.copy() - VX.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
             vxp_mean_shift = vx_mean_shift + bias_mean_shift / 1
 
             temp = VYP.copy() - VY.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
             vyp_mean_shift = vy_mean_shift + bias_mean_shift / 1
 
         if stable_count1_p != 0:
             temp = VXP.copy() - VX.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
             vxp_mean_shift1 = vx_mean_shift1 + bias_mean_shift1 / 1
 
             temp = VYP.copy() - VY.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
             vyp_mean_shift1 = vy_mean_shift1 + bias_mean_shift1 / 1
 
@@ -357,21 +298,18 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         else:
             stable_shift_applied_p = 1
 
-
-
     CHIPSIZEX = CHIPSIZEX * rangePixelSize
     CHIPSIZEY = CHIPSIZEY * azimuthPixelSize
 
     NoDataValue = -32767
     noDataMask = np.isnan(VX) | np.isnan(VY)
 
+    # VXref[noDataMask] = NoDataValue
+    # VYref[noDataMask] = NoDataValue
 
-#    VXref[noDataMask] = NoDataValue
-#    VYref[noDataMask] = NoDataValue
-
-#    if pair_type is 'radar':
-#        VRref[noDataMask] = NoDataValue
-#        VAref[noDataMask] = NoDataValue
+    # if pair_type is 'radar':
+    #     VRref[noDataMask] = NoDataValue
+    #     VAref[noDataMask] = NoDataValue
 
     CHIPSIZEX[noDataMask] = 0
     CHIPSIZEY[noDataMask] = 0
@@ -381,15 +319,15 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     author = 'Alex S. Gardner, JPL/NASA; Yang Lei, GPS/Caltech'
     institution = 'NASA Jet Propulsion Laboratory (JPL), California Institute of Technology'
 
-#    VX = np.round(np.clip(VX, -32768, 32767)).astype(np.int16)
-#    VY = np.round(np.clip(VY, -32768, 32767)).astype(np.int16)
-#    V = np.round(np.clip(V, -32768, 32767)).astype(np.int16)
-#    if pair_type is 'radar':
-#        VR = np.round(np.clip(VR, -32768, 32767)).astype(np.int16)
-#        VA = np.round(np.clip(VA, -32768, 32767)).astype(np.int16)
-#    CHIPSIZEX = np.round(np.clip(CHIPSIZEX, 0, 65535)).astype(np.uint16)
-#    CHIPSIZEY = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype(np.uint16)
-#    INTERPMASK = np.round(np.clip(INTERPMASK, 0, 255)).astype(np.uint8)
+    # VX = np.round(np.clip(VX, -32768, 32767)).astype(np.int16)
+    # VY = np.round(np.clip(VY, -32768, 32767)).astype(np.int16)
+    # V = np.round(np.clip(V, -32768, 32767)).astype(np.int16)
+    # if pair_type is 'radar':
+    #     VR = np.round(np.clip(VR, -32768, 32767)).astype(np.int16)
+    #     VA = np.round(np.clip(VA, -32768, 32767)).astype(np.int16)
+    # CHIPSIZEX = np.round(np.clip(CHIPSIZEX, 0, 65535)).astype(np.uint16)
+    # CHIPSIZEY = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype(np.uint16)
+    # INTERPMASK = np.round(np.clip(INTERPMASK, 0, 255)).astype(np.uint8)
 
     source = f'NASA MEaSUREs ITS_LIVE project. Processed by ASF DAAC HyP3 {datetime.datetime.now().year} using the ' \
              f'{hyp3_autorift.__name__} plugin version {hyp3_autorift.__version__} running autoRIFT version ' \
@@ -419,203 +357,129 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
 
     clobber = True     # overwrite existing output nc file
 
-    nc_outfile = netCDF4.Dataset(out_nc_filename,'w',clobber=clobber,format='NETCDF4')
+    nc_outfile = netCDF4.Dataset(out_nc_filename, 'w', clobber=clobber, format='NETCDF4')
 
     # First set global attributes that GDAL uses when it reads netCFDF files
-    nc_outfile.setncattr('GDAL_AREA_OR_POINT','Area')
-    nc_outfile.setncattr('Conventions','CF-1.6')
-    nc_outfile.setncattr('date_created',datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
-    nc_outfile.setncattr('title',title)
+    nc_outfile.setncattr('GDAL_AREA_OR_POINT', 'Area')
+    nc_outfile.setncattr('Conventions', 'CF-1.6')
+    nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
+    nc_outfile.setncattr('title', title)
     nc_outfile.setncattr('autoRIFT_software_version', IMG_INFO_DICT["autoRIFT_software_version"])
     nc_outfile.setncattr('autoRIFT_parameter_file', parameter_file)
-    nc_outfile.setncattr('scene_pair_type',pair_type)
-    nc_outfile.setncattr('motion_detection_method',detection_method)
-    nc_outfile.setncattr('motion_coordinates',coordinates)
+    nc_outfile.setncattr('scene_pair_type', pair_type)
+    nc_outfile.setncattr('motion_detection_method', detection_method)
+    nc_outfile.setncattr('motion_coordinates', coordinates)
     nc_outfile.setncattr('author', author)
     nc_outfile.setncattr('institution', institution)
     nc_outfile.setncattr('source', source)
     nc_outfile.setncattr('references', references)
 
-    varname='img_pair_info'
-#    datatype=np.dtype('S1')
-    datatype='U1'
-    dimensions=()
-    FillValue=None
 
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    # variable made, now add attributes
-
-#    var.setncattr('mission_img1',master_split[0][0])
-#    var.setncattr('sensor_img1','C')
-#    var.setncattr('satellite_img1',master_split[0][1:3])
-#    var.setncattr('acquisition_img1',master_split[5][0:8])
-#    var.setncattr('absolute_orbit_number_img1',master_split[7])
-#    var.setncattr('mission_data_take_ID_img1',master_split[8])
-#    var.setncattr('product_unique_ID_img1',master_split[9][0:4])
-#
-#    var.setncattr('mission_img2',slave_split[0][0])
-#    var.setncattr('sensor_img2','C')
-#    var.setncattr('satellite_img2',slave_split[0][1:3])
-#    var.setncattr('acquisition_img2',slave_split[5][0:8])
-#    var.setncattr('absolute_orbit_number_img2',slave_split[7])
-#    var.setncattr('mission_data_take_ID_img2',slave_split[8])
-#    var.setncattr('product_unique_ID_img2',slave_split[9][0:4])
-#
-#    from datetime import date
-#    d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
-#    d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
-#    date_dt = d1 - d0
-#    var.setncattr('date_dt',np.float64(np.abs(date_dt.days)))
-#    if date_dt.days < 0:
-#        date_ct = d1 + (d0 - d1)/2
-#        var.setncattr('date_center',date_ct.strftime("%Y%m%d"))
-#    else:
-#        date_ct = d0 + (d1 - d0)/2
-#        var.setncattr('date_center',date_ct.strftime("%Y%m%d"))
-##    var.setncattr('date_center',np.abs(np.int(slave_split[5][0:8])+np.int(master_split[5][0:8]))/2)
-#
-#    var.setncattr('roi_valid_percentage',roi_valid_percentage)
-#    var.setncattr('autoRIFT_software_version',version)
-
+    var = nc_outfile.createVariable('img_pair_info', 'U1', (), fill_value=None)
     for key in IMG_INFO_DICT:
         if key == 'autoRIFT_software_version':
             continue
-        var.setncattr(key,IMG_INFO_DICT[key])
-
-
-
+        var.setncattr(key, IMG_INFO_DICT[key])
 
     # set dimensions
     dimidY, dimidX = VX.shape
-    nc_outfile.createDimension('x',dimidX)
-    nc_outfile.createDimension('y',dimidY)
-#    pdb.set_trace()
-    x = np.arange(tran[0],tran[0]+tran[1]*(dimidX),tran[1])
-    y = np.arange(tran[3],tran[3]+tran[5]*(dimidY),tran[5])
-#    pdb.set_trace()
+    nc_outfile.createDimension('x', dimidX)
+    nc_outfile.createDimension('y', dimidY)
+
+    x = np.arange(tran[0], tran[0] + tran[1] * dimidX, tran[1])
+    y = np.arange(tran[3], tran[3] + tran[5] * dimidY, tran[5])
+
     chunk_lines = np.min([np.ceil(8192/dimidY)*128, dimidY])
-#    ChunkSize = [dimidX, chunk_lines]
     ChunkSize = [chunk_lines, dimidX]
 
 
-    varname='x'
-    datatype=np.dtype('float64')
-    dimensions=('x')
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','projection_x_coordinate')
-    var.setncattr('description','x coordinate of projection')
-    var.setncattr('units','m')
-#    var.setncattr('scene_pair_type',pair_type)
-#    var.setncattr('motion_detection_method',detection_method)
-#    var.setncattr('motion_coordinates',coordinates)
-#    pdb.set_trace()
+    var = nc_outfile.createVariable('x', np.dtype('float64'), 'x', fill_value=None)
+    var.setncattr('standard_name', 'projection_x_coordinate')
+    var.setncattr('description', 'x coordinate of projection')
+    var.setncattr('units', 'm')
+    # var.setncattr('scene_pair_type', pair_type)
+    # var.setncattr('motion_detection_method', detection_method)
+    # var.setncattr('motion_coordinates', coordinates)
+    # pdb.set_trace()
     var[:] = x
 
-    varname='y'
-    datatype=np.dtype('float64')
-    dimensions=('y')
-    FillValue=None
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue)
-    var.setncattr('standard_name','projection_y_coordinate')
-    var.setncattr('description','y coordinate of projection')
-    var.setncattr('units','m')
-#    var.setncattr('scene_pair_type',pair_type)
-#    var.setncattr('motion_detection_method',detection_method)
-#    var.setncattr('motion_coordinates',coordinates)
+
+    var = nc_outfile.createVariable('y', np.dtype('float64'), 'y', fill_value=None)
+    var.setncattr('standard_name', 'projection_y_coordinate')
+    var.setncattr('description', 'y coordinate of projection')
+    var.setncattr('units', 'm')
+    # var.setncattr('scene_pair_type', pair_type)
+    # var.setncattr('motion_detection_method', detection_method)
+    # var.setncattr('motion_coordinates', coordinates)
     var[:] = y
 
 
+    var = nc_outfile.createVariable('mapping', 'U1', (), fill_value=None)
+    if srs.GetAttrValue('PROJECTION') == 'Polar_Stereographic':
+        grid_mapping = 'polar_stereographic'  # need to set this as an attribute for the image variables
+        var.setncattr('grid_mapping_name', grid_mapping)
 
-    if (srs.GetAttrValue('PROJECTION') == 'Polar_Stereographic'):
+        var.setncattr('straight_vertical_longitude_from_pole', srs.GetProjParm('central_meridian'))
+        var.setncattr('false_easting', srs.GetProjParm('false_easting'))
+        var.setncattr('false_northing', srs.GetProjParm('false_northing'))
+        var.setncattr('latitude_of_projection_origin', np.sign(srs.GetProjParm('latitude_of_origin'))*90.0)  # could hardcode this to be -90 for landsat - just making it more general, maybe...
+        var.setncattr('latitude_of_origin', srs.GetProjParm('latitude_of_origin'))
+        # var.setncattr('longitude_of_prime_meridian', float(srs.GetAttrValue('GEOGCS|PRIMEM', 1)))
+        var.setncattr('semi_major_axis', float(srs.GetAttrValue('GEOGCS|SPHEROID', 1)))
+        # var.setncattr('semi_minor_axis', float(6356.752))
+        var.setncattr('scale_factor_at_projection_origin', 1)
+        var.setncattr('inverse_flattening', float(srs.GetAttrValue('GEOGCS|SPHEROID', 2)))
+        var.setncattr('spatial_ref', srs.ExportToWkt())
+        var.setncattr('spatial_proj4', srs.ExportToProj4())
+        var.setncattr('spatial_epsg', epsg)
+        var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
 
-#        mapping_name='Polar_Stereographic'
-        mapping_name='mapping'
-        grid_mapping='polar_stereographic'  # need to set this as an attribute for the image variables
-#        datatype=np.dtype('S1')
-        datatype='U1'
-        dimensions=()
-        FillValue=None
+    elif srs.GetAttrValue('PROJECTION') == 'Transverse_Mercator':
+        grid_mapping = 'universal_transverse_mercator'  # need to set this as an attribute for the image variables
+        var.setncattr('grid_mapping_name', grid_mapping)
 
-        var = nc_outfile.createVariable(mapping_name,datatype,dimensions, fill_value=FillValue)
-        # variable made, now add attributes
-
-        var.setncattr('grid_mapping_name',grid_mapping)
-        var.setncattr('straight_vertical_longitude_from_pole',srs.GetProjParm('central_meridian'))
-        var.setncattr('false_easting',srs.GetProjParm('false_easting'))
-        var.setncattr('false_northing',srs.GetProjParm('false_northing'))
-        var.setncattr('latitude_of_projection_origin',np.sign(srs.GetProjParm('latitude_of_origin'))*90.0)  # could hardcode this to be -90 for landsat - just making it more general, maybe...
-        var.setncattr('latitude_of_origin',srs.GetProjParm('latitude_of_origin'))
-#        var.setncattr('longitude_of_prime_meridian',float(srs.GetAttrValue('GEOGCS|PRIMEM',1)))
-        var.setncattr('semi_major_axis',float(srs.GetAttrValue('GEOGCS|SPHEROID',1)))
-#        var.setncattr('semi_minor_axis',float(6356.752))
-        var.setncattr('scale_factor_at_projection_origin',1)
-        var.setncattr('inverse_flattening',float(srs.GetAttrValue('GEOGCS|SPHEROID',2)))
-        var.setncattr('spatial_ref',srs.ExportToWkt())
-        var.setncattr('spatial_proj4',srs.ExportToProj4())
-        var.setncattr('spatial_epsg',epsg)
-        var.setncattr('GeoTransform',' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
-
-    elif (srs.GetAttrValue('PROJECTION') == 'Transverse_Mercator'):
-
-#        mapping_name='UTM_projection'
-        mapping_name='mapping'
-        grid_mapping='universal_transverse_mercator'  # need to set this as an attribute for the image variables
-#        datatype=np.dtype('S1')
-        datatype='U1'
-        dimensions=()
-        FillValue=None
-
-        var = nc_outfile.createVariable(mapping_name,datatype,dimensions, fill_value=FillValue)
-        # variable made, now add attributes
-
-
-        var.setncattr('grid_mapping_name',grid_mapping)
         zone = epsg - np.floor(epsg/100)*100
-        var.setncattr('utm_zone_number',zone)
-        var.setncattr('CoordinateTransformType','Projection')
-        var.setncattr('CoordinateAxisTypes','GeoX GeoY')
-#        var.setncattr('longitude_of_central_meridian',srs.GetProjParm('central_meridian'))
-#        var.setncattr('false_easting',srs.GetProjParm('false_easting'))
-#        var.setncattr('false_northing',srs.GetProjParm('false_northing'))
-#        var.setncattr('latitude_of_projection_origin',srs.GetProjParm('latitude_of_origin'))
-#        var.setncattr('scale_factor_at_central_meridian',srs.GetProjParm('scale_factor'))
-#        var.setncattr('longitude_of_prime_meridian',float(srs.GetAttrValue('GEOGCS|PRIMEM',1)))
-        var.setncattr('semi_major_axis',float(srs.GetAttrValue('GEOGCS|SPHEROID',1)))
-        var.setncattr('inverse_flattening',float(srs.GetAttrValue('GEOGCS|SPHEROID',2)))
-        var.setncattr('spatial_ref',srs.ExportToWkt())
-        var.setncattr('spatial_proj4',srs.ExportToProj4())
-        var.setncattr('spatial_epsg',epsg)
-        var.setncattr('GeoTransform',' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
+        var.setncattr('utm_zone_number', zone)
+        var.setncattr('CoordinateTransformType', 'Projection')
+        var.setncattr('CoordinateAxisTypes', 'GeoX GeoY')
+        # var.setncattr('longitude_of_central_meridian', srs.GetProjParm('central_meridian'))
+        # var.setncattr('false_easting', srs.GetProjParm('false_easting'))
+        # var.setncattr('false_northing', srs.GetProjParm('false_northing'))
+        # var.setncattr('latitude_of_projection_origin', srs.GetProjParm('latitude_of_origin'))
+        # var.setncattr('scale_factor_at_central_meridian', srs.GetProjParm('scale_factor'))
+        # var.setncattr('longitude_of_prime_meridian', float(srs.GetAttrValue('GEOGCS|PRIMEM', 1)))
+        var.setncattr('semi_major_axis', float(srs.GetAttrValue('GEOGCS|SPHEROID', 1)))
+        var.setncattr('inverse_flattening', float(srs.GetAttrValue('GEOGCS|SPHEROID', 2)))
+        var.setncattr('spatial_ref', srs.ExportToWkt())
+        var.setncattr('spatial_proj4', srs.ExportToProj4())
+        var.setncattr('spatial_epsg', epsg)
+        var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))  # note this has pixel size in it - set  explicitly above
+
     else:
         raise Exception('Projection {0} not recognized for this program'.format(srs.GetAttrValue('PROJECTION')))
 
 
-    varname='vx'
-    datatype=np.dtype('int16')
-    dimensions=('y','x')
-    FillValue=NoDataValue
-    var = nc_outfile.createVariable(varname,datatype,dimensions, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize, fill_value=FillValue)
-
-    var.setncattr('standard_name','x_velocity')
+    var = nc_outfile.createVariable('vx', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'x_velocity')
     if pair_type is 'radar':
-        var.setncattr('description','velocity component in x direction from radar range and azimuth measurements')
+        var.setncattr('description', 'velocity component in x direction from radar range and azimuth measurements')
     else:
-        var.setncattr('description','velocity component in x direction')
-    var.setncattr('units','m/y')
-    var.setncattr('grid_mapping',mapping_name)
+        var.setncattr('description', 'velocity component in x direction')
+    var.setncattr('units', 'm/y')
+    var.setncattr('grid_mapping', grid_mapping)
 
     if stable_count != 0:
         temp = VX.copy() - VXref.copy()
         temp[np.logical_not(SSM)] = np.nan
-#        vx_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+        # vx_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
         vx_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
     else:
         vx_error_mask = np.nan
     if stable_count1 != 0:
         temp = VX.copy() - VXref.copy()
         temp[np.logical_not(SSM1)] = np.nan
-#        vx_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+        # vx_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
         vx_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
     else:
         vx_error_slow = np.nan
@@ -630,75 +494,78 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     else:
         vx_error = vx_error_mod
 
-    var.setncattr('error',int(round(vx_error*10))/10)
-    var.setncattr('error_description','best estimate of x_velocity error: vx_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+    var.setncattr('error', int(round(vx_error*10))/10)
+    var.setncattr('error_description', 'best estimate of x_velocity error: vx_error is populated '
+                                       'according to the approach used for the velocity bias '
+                                       'correction as indicated in "stable_shift_flag"')
 
     if stable_count != 0:
-        var.setncattr('error_mask',int(round(vx_error_mask*10))/10)
+        var.setncattr('error_mask', int(round(vx_error_mask*10))/10)
     else:
-        var.setncattr('error_mask',np.nan)
-    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+        var.setncattr('error_mask', np.nan)
+    var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing '
+                                            'surfaces with velocity < 15 m/yr identified from an external mask')
 
-    var.setncattr('error_modeled',int(round(vx_error_mod*10))/10)
-    var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+    var.setncattr('error_modeled', int(round(vx_error_mod*10))/10)
+    var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
 
     if stable_count1 != 0:
-        var.setncattr('error_slow',int(round(vx_error_slow*10))/10)
+        var.setncattr('error_slow', int(round(vx_error_slow*10))/10)
     else:
-        var.setncattr('error_slow',np.nan)
-    var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+        var.setncattr('error_slow', np.nan)
+    var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
 
     if stable_shift_applied == 2:
-        var.setncattr('stable_shift',int(round(vx_mean_shift1*10))/10)
+        var.setncattr('stable_shift', int(round(vx_mean_shift1*10))/10)
     elif stable_shift_applied == 1:
-        var.setncattr('stable_shift',int(round(vx_mean_shift*10))/10)
+        var.setncattr('stable_shift', int(round(vx_mean_shift*10))/10)
     else:
-        var.setncattr('stable_shift',np.nan)
-    var.setncattr('stable_shift_flag',stable_shift_applied)
-    var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
+        var.setncattr('stable_shift', np.nan)
+    var.setncattr('stable_shift_flag', stable_shift_applied)
+    var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
+                                                   '1 = correction from overlapping stable surface mask (stationary '
+                                                   'or slow-flowing surfaces with velocity < 15 m/yr)(top priority); '
+                                                   '2 = correction from slowest 25% of overlapping velocities '
+                                                   '(second priority)')
 
     if stable_count != 0:
-        var.setncattr('stable_shift_mask',int(round(vx_mean_shift*10))/10)
+        var.setncattr('stable_shift_mask', int(round(vx_mean_shift*10))/10)
     else:
-        var.setncattr('stable_shift_mask',np.nan)
-    var.setncattr('stable_count_mask',stable_count)
+        var.setncattr('stable_shift_mask', np.nan)
+    var.setncattr('stable_count_mask', stable_count)
 
     if stable_count1 != 0:
-        var.setncattr('stable_shift_slow',int(round(vx_mean_shift1*10))/10)
+        var.setncattr('stable_shift_slow', int(round(vx_mean_shift1*10))/10)
     else:
-        var.setncattr('stable_shift_slow',np.nan)
+        var.setncattr('stable_shift_slow', np.nan)
     var.setncattr('stable_count_slow', stable_count1)
 
     VX[noDataMask] = NoDataValue
     var[:] = np.round(np.clip(VX, -32768, 32767)).astype(np.int16)
-#    var.setncattr('_FillValue',np.int16(FillValue))
+    # var.setncattr('_FillValue', np.int16(FillValue))
 
 
-    varname='vy'
-    datatype=np.dtype('int16')
-    dimensions=('y','x')
-    FillValue=NoDataValue
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-
-    var.setncattr('standard_name','y_velocity')
+    var = nc_outfile.createVariable('vy', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'y_velocity')
     if pair_type is 'radar':
-        var.setncattr('description','velocity component in y direction from radar range and azimuth measurements')
+        var.setncattr('description', 'velocity component in y direction from radar range and azimuth measurements')
     else:
-        var.setncattr('description','velocity component in y direction')
-    var.setncattr('units','m/y')
-    var.setncattr('grid_mapping',mapping_name)
+        var.setncattr('description', 'velocity component in y direction')
+    var.setncattr('units', 'm/y')
+    var.setncattr('grid_mapping', grid_mapping)
 
     if stable_count != 0:
         temp = VY.copy() - VYref.copy()
         temp[np.logical_not(SSM)] = np.nan
-#        vy_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+        # vy_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
         vy_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
     else:
         vy_error_mask = np.nan
     if stable_count1 != 0:
         temp = VY.copy() - VYref.copy()
         temp[np.logical_not(SSM1)] = np.nan
-#        vy_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+        # vy_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
         vy_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
     else:
         vy_error_slow = np.nan
@@ -712,14 +579,17 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         vy_error = vy_error_slow
     else:
         vy_error = vy_error_mod
-    var.setncattr('error',int(round(vy_error*10))/10)
-    var.setncattr('error_description','best estimate of y_velocity error: vy_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+    var.setncattr('error', int(round(vy_error*10))/10)
+    var.setncattr('error_description', 'best estimate of y_velocity error: vy_error is populated according '
+                                       'to the approach used for the velocity bias correction as indicated '
+                                       'in "stable_shift_flag"')
 
     if stable_count != 0:
-        var.setncattr('error_mask',int(round(vy_error_mask*10))/10)
+        var.setncattr('error_mask', int(round(vy_error_mask*10))/10)
     else:
-        var.setncattr('error_mask',np.nan)
-    var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+        var.setncattr('error_mask', np.nan)
+    var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces '
+                                            'with velocity < 15 m/yr identified from an external mask')
 
     var.setncattr('error_modeled', int(round(vy_error_mod * 10)) / 10)
     var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
@@ -731,104 +601,89 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
 
     if stable_shift_applied == 2:
-        var.setncattr('stable_shift',int(round(vy_mean_shift1*10))/10)
+        var.setncattr('stable_shift', int(round(vy_mean_shift1*10))/10)
     elif stable_shift_applied == 1:
-        var.setncattr('stable_shift',int(round(vy_mean_shift*10))/10)
+        var.setncattr('stable_shift', int(round(vy_mean_shift*10))/10)
     else:
-        var.setncattr('stable_shift',np.nan)
+        var.setncattr('stable_shift', np.nan)
 
-    var.setncattr('stable_shift_flag',stable_shift_applied)
-    var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
+    var.setncattr('stable_shift_flag', stable_shift_applied)
+    var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
+                                                   '1 = correction from overlapping stable surface mask (stationary '
+                                                   'or slow-flowing surfaces with velocity < 15 m/yr)(top priority); '
+                                                   '2 = correction from slowest 25% of overlapping velocities '
+                                                   '(second priority)')
 
     if stable_count != 0:
-        var.setncattr('stable_shift_mask',int(round(vy_mean_shift*10))/10)
+        var.setncattr('stable_shift_mask', int(round(vy_mean_shift*10))/10)
     else:
-        var.setncattr('stable_shift_mask',np.nan)
-    var.setncattr('stable_count_mask',stable_count)
+        var.setncattr('stable_shift_mask', np.nan)
+    var.setncattr('stable_count_mask', stable_count)
 
     if stable_count1 != 0:
-        var.setncattr('stable_shift_slow',int(round(vy_mean_shift1*10))/10)
+        var.setncattr('stable_shift_slow', int(round(vy_mean_shift1*10))/10)
     else:
-        var.setncattr('stable_shift_slow',np.nan)
+        var.setncattr('stable_shift_slow', np.nan)
     var.setncattr('stable_count_slow', stable_count1)
 
     VY[noDataMask] = NoDataValue
     var[:] = np.round(np.clip(VY, -32768, 32767)).astype(np.int16)
-#    var.setncattr('missing_value',np.int16(NoDataValue))
+    # var.setncattr('missing_value', np.int16(NoDataValue))
 
 
-
-
-    varname='v'
-    datatype=np.dtype('int16')
-    dimensions=('y','x')
-    FillValue=NoDataValue
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-    var.setncattr('standard_name','velocity')
+    var = nc_outfile.createVariable('v', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'velocity')
     if pair_type is 'radar':
-        var.setncattr('description','velocity magnitude from radar range and azimuth measurements')
+        var.setncattr('description', 'velocity magnitude from radar range and azimuth measurements')
     else:
-        var.setncattr('description','velocity magnitude')
-    var.setncattr('units','m/y')
-
-    var.setncattr('grid_mapping',mapping_name)
+        var.setncattr('description', 'velocity magnitude')
+    var.setncattr('units', 'm/y')
+    var.setncattr('grid_mapping', grid_mapping)
 
     V[noDataMask] = NoDataValue
     var[:] = np.round(np.clip(V, -32768, 32767)).astype(np.int16)
-#    var.setncattr('missing_value',np.int16(NoDataValue))
+    # var.setncattr('missing_value',np.int16(NoDataValue))
 
 
-
+    var = nc_outfile.createVariable('v_error', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'velocity_error')
+    if pair_type is 'radar':
+        var.setncattr('description', 'velocity magnitude error from radar range and azimuth measurements')
+    else:
+        var.setncattr('description', 'velocity magnitude error')
+    var.setncattr('units', 'm/y')
+    var.setncattr('grid_mapping', grid_mapping)
 
     v_error = v_error_cal(vx_error, vy_error)
-    varname='v_error'
-    datatype=np.dtype('int16')
-    dimensions=('y','x')
-    FillValue=NoDataValue
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-    var.setncattr('standard_name','velocity_error')
-    if pair_type is 'radar':
-        var.setncattr('description','velocity magnitude error from radar range and azimuth measurements')
-    else:
-        var.setncattr('description','velocity magnitude error')
-    var.setncattr('units','m/y')
-
-    var.setncattr('grid_mapping',mapping_name)
-
     V_error = np.sqrt((vx_error * VX / V)**2 + (vy_error * VY / V)**2)
-    V_error[V==0] = v_error
+    V_error[V == 0] = v_error
     V_error[noDataMask] = NoDataValue
     var[:] = np.round(np.clip(V_error, -32768, 32767)).astype(np.int16)
 #    var.setncattr('missing_value',np.int16(NoDataValue))
 
 
-
-
-
     if pair_type is 'radar':
+        var = nc_outfile.createVariable('vr', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
 
-        varname='vr'
-        datatype=np.dtype('int16')
-        dimensions=('y','x')
-        FillValue=NoDataValue
-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-
-        var.setncattr('standard_name','range_velocity')
-        var.setncattr('description','velocity in radar range direction')
-        var.setncattr('units','m/y')
-        var.setncattr('grid_mapping',mapping_name)
+        var.setncattr('standard_name', 'range_velocity')
+        var.setncattr('description', 'velocity in radar range direction')
+        var.setncattr('units', 'm/y')
+        var.setncattr('grid_mapping', grid_mapping)
 
         if stable_count != 0:
             temp = VR.copy() - VRref.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            vr_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+            # vr_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
             vr_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
         else:
             vr_error_mask = np.nan
         if stable_count1 != 0:
             temp = VR.copy() - VRref.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            vr_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+            # vr_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
             vr_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
         else:
             vr_error_slow = np.nan
@@ -840,72 +695,75 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         else:
             vr_error = vr_error_mod
 
-        var.setncattr('error',int(round(vr_error*10))/10)
-        var.setncattr('error_description','best estimate of range_velocity error: vr_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+        var.setncattr('error', int(round(vr_error*10))/10)
+        var.setncattr('error_description', 'best estimate of range_velocity error: vr_error is populated '
+                                           'according to the approach used for the velocity bias correction '
+                                           'as indicated in "stable_shift_flag"')
 
         if stable_count != 0:
-            var.setncattr('error_mask',int(round(vr_error_mask*10))/10)
+            var.setncattr('error_mask', int(round(vr_error_mask*10))/10)
         else:
-            var.setncattr('error_mask',np.nan)
-        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+            var.setncattr('error_mask', np.nan)
+        var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing '
+                                                'surfaces with velocity < 15 m/yr identified from an external mask')
 
-        var.setncattr('error_modeled',int(round(vr_error_mod*10))/10)
-        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+        var.setncattr('error_modeled', int(round(vr_error_mod*10))/10)
+        var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
 
         if stable_count1 != 0:
-            var.setncattr('error_slow',int(round(vr_error_slow*10))/10)
+            var.setncattr('error_slow', int(round(vr_error_slow*10))/10)
         else:
-            var.setncattr('error_slow',np.nan)
-        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+            var.setncattr('error_slow', np.nan)
+        var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
 
         if stable_shift_applied == 2:
-            var.setncattr('stable_shift',int(round(vr_mean_shift1*10))/10)
+            var.setncattr('stable_shift', int(round(vr_mean_shift1*10))/10)
         elif stable_shift_applied == 1:
-            var.setncattr('stable_shift',int(round(vr_mean_shift*10))/10)
+            var.setncattr('stable_shift', int(round(vr_mean_shift*10))/10)
         else:
-            var.setncattr('stable_shift',np.nan)
-        var.setncattr('stable_shift_flag',stable_shift_applied)
-        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
+            var.setncattr('stable_shift', np.nan)
+        var.setncattr('stable_shift_flag', stable_shift_applied)
+        var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
+                                                       '1 = correction from overlapping stable surface mask '
+                                                       '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
+                                                       '(top priority); 2 = correction from slowest 25% of overlapping '
+                                                       'velocities (second priority)')
 
         if stable_count != 0:
-            var.setncattr('stable_shift_mask',int(round(vr_mean_shift*10))/10)
+            var.setncattr('stable_shift_mask', int(round(vr_mean_shift*10))/10)
         else:
-            var.setncattr('stable_shift_mask',np.nan)
-        var.setncattr('stable_count_mask',stable_count)
+            var.setncattr('stable_shift_mask', np.nan)
+        var.setncattr('stable_count_mask', stable_count)
 
         if stable_count1 != 0:
-            var.setncattr('stable_shift_slow',int(round(vr_mean_shift1*10))/10)
+            var.setncattr('stable_shift_slow', int(round(vr_mean_shift1*10))/10)
         else:
-            var.setncattr('stable_shift_slow',np.nan)
-        var.setncattr('stable_count_slow',stable_count1)
+            var.setncattr('stable_shift_slow', np.nan)
+        var.setncattr('stable_count_slow', stable_count1)
 
         VR[noDataMask] = NoDataValue
         var[:] = np.round(np.clip(VR, -32768, 32767)).astype(np.int16)
-#        var.setncattr('missing_value',np.int16(NoDataValue))
+        # var.setncattr('missing_value', np.int16(NoDataValue))
 
 
-        varname='va'
-        datatype=np.dtype('int16')
-        dimensions=('y','x')
-        FillValue=NoDataValue
-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-
-        var.setncattr('standard_name','azimuth_velocity')
-        var.setncattr('description','velocity in radar azimuth direction')
-        var.setncattr('units','m/y')
-        var.setncattr('grid_mapping',mapping_name)
+        var = nc_outfile.createVariable('va', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+        var.setncattr('standard_name', 'azimuth_velocity')
+        var.setncattr('description', 'velocity in radar azimuth direction')
+        var.setncattr('units', 'm/y')
+        var.setncattr('grid_mapping', grid_mapping)
 
         if stable_count != 0:
             temp = VA.copy() - VAref.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            va_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+            # va_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
             va_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
         else:
             va_error_mask = np.nan
         if stable_count1 != 0:
             temp = VA.copy() - VAref.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            va_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+            # va_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
             va_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
         else:
             va_error_slow = np.nan
@@ -917,70 +775,75 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         else:
             va_error = va_error_mod
 
-        var.setncattr('error',int(round(va_error*10))/10)
-        var.setncattr('error_description','best estimate of azimuth_velocity error: va_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
+        var.setncattr('error', int(round(va_error*10))/10)
+        var.setncattr('error_description', 'best estimate of azimuth_velocity error: va_error is populated '
+                                           'according to the approach used for the velocity bias correction '
+                                           'as indicated in "stable_shift_flag"')
 
         if stable_count != 0:
-            var.setncattr('error_mask',int(round(va_error_mask*10))/10)
+            var.setncattr('error_mask', int(round(va_error_mask*10))/10)
         else:
-            var.setncattr('error_mask',np.nan)
-        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
+            var.setncattr('error_mask', np.nan)
+        var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
 
-        var.setncattr('error_modeled',int(round(va_error_mod*10))/10)
-        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
+        var.setncattr('error_modeled', int(round(va_error_mod*10))/10)
+        var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
 
         if stable_count1 != 0:
-            var.setncattr('error_slow',int(round(va_error_slow*10))/10)
+            var.setncattr('error_slow', int(round(va_error_slow*10))/10)
         else:
-            var.setncattr('error_slow',np.nan)
-        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
+            var.setncattr('error_slow', np.nan)
+        var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
 
         if stable_shift_applied == 2:
-            var.setncattr('stable_shift',int(round(va_mean_shift1*10))/10)
+            var.setncattr('stable_shift', int(round(va_mean_shift1*10))/10)
         elif stable_shift_applied == 1:
-            var.setncattr('stable_shift',int(round(va_mean_shift*10))/10)
+            var.setncattr('stable_shift', int(round(va_mean_shift*10))/10)
         else:
-            var.setncattr('stable_shift',np.nan)
-        var.setncattr('stable_shift_flag',stable_shift_applied)
-        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
+            var.setncattr('stable_shift', np.nan)
+        var.setncattr('stable_shift_flag', stable_shift_applied)
+        var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
+                                                       '1 = correction from overlapping stable surface mask '
+                                                       '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
+                                                       '(top priority); 2 = correction from slowest 25% of overlapping '
+                                                       'velocities (second priority)')
 
         if stable_count != 0:
-            var.setncattr('stable_shift_mask',int(round(va_mean_shift*10))/10)
+            var.setncattr('stable_shift_mask', int(round(va_mean_shift*10))/10)
         else:
-            var.setncattr('stable_shift_mask',np.nan)
-        var.setncattr('stable_count_mask',stable_count)
+            var.setncattr('stable_shift_mask', np.nan)
+        var.setncattr('stable_count_mask', stable_count)
 
         if stable_count1 != 0:
-            var.setncattr('stable_shift_slow',int(round(va_mean_shift1*10))/10)
+            var.setncattr('stable_shift_slow', int(round(va_mean_shift1*10))/10)
         else:
-            var.setncattr('stable_shift_slow',np.nan)
-        var.setncattr('stable_count_slow',stable_count1)
+            var.setncattr('stable_shift_slow', np.nan)
+        var.setncattr('stable_count_slow', stable_count1)
 
         VA[noDataMask] = NoDataValue
         var[:] = np.round(np.clip(VA, -32768, 32767)).astype(np.int16)
-#        var.setncattr('missing_value',np.int16(NoDataValue))
-
+        # var.setncattr('missing_value', np.int16(NoDataValue))
 
         # fuse the (slope parallel & reference) flow-based range-projected result with the raw observed range/azimuth-based result
         if stable_count_p != 0:
             temp = VXP.copy() - VXref.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+            # vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
             vxp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
 
             temp = VYP.copy() - VYref.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+            # vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
             vyp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
         if stable_count1_p != 0:
             temp = VXP.copy() - VXref.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+            # vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
             vxp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
 
             temp = VYP.copy() - VYref.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+            # vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
             vyp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
         vxp_error_mod = (error_vector[0][4]*IMG_INFO_DICT['date_dt']+error_vector[1][4])/IMG_INFO_DICT['date_dt']*365
         vyp_error_mod = (error_vector[0][5]*IMG_INFO_DICT['date_dt']+error_vector[1][5])/IMG_INFO_DICT['date_dt']*365
@@ -997,13 +860,11 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
 
         VP_error = np.sqrt((vxp_error * VXP / VP)**2 + (vyp_error * VYP / VP)**2)
 
-
         VXPP[V_error > VP_error] = VXP[V_error > VP_error]
         VYPP[V_error > VP_error] = VYP[V_error > VP_error]
         VXP = VXPP.astype(np.float32)
         VYP = VYPP.astype(np.float32)
         VP = np.sqrt(VXP**2+VYP**2)
-
 
         stable_count_p = np.sum(SSM & np.logical_not(np.isnan(VXP)))
         stable_count1_p = np.sum(SSM1 & np.logical_not(np.isnan(VXP)))
@@ -1016,26 +877,26 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         if stable_count_p != 0:
             temp = VXP.copy() - VX.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
             vxp_mean_shift = vx_mean_shift + bias_mean_shift / 1
 
             temp = VYP.copy() - VY.copy()
             temp[np.logical_not(SSM)] = np.nan
-#            bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift = np.median(temp[np.logical_not(np.isnan(temp))])
             vyp_mean_shift = vy_mean_shift + bias_mean_shift / 1
 
         if stable_count1_p != 0:
             temp = VXP.copy() - VX.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
             vxp_mean_shift1 = vx_mean_shift1 + bias_mean_shift1 / 1
 
             temp = VYP.copy() - VY.copy()
             temp[np.logical_not(SSM1)] = np.nan
-#            bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
+            # bias_mean_shift1 = np.median(temp[(temp > -500)&(temp < 500)])
             bias_mean_shift1 = np.median(temp[np.logical_not(np.isnan(temp))])
             vyp_mean_shift1 = vy_mean_shift1 + bias_mean_shift1 / 1
 
@@ -1048,208 +909,207 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
             stable_shift_applied_p = 1
 
 
-#        varname='vxp'
-#        datatype=np.dtype('int16')
-#        dimensions=('y','x')
-#        FillValue=NoDataValue
-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-#
-#
-#        var.setncattr('standard_name','projected_x_velocity')
-#        var.setncattr('description','x-direction velocity determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected vx estimates are used')
-#        var.setncattr('units','m/y')
-#
-#
-#        if stable_count_p != 0:
-#            temp = VXP.copy() - VXref.copy()
-#            temp[np.logical_not(SSM)] = np.nan
-##            vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
-#            vxp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
-#        else:
-#            vxp_error_mask = np.nan
-#        if stable_count1_p != 0:
-#            temp = VXP.copy() - VXref.copy()
-#            temp[np.logical_not(SSM1)] = np.nan
-##            vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
-#            vxp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
-#        else:
-#            vxp_error_slow = np.nan
-#        if stable_shift_applied_p == 1:
-#            vxp_error = vxp_error_mask
-#        elif stable_shift_applied_p == 2:
-#            vxp_error = vxp_error_slow
-#        else:
-#            vxp_error = vxp_error_mod
-#        var.setncattr('error',int(round(vxp_error*10))/10)
-#        var.setncattr('error_description','best estimate of projected_x_velocity error: vxp_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
-#
-#
-#        if stable_shift_applied_p == 2:
-#            var.setncattr('stable_shift',int(round(vxp_mean_shift1*10))/10)
-#        elif stable_shift_applied_p == 1:
-#            var.setncattr('stable_shift',int(round(vxp_mean_shift*10))/10)
-#        else:
-#            var.setncattr('stable_shift',np.nan)
-#        var.setncattr('stable_shift_flag',stable_shift_applied_p)
-#        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
-#
-#
-#        var.setncattr('stable_count_mask',stable_count_p)
-#        var.setncattr('stable_count_slow',stable_count1_p)
-#        if stable_count_p != 0:
-#            var.setncattr('stable_shift_mask',int(round(vxp_mean_shift*10))/10)
-#        else:
-#            var.setncattr('stable_shift_mask',np.nan)
-#        if stable_count1_p != 0:
-#            var.setncattr('stable_shift_slow',int(round(vxp_mean_shift1*10))/10)
-#        else:
-#            var.setncattr('stable_shift_slow',np.nan)
-#
-#        if stable_count_p != 0:
-#            var.setncattr('error_mask',int(round(vxp_error_mask*10))/10)
-#        else:
-#            var.setncattr('error_mask',np.nan)
-#        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
-#        if stable_count1_p != 0:
-#            var.setncattr('error_slow',int(round(vxp_error_slow*10))/10)
-#        else:
-#            var.setncattr('error_slow',np.nan)
-#        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
-#        var.setncattr('error_modeled',int(round(vxp_error_mod*10))/10)
-#        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
-#
-#
-#        var.setncattr('grid_mapping',mapping_name)
-#
-#        VXP[noDataMask] = NoDataValue
-#        var[:] = np.round(np.clip(VXP, -32768, 32767)).astype(np.int16)
-##        var.setncattr('missing_value',np.int16(NoDataValue))
-#
-#
-#
-#
-#
-#
-#        varname='vyp'
-#        datatype=np.dtype('int16')
-#        dimensions=('y','x')
-#        FillValue=NoDataValue
-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-#
-#
-#        var.setncattr('standard_name','projected_y_velocity')
-#        var.setncattr('description','y-direction velocity determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected vy estimates are used')
-#        var.setncattr('units','m/y')
-#
-#
-#        if stable_count_p != 0:
-#            temp = VYP.copy() - VYref.copy()
-#            temp[np.logical_not(SSM)] = np.nan
-##            vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
-#            vyp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
-#        else:
-#            vyp_error_mask = np.nan
-#        if stable_count1_p != 0:
-#            temp = VYP.copy() - VYref.copy()
-#            temp[np.logical_not(SSM1)] = np.nan
-##            vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
-#            vyp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
-#        else:
-#            vyp_error_slow = np.nan
-#        if stable_shift_applied_p == 1:
-#            vyp_error = vyp_error_mask
-#        elif stable_shift_applied_p == 2:
-#            vyp_error = vyp_error_slow
-#        else:
-#            vyp_error = vyp_error_mod
-#        var.setncattr('error',int(round(vyp_error*10))/10)
-#        var.setncattr('error_description','best estimate of projected_y_velocity error: vyp_error is populated according to the approach used for the velocity bias correction as indicated in "stable_shift_flag"')
-#
-#
-#        if stable_shift_applied_p == 2:
-#            var.setncattr('stable_shift',int(round(vyp_mean_shift1*10))/10)
-#        elif stable_shift_applied_p == 1:
-#            var.setncattr('stable_shift',int(round(vyp_mean_shift*10))/10)
-#        else:
-#            var.setncattr('stable_shift',np.nan)
-#        var.setncattr('stable_shift_flag',stable_shift_applied_p)
-#        var.setncattr('stable_shift_flag_description','flag for applying velocity bias correction: 0 = no correction; 1 = correction from overlapping stable surface mask (stationary or slow-flowing surfaces with velocity < 15 m/yr)(top priority); 2 = correction from slowest 25% of overlapping velocities (second priority)')
-#
-#
-#        var.setncattr('stable_count_mask',stable_count_p)
-#        var.setncattr('stable_count_slow',stable_count1_p)
-#        if stable_count_p != 0:
-#            var.setncattr('stable_shift_mask',int(round(vyp_mean_shift*10))/10)
-#        else:
-#            var.setncattr('stable_shift_mask',np.nan)
-#        if stable_count1_p != 0:
-#            var.setncattr('stable_shift_slow',int(round(vyp_mean_shift1*10))/10)
-#        else:
-#            var.setncattr('stable_shift_slow',np.nan)
-#
-#        if stable_count_p != 0:
-#            var.setncattr('error_mask',int(round(vyp_error_mask*10))/10)
-#        else:
-#            var.setncattr('error_mask',np.nan)
-#        var.setncattr('error_mask_description','RMSE over stable surfaces, stationary or slow-flowing surfaces with velocity < 15 m/yr identified from an external mask')
-#        if stable_count1_p != 0:
-#            var.setncattr('error_slow',int(round(vyp_error_slow*10))/10)
-#        else:
-#            var.setncattr('error_slow',np.nan)
-#        var.setncattr('error_slow_description','RMSE over slowest 25% of retrieved velocities')
-#        var.setncattr('error_modeled',int(round(vyp_error_mod*10))/10)
-#        var.setncattr('error_modeled_description','1-sigma error calculated using a modeled error-dt relationship')
-#
-#
-#        var.setncattr('grid_mapping',mapping_name)
-#
-#        VYP[noDataMask] = NoDataValue
-#        var[:] = np.round(np.clip(VYP, -32768, 32767)).astype(np.int16)
-##        var.setncattr('missing_value',np.int16(NoDataValue))
-#
-#
-#
-#
-#
-#
-#        varname='vp'
-#        datatype=np.dtype('int16')
-#        dimensions=('y','x')
-#        FillValue=NoDataValue
-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-#        var.setncattr('standard_name','projected_velocity')
-#        var.setncattr('description','velocity magnitude determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected v estimates are used')
-#        var.setncattr('units','m/y')
-#
-#        var.setncattr('grid_mapping',mapping_name)
-#
-#        VP[noDataMask] = NoDataValue
-#        var[:] = np.round(np.clip(VP, -32768, 32767)).astype(np.int16)
-##        var.setncattr('missing_value',np.int16(NoDataValue))
-#
-#
-#
-#
-#
-#        vp_error = v_error_cal(vxp_error, vyp_error)
-#        varname='vp_error'
-#        datatype=np.dtype('int16')
-#        dimensions=('y','x')
-#        FillValue=NoDataValue
-#        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-#        var.setncattr('standard_name','projected_velocity_error')
-#        var.setncattr('description','velocity magnitude error determined by projecting radar range measurements onto an a priori flow vector. Where projected errors are larger than those determined from range and azimuth measurements, unprojected v_error estimates are used')
-#        var.setncattr('units','m/y')
-#
-#        var.setncattr('grid_mapping',mapping_name)
-#
-#        VP_error = np.sqrt((vxp_error * VXP / VP)**2 + (vyp_error * VYP / VP)**2)
-#        VP_error[VP==0] = vp_error
-#        VP_error[noDataMask] = NoDataValue
-#        var[:] = np.round(np.clip(VP_error, -32768, 32767)).astype(np.int16)
-##        var.setncattr('missing_value',np.int16(NoDataValue))
+        # var = nc_outfile.createVariable('vxp',np.dtype('int16'),('y', 'x'), fill_value=NoDataValue,
+        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+        # var.setncattr('standard_name', 'projected_x_velocity')
+        # var.setncattr('description', 'x-direction velocity determined by projecting radar range measurements '
+        #                              'onto an a priori flow vector. Where projected errors are larger than those '
+        #                              'determined from range and azimuth measurements, unprojected vx estimates are used')
+        # var.setncattr('units', 'm/y')
+        # var.setncattr('grid_mapping', grid_mapping)
+        #
+        # if stable_count_p != 0:
+        #     temp = VXP.copy() - VXref.copy()
+        #     temp[np.logical_not(SSM)] = np.nan
+        #     # vxp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+        #     vxp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+        # else:
+        #     vxp_error_mask = np.nan
+        # if stable_count1_p != 0:
+        #     temp = VXP.copy() - VXref.copy()
+        #     temp[np.logical_not(SSM1)] = np.nan
+        #     # vxp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+        #     vxp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+        # else:
+        #     vxp_error_slow = np.nan
+        # if stable_shift_applied_p == 1:
+        #     vxp_error = vxp_error_mask
+        # elif stable_shift_applied_p == 2:
+        #     vxp_error = vxp_error_slow
+        # else:
+        #     vxp_error = vxp_error_mod
+        # var.setncattr('error', int(round(vxp_error*10))/10)
+        # var.setncattr('error_description', 'best estimate of projected_x_velocity error: vxp_error is populated '
+        #                                    'according to the approach used for the velocity bias correction as '
+        #                                    'indicated in "stable_shift_flag"')
+        #
+        # if stable_count_p != 0:
+        #     var.setncattr('error_mask', int(round(vxp_error_mask*10))/10)
+        # else:
+        #     var.setncattr('error_mask', np.nan)
+        # var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces '
+        #                                         'with velocity < 15 m/yr identified from an external mask')
+        #
+        # var.setncattr('error_modeled', int(round(vxp_error_mod * 10)) / 10)
+        # var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
+        #
+        # if stable_count1_p != 0:
+        #     var.setncattr('error_slow', int(round(vxp_error_slow * 10)) / 10)
+        # else:
+        #     var.setncattr('error_slow', np.nan)
+        # var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
+        #
+        # if stable_shift_applied_p == 2:
+        #     var.setncattr('stable_shift', int(round(vxp_mean_shift1*10))/10)
+        # elif stable_shift_applied_p == 1:
+        #     var.setncattr('stable_shift', int(round(vxp_mean_shift*10))/10)
+        # else:
+        #     var.setncattr('stable_shift', np.nan)
+        # var.setncattr('stable_shift_flag', stable_shift_applied_p)
+        # var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
+        #                                                '1 = correction from overlapping stable surface mask '
+        #                                                '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
+        #                                                '(top priority); 2 = correction from slowest 25% of overlapping '
+        #                                                'velocities (second priority)')
+        #
+        # if stable_count_p != 0:
+        #     var.setncattr('stable_shift_mask',int(round(vxp_mean_shift*10))/10)
+        # else:
+        #     var.setncattr('stable_shift_mask',np.nan)
+        # var.setncattr('stable_count_mask',stable_count_p)
+        #
+        # if stable_count1_p != 0:
+        #     var.setncattr('stable_shift_slow',int(round(vxp_mean_shift1*10))/10)
+        # else:
+        #     var.setncattr('stable_shift_slow',np.nan)
+        # var.setncattr('stable_count_slow',stable_count1_p)
+        #
+        # VXP[noDataMask] = NoDataValue
+        # var[:] = np.round(np.clip(VXP, -32768, 32767)).astype(np.int16)
+        # # var.setncattr('missing_value', np.int16(NoDataValue))
+        #
+        #
+        # var = nc_outfile.createVariable('vyp', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+        # var.setncattr('standard_name', 'projected_y_velocity')
+        # var.setncattr('description', 'y-direction velocity determined by projecting radar range measurements '
+        #                              'onto an a priori flow vector. Where projected errors are larger than those '
+        #                              'determined from range and azimuth measurements, unprojected vy estimates are used')
+        # var.setncattr('units', 'm/y')
+        # var.setncattr('grid_mapping', grid_mapping)
+        #
+        # if stable_count_p != 0:
+        #     temp = VYP.copy() - VYref.copy()
+        #     temp[np.logical_not(SSM)] = np.nan
+        #     # vyp_error_mask = np.std(temp[(temp > -500)&(temp < 500)])
+        #     vyp_error_mask = np.std(temp[np.logical_not(np.isnan(temp))])
+        # else:
+        #     vyp_error_mask = np.nan
+        # if stable_count1_p != 0:
+        #     temp = VYP.copy() - VYref.copy()
+        #     temp[np.logical_not(SSM1)] = np.nan
+        #     # vyp_error_slow = np.std(temp[(temp > -500)&(temp < 500)])
+        #     vyp_error_slow = np.std(temp[np.logical_not(np.isnan(temp))])
+        # else:
+        #     vyp_error_slow = np.nan
+        # if stable_shift_applied_p == 1:
+        #     vyp_error = vyp_error_mask
+        # elif stable_shift_applied_p == 2:
+        #     vyp_error = vyp_error_slow
+        # else:
+        #     vyp_error = vyp_error_mod
+        # var.setncattr('error', int(round(vyp_error*10))/10)
+        # var.setncattr('error_description', 'best estimate of projected_y_velocity error: vyp_error is populated '
+        #                                    'according to the approach used for the velocity bias correction as '
+        #                                    'indicated in "stable_shift_flag"')
+        #
+        # if stable_count_p != 0:
+        #     var.setncattr('error_mask', int(round(vyp_error_mask*10))/10)
+        # else:
+        #     var.setncattr('error_mask', np.nan)
+        # var.setncattr('error_mask_description', 'RMSE over stable surfaces, stationary or slow-flowing surfaces '
+        #                                         'with velocity < 15 m/yr identified from an external mask')
+        #
+        # var.setncattr('error_modeled', int(round(vyp_error_mod * 10)) / 10)
+        # var.setncattr('error_modeled_description', '1-sigma error calculated using a modeled error-dt relationship')
+        #
+        # if stable_count1_p != 0:
+        #     var.setncattr('error_slow', int(round(vyp_error_slow*10))/10)
+        # else:
+        #     var.setncattr('error_slow', np.nan)
+        # var.setncattr('error_slow_description', 'RMSE over slowest 25% of retrieved velocities')
+        #
+        # if stable_shift_applied_p == 2:
+        #     var.setncattr('stable_shift', int(round(vyp_mean_shift1*10))/10)
+        # elif stable_shift_applied_p == 1:
+        #     var.setncattr('stable_shift', int(round(vyp_mean_shift*10))/10)
+        # else:
+        #     var.setncattr('stable_shift', np.nan)
+        # var.setncattr('stable_shift_flag', stable_shift_applied_p)
+        # var.setncattr('stable_shift_flag_description', 'flag for applying velocity bias correction: 0 = no correction; '
+        #                                                '1 = correction from overlapping stable surface mask '
+        #                                                '(stationary or slow-flowing surfaces with velocity < 15 m/yr)'
+        #                                                '(top priority); 2 = correction from slowest 25% of overlapping '
+        #                                                'velocities (second priority)')
+        #
+        # if stable_count_p != 0:
+        #     var.setncattr('stable_shift_mask', int(round(vyp_mean_shift*10))/10)
+        # else:
+        #     var.setncattr('stable_shift_mask', np.nan)
+        # var.setncattr('stable_count_mask', stable_count_p)
+        #
+        # if stable_count1_p != 0:
+        #     var.setncattr('stable_shift_slow',int(round(vyp_mean_shift1*10))/10)
+        # else:
+        #     var.setncattr('stable_shift_slow',np.nan)
+        # var.setncattr('stable_count_slow', stable_count1_p)
+        #
+        # VYP[noDataMask] = NoDataValue
+        # var[:] = np.round(np.clip(VYP, -32768, 32767)).astype(np.int16)
+        # # var.setncattr('missing_value', np.int16(NoDataValue))
+        #
+        #
+        # var = nc_outfile.createVariable('vp', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+        # var.setncattr('standard_name', 'projected_velocity')
+        # var.setncattr('description', 'velocity magnitude determined by projecting radar range measurements '
+        #                              'onto an a priori flow vector. Where projected errors are larger than those '
+        #                              'determined from range and azimuth measurements, unprojected v estimates are used')
+        # var.setncattr('units', 'm/y')
+        # var.setncattr('grid_mapping', grid_mapping)
+        #
+        # VP[noDataMask] = NoDataValue
+        # var[:] = np.round(np.clip(VP, -32768, 32767)).astype(np.int16)
+        # # var.setncattr('missing_value',np.int16(NoDataValue))
+        #
+        #
+        # var = nc_outfile.createVariable('vp_error', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+        #                                 zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+        # var.setncattr('standard_name', 'projected_velocity_error')
+        # var.setncattr('description', 'velocity magnitude error determined by projecting radar range measurements '
+        #                              'onto an a priori flow vector. Where projected errors are larger than those '
+        #                              'determined from range and azimuth measurements, unprojected v_error estimates are used')
+        # var.setncattr('units', 'm/y')
+        # var.setncattr('grid_mapping', grid_mapping)
+        #
+        # vp_error = v_error_cal(vxp_error, vyp_error)
+        # VP_error = np.sqrt((vxp_error * VXP / VP)**2 + (vyp_error * VYP / VP)**2)
+        # VP_error[VP==0] = vp_error
+        # VP_error[noDataMask] = NoDataValue
+        # var[:] = np.round(np.clip(VP_error, -32768, 32767)).astype(np.int16)
+        # # var.setncattr('missing_value', np.int16(NoDataValue))
 
 
+        var = nc_outfile.createVariable('M11', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+        var.setncattr('standard_name', 'conversion_matrix_element_11')
+        var.setncattr('description', 'conversion matrix element (1st row, 1st column) that can be multiplied with vx '
+                                     'to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
+        var.setncattr('units', 'pixel/(m/y)')
+        var.setncattr('grid_mapping', grid_mapping)
+        var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
+        var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
+                                                     'pixel displacement dr to slant range velocity vr')
 
         M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
 
@@ -1259,32 +1119,29 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         y2 = 50
 
         C = [(y2-y1)/(x2-x1), y1-x1*(y2-y1)/(x2-x1)]
-#        M11 = C[0]*M11+C[1]
-
-        varname='M11'
-        datatype=np.dtype('int16')
-        dimensions=('y','x')
-        FillValue=NoDataValue
-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-        var.setncattr('standard_name','conversion_matrix_element_11')
-        var.setncattr('description','conversion matrix element (1st row, 1st column) that can be multiplied with vx to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
-        var.setncattr('units','pixel/(m/y)')
-
-        var.setncattr('grid_mapping',mapping_name)
-        var.setncattr('dr_to_vr_factor',dr_2_vr_factor)
-        var.setncattr('dr_to_vr_factor_description','multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr')
-
-        var.setncattr('scale_factor',np.float32(1/C[0]))
-        var.setncattr('add_offset',np.float32(-C[1]/C[0]))
+        # M11 = C[0]*M11+C[1]
+        var.setncattr('scale_factor', np.float32(1/C[0]))
+        var.setncattr('add_offset', np.float32(-C[1]/C[0]))
 
         M11[noDataMask] = NoDataValue * np.float32(1/C[0]) + np.float32(-C[1]/C[0])
-#        M11[noDataMask] = NoDataValue
+        # M11[noDataMask] = NoDataValue
         var[:] = M11
-#        var[:] = np.round(np.clip(M11, -32768, 32767)).astype(np.int16)
-#        var[:] = np.clip(M11, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
-#        var.setncattr('missing_value',np.int16(NoDataValue))
+        # var[:] = np.round(np.clip(M11, -32768, 32767)).astype(np.int16)
+        # var[:] = np.clip(M11, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
+        # var.setncattr('missing_value',np.int16(NoDataValue))
 
 
+        var = nc_outfile.createVariable('M12', np.dtype('int16'), ('y', 'x'), fill_value=NoDataValue,
+                                        zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+        var.setncattr('standard_name', 'conversion_matrix_element_12')
+        var.setncattr('description', 'conversion matrix element (1st row, 2nd column) that can be multiplied with vy '
+                                     'to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
+        var.setncattr('units', 'pixel/(m/y)')
+        var.setncattr('grid_mapping', grid_mapping)
+
+        var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
+        var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
+                                                     'pixel displacement dr to slant range velocity vr')
 
         M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
 
@@ -1293,121 +1150,87 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         y1 = -50
         y2 = 50
 
-        C = [(y2-y1)/(x2-x1), y1-x1*(y2-y1)/(x2-x1)]
-#        M12 = C[0]*M12+C[1]
-
-        varname='M12'
-        datatype=np.dtype('int16')
-        dimensions=('y','x')
-        FillValue=NoDataValue
-        var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-        var.setncattr('standard_name','conversion_matrix_element_12')
-        var.setncattr('description','conversion matrix element (1st row, 2nd column) that can be multiplied with vy to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)')
-        var.setncattr('units','pixel/(m/y)')
-        var.setncattr('grid_mapping',mapping_name)
-
-        var.setncattr('dr_to_vr_factor',dr_2_vr_factor)
-        var.setncattr('dr_to_vr_factor_description','multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr')
-
-        var.setncattr('scale_factor',np.float32(1/C[0]))
-        var.setncattr('add_offset',np.float32(-C[1]/C[0]))
+        C = [(y2 - y1) / (x2 - x1), y1 - x1 * (y2 - y1) / (x2 - x1)]
+        # M12 = C[0]*M12+C[1]
+        var.setncattr('scale_factor', np.float32(1/C[0]))
+        var.setncattr('add_offset', np.float32(-C[1]/C[0]))
 
         M12[noDataMask] = NoDataValue * np.float32(1/C[0]) + np.float32(-C[1]/C[0])
-#        M12[noDataMask] = NoDataValue
+        # M12[noDataMask] = NoDataValue
         var[:] = M12
-#        var[:] = np.round(np.clip(M12, -32768, 32767)).astype(np.int16)
-#        var[:] = np.clip(M12, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
-#        var.setncattr('missing_value',np.int16(NoDataValue))
+        # var[:] = np.round(np.clip(M12, -32768, 32767)).astype(np.int16)
+        # var[:] = np.clip(M12, -3.4028235e+38, 3.4028235e+38).astype(np.float32)
+        # var.setncattr('missing_value',np.int16(NoDataValue))
 
 
-    varname='chip_size_width'
-    datatype=np.dtype('uint16')
-    dimensions=('y','x')
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-
-    var.setncattr('standard_name','chip_size_width')
-    var.setncattr('description','width of search template (chip)')
-    var.setncattr('units','m')
-    var.setncattr('grid_mapping',mapping_name)
+    var = nc_outfile.createVariable('chip_size_width', np.dtype('uint16'), ('y', 'x'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'chip_size_width')
+    var.setncattr('description', 'width of search template (chip)')
+    var.setncattr('units', 'm')
+    var.setncattr('grid_mapping', grid_mapping)
 
     if pair_type is 'radar':
-        var.setncattr('range_pixel_size',rangePixelSize)
-        var.setncattr('chip_size_coordinates','radar geometry: width = range, height = azimuth')
+        var.setncattr('range_pixel_size', rangePixelSize)
+        var.setncattr('chip_size_coordinates', 'radar geometry: width = range, height = azimuth')
     else:
-        var.setncattr('x_pixel_size',rangePixelSize)
-        var.setncattr('chip_size_coordinates','image projection geometry: width = x, height = y')
+        var.setncattr('x_pixel_size', rangePixelSize)
+        var.setncattr('chip_size_coordinates', 'image projection geometry: width = x, height = y')
 
     # var[:] = np.flipud(vx_nomask).astype('float32')
     var[:] = np.round(np.clip(CHIPSIZEX, 0, 65535)).astype('uint16')
-#    var.setncattr('missing_value',np.uint16(0))
+    # var.setncattr('missing_value', np.uint16(0))
 
 
-    varname='chip_size_height'
-    datatype=np.dtype('uint16')
-    dimensions=('y','x')
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-
-    var.setncattr('standard_name','chip_size_height')
-    var.setncattr('description','height of search template (chip)')
-    var.setncattr('units','m')
-    var.setncattr('grid_mapping',mapping_name)
+    var = nc_outfile.createVariable('chip_size_height', np.dtype('uint16'), ('y', 'x'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'chip_size_height')
+    var.setncattr('description', 'height of search template (chip)')
+    var.setncattr('units', 'm')
+    var.setncattr('grid_mapping', grid_mapping)
 
     if pair_type is 'radar':
-        var.setncattr('azimuth_pixel_size',azimuthPixelSize)
-        var.setncattr('chip_size_coordinates','radar geometry: width = range, height = azimuth')
+        var.setncattr('azimuth_pixel_size', azimuthPixelSize)
+        var.setncattr('chip_size_coordinates', 'radar geometry: width = range, height = azimuth')
     else:
-        var.setncattr('y_pixel_size',azimuthPixelSize)
-        var.setncattr('chip_size_coordinates','image projection geometry: width = x, height = y')
+        var.setncattr('y_pixel_size', azimuthPixelSize)
+        var.setncattr('chip_size_coordinates', 'image projection geometry: width = x, height = y')
 
     # var[:] = np.flipud(vx_nomask).astype('float32')
     var[:] = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype('uint16')
-#    var.setncattr('missing_value',np.uint16(0))
+    # var.setncattr('missing_value', np.uint16(0))
 
 
-    varname='interp_mask'
-    datatype=np.dtype('uint8')
-    dimensions=('y','x')
-#    FillValue=None
-    FillValue=0
-    var = nc_outfile.createVariable(varname,datatype,dimensions, fill_value=FillValue, zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
-
-    var.setncattr('standard_name','interpolated_value_mask')
-    var.setncattr('description','light interpolation mask')
-    var.setncattr('units','binary')
-    var.setncattr('grid_mapping',mapping_name)
+    var = nc_outfile.createVariable('interp_mask', np.dtype('uint8'), ('y', 'x'), fill_value=0,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'interpolated_value_mask')
+    var.setncattr('description', 'light interpolation mask')
+    var.setncattr('units', 'binary')
+    var.setncattr('grid_mapping', grid_mapping)
 
     # var[:] = np.flipud(vx_nomask).astype('float32')
     var[:] = np.round(np.clip(INTERPMASK, 0, 255)).astype('uint8')
-#    var.setncattr('missing_value',np.uint8(0))
+    # var.setncattr('missing_value', np.uint8(0))
 
-    nc_outfile.sync() # flush data to disk
+
+    nc_outfile.sync()  # flush data to disk
     nc_outfile.close()
 
     return out_nc_filename
 
 
 def rotate_vel2radar(rngind, azmind, vel_x, vel_y, swath_border, swath_border_full, GridSpacingX, ScaleChipSizeY, flag):
-    from osgeo import gdal
-    import numpy as np
-    import scipy.io as sio
-    import pandas as pd
-
-
     ncols = np.nanmax(rngind)+1
     nrows = np.nanmax(azmind)+1
 
-#    pdb.set_trace()
-
     skipSample_x = GridSpacingX
     skipSample_y = int(np.round(GridSpacingX*ScaleChipSizeY))
-    xGrid = np.arange(0,ncols,skipSample_x)
-    yGrid = np.arange(0,nrows,skipSample_y)
+    xGrid = np.arange(0, ncols, skipSample_x)
+    yGrid = np.arange(0, nrows, skipSample_y)
     nd = xGrid.__len__()
     md = yGrid.__len__()
-    rngind1 = np.int32(np.dot(np.ones((md,1)),np.reshape(xGrid,(1,xGrid.__len__()))))
-    azmind1 = np.int32(np.dot(np.reshape(yGrid,(yGrid.__len__(),1)),np.ones((1,nd))))
+    rngind1 = np.int32(np.dot(np.ones((md, 1)), np.reshape(xGrid, (1, xGrid.__len__()))))
+    azmind1 = np.int32(np.dot(np.reshape(yGrid, (yGrid.__len__(), 1)), np.ones((1, nd))))
 
     rngind1 = rngind1.astype(np.float32)
     azmind1 = azmind1.astype(np.float32)
@@ -1415,55 +1238,53 @@ def rotate_vel2radar(rngind, azmind, vel_x, vel_y, swath_border, swath_border_fu
     output_vel_x = np.zeros(rngind1.shape)*np.nan
     output_vel_y = np.zeros(rngind1.shape)*np.nan
 
-#    pdb.set_trace()
-
     for irow in range(rngind.shape[0]):
         for icol in range(rngind.shape[1]):
-            tempcol = rngind[irow,icol]
-            temprow = azmind[irow,icol]
-            if ((~np.isnan(tempcol))&(~np.isnan(temprow))):
-                tempcol = np.argmin(np.abs(xGrid-rngind[irow,icol]))
-                temprow = np.argmin(np.abs(yGrid-azmind[irow,icol]))
-                output_vel_x[temprow,tempcol] = vel_x[irow,icol]
-                output_vel_y[temprow,tempcol] = vel_y[irow,icol]
+            tempcol = rngind[irow, icol]
+            temprow = azmind[irow, icol]
+            if (~np.isnan(tempcol)) & (~np.isnan(temprow)):
+                tempcol = np.argmin(np.abs(xGrid-rngind[irow, icol]))
+                temprow = np.argmin(np.abs(yGrid-azmind[irow, icol]))
+                output_vel_x[temprow, tempcol] = vel_x[irow, icol]
+                output_vel_y[temprow, tempcol] = vel_y[irow, icol]
 
     shift = 500
 
     if flag == 0:
-        mask = (rngind1 > swath_border[0]-shift)&(rngind1 < swath_border[0]+shift)
-#        mask = (rngind1 > swath_border_full[0])&(rngind1 < swath_border_full[1])
+        mask = (rngind1 > swath_border[0]-shift) & (rngind1 < swath_border[0]+shift)
+        # mask = (rngind1 > swath_border_full[0]) & (rngind1 < swath_border_full[1])
         output_vel_x[mask] = np.nan
         output_vel_y[mask] = np.nan
 
     if flag == 1:
-        mask = (rngind1 > swath_border[1]-shift)&(rngind1 < swath_border[1]+shift)
-#        mask = (rngind1 > swath_border_full[2])&(rngind1 < swath_border_full[3])
+        mask = (rngind1 > swath_border[1]-shift) & (rngind1 < swath_border[1]+shift)
+        # mask = (rngind1 > swath_border_full[2]) & (rngind1 < swath_border_full[3])
         output_vel_x[mask] = np.nan
         output_vel_y[mask] = np.nan
 
     df = pd.DataFrame(output_vel_x)
-    df = df.interpolate(method='linear',axis=1)
+    df = df.interpolate(method='linear', axis=1)
     output_vel_x = df.to_numpy()
 
     df = pd.DataFrame(output_vel_y)
-    df = df.interpolate(method='linear',axis=1)
+    df = df.interpolate(method='linear', axis=1)
     output_vel_y = df.to_numpy()
 
-    output_vel_x=output_vel_x.astype('float32')
-    output_vel_y=output_vel_y.astype('float32')
+    output_vel_x = output_vel_x.astype('float32')
+    output_vel_y = output_vel_y.astype('float32')
 
     output_vel_x1 = vel_x.copy()
     output_vel_y1 = vel_y.copy()
 
     for irow in range(rngind.shape[0]):
         for icol in range(rngind.shape[1]):
-            tempcol = rngind[irow,icol]
-            temprow = azmind[irow,icol]
-            if ((~np.isnan(tempcol))&(~np.isnan(temprow))):
-                tempcol = np.argmin(np.abs(xGrid-rngind[irow,icol]))
-                temprow = np.argmin(np.abs(yGrid-azmind[irow,icol]))
-                output_vel_x1[irow,icol] = output_vel_x[temprow,tempcol]
-                output_vel_y1[irow,icol] = output_vel_y[temprow,tempcol]
+            tempcol = rngind[irow, icol]
+            temprow = azmind[irow, icol]
+            if (~np.isnan(tempcol)) & (~np.isnan(temprow)):
+                tempcol = np.argmin(np.abs(xGrid-rngind[irow, icol]))
+                temprow = np.argmin(np.abs(yGrid-azmind[irow, icol]))
+                output_vel_x1[irow, icol] = output_vel_x[temprow, tempcol]
+                output_vel_y1[irow, icol] = output_vel_y[temprow, tempcol]
 
     output_vel_x1[np.isnan(vel_x)] = np.nan
     output_vel_y1[np.isnan(vel_y)] = np.nan
@@ -1472,10 +1293,9 @@ def rotate_vel2radar(rngind, azmind, vel_x, vel_y, swath_border, swath_border_fu
 
 
 def loadProduct(xmlname):
-    '''
-        Load the product using Product Manager.
-        '''
-    import isce
+    """
+    Load the product using Product Manager.
+    """
     from iscesys.Component.ProductManager import ProductManager as PM
 
     pm = PM()
@@ -1486,16 +1306,14 @@ def loadProduct(xmlname):
     return obj
 
 
-
 def loadMetadata(indir):
-    '''
-        Input file.
-        '''
+    """
+    Input file.
+    """
     import os
-    import numpy as np
 
     frames = []
-    for swath in range(1,4):
+    for swath in range(1, 4):
         inxml = os.path.join(indir, 'IW{0}.xml'.format(swath))
         if os.path.exists(inxml):
             ifg = loadProduct(inxml)
@@ -1504,16 +1322,8 @@ def loadMetadata(indir):
     return frames, flight_direction
 
 
-
-
-def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran, proj, GridSpacingX, ScaleChipSizeY, output_ref=[0.0,0.0,0.0,0.0]):
-    from osgeo import gdal
-    import numpy as np
-
-    frames =  None
-    flight_direction = None
-    frames_s =  None
-    flight_direction_s = None
+def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata,
+                          tran, proj, GridSpacingX, ScaleChipSizeY, output_ref=[0.0, 0.0, 0.0, 0.0]):
 
     frames, flight_direction = loadMetadata(os.path.dirname(indir_m)[:-6]+'fine_coreg')
     frames_s, flight_direction_s = loadMetadata(os.path.dirname(indir_m)[:-6]+'secondary')
@@ -1545,30 +1355,28 @@ def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran,
     flag21 = 0
     flag32 = 0
 
-
-
     rngind = rngind.astype(np.float32)
     azmind = azmind.astype(np.float32)
     rngind[rngind == nodata] = np.nan
     azmind[azmind == nodata] = np.nan
 
-#    pdb.set_trace()
-    ncols = int( np.round( (frames[2].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+    ncols = int(np.round((frames[2].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
 
-    ind2 = int( np.round( (frames[0].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+    ind2 = int(np.round((frames[0].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
 
-    ind1 = int( np.round( (frames[1].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+    ind1 = int(np.round((frames[1].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
 
     swath_border.append((ind1+ind2)/2)
     swath_border_full.append(ind1)
     swath_border_full.append(ind2)
 
-    mask1 = (rngind > ind1-500)&(rngind < ind1)
-    mask2 = (rngind > ind2)&(rngind < ind2+500)
+    mask1 = (rngind > ind1-500) & (rngind < ind1)
+    mask2 = (rngind > ind2) & (rngind < ind2+500)
 
-    if (np.nanstd(VX[mask2])<25)&(np.nanstd(VX[mask1])<25)&(np.nanstd(VY[mask2])<25)&(np.nanstd(VY[mask1])<25):
-#        output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
-#        output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
+    if (np.nanstd(VX[mask2]) < 25) & (np.nanstd(VX[mask1]) < 25) \
+            & (np.nanstd(VY[mask2]) < 25) & (np.nanstd(VY[mask1]) < 25):
+        # output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
+        # output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
         output.append(output_ref[0])
         output.append(output_ref[1])
         flag21 = 1
@@ -1576,23 +1384,20 @@ def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran,
         output.append(output_ref[0])
         output.append(output_ref[1])
 
-#    pdb.set_trace()
-
-    ind2 = int( np.round( (frames[1].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
-
-    ind1 = int( np.round( (frames[2].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+    ind2 = int(np.round((frames[1].farRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
+    ind1 = int(np.round((frames[2].startingRange - frames[0].startingRange)/frames[0].bursts[0].rangePixelSize))
 
     swath_border.append((ind1+ind2)/2)
     swath_border_full.append(ind1)
     swath_border_full.append(ind2)
 
-    mask1 = (rngind > ind1-500)&(rngind < ind1)
-    mask2 = (rngind > ind2)&(rngind < ind2+500)
+    mask1 = (rngind > ind1-500) & (rngind < ind1)
+    mask2 = (rngind > ind2) & (rngind < ind2+500)
 
-
-    if (np.nanstd(VX[mask2])<25)&(np.nanstd(VX[mask1])<25)&(np.nanstd(VY[mask2])<25)&(np.nanstd(VY[mask1])<25):
-#        output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
-#        output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
+    if (np.nanstd(VX[mask2]) < 25) & (np.nanstd(VX[mask1]) < 25) \
+            & (np.nanstd(VY[mask2]) < 25) & (np.nanstd(VY[mask1]) < 25):
+        # output.append(np.nanmedian(DX[mask2])-np.nanmedian(DX[mask1]))
+        # output.append(np.nanmedian(DY[mask2])-np.nanmedian(DY[mask1]))
         output.append(output_ref[2])
         output.append(output_ref[3])
         flag32 = 1
@@ -1600,52 +1405,23 @@ def cal_swath_offset_bias(indir_m, rngind, azmind, VX, VY, DX, DY, nodata, tran,
         output.append(output_ref[2])
         output.append(output_ref[3])
 
-
-
-
-#    pdb.set_trace()
-
-    mask1 = (rngind > swath_border[1])&(rngind < ncols)
+    mask1 = (rngind > swath_border[1]) & (rngind < ncols)
     DX[mask1] = DX[mask1] - output[2]
     DY[mask1] = DY[mask1] - output[3]
 
-    mask2 = (rngind > swath_border[0])&(rngind < ncols)
+    mask2 = (rngind > swath_border[0]) & (rngind < ncols)
     DX[mask2] = DX[mask2] - output[0]
     DY[mask2] = DY[mask2] - output[1]
 
-    if (flag21 == 1):
+    if flag21 == 1:
         DX, DY = rotate_vel2radar(rngind, azmind, DX, DY, swath_border, swath_border_full, GridSpacingX, ScaleChipSizeY, 0)
         print('sharp peaks corrected at subswath 2 and 1 borders')
-    if (flag32 == 1):
+    if flag32 == 1:
         DX, DY = rotate_vel2radar(rngind, azmind, DX, DY, swath_border, swath_border_full, GridSpacingX, ScaleChipSizeY, 1)
         print('sharp peaks corrected at subswath 3 and 2 borders')
 
-
-    print('subswath offset bias between subswath 2 and 1: {0} {1}'.format(output[0],output[1]))
-    print('subswath offset bias between subswath 3 and 2: {0} {1}'.format(output[2],output[3]))
-    print('subswath border index: {0} {1}'.format(swath_border[0],swath_border[1]))
+    print('subswath offset bias between subswath 2 and 1: {0} {1}'.format(output[0], output[1]))
+    print('subswath offset bias between subswath 3 and 2: {0} {1}'.format(output[2], output[3]))
+    print('subswath border index: {0} {1}'.format(swath_border[0], swath_border[1]))
 
     return DX, DY, flight_direction, flight_direction_s
-
-
-
-
-#if __name__ == '__main__':
-#
-#        inps = cmdLineParse()
-#
-#        print (time.strftime("%H:%M:%S"))
-#        from topsApp import TopsInSAR
-#        insar = TopsInSAR(name="topsApp")
-#
-#
-##        pdb.set_trace()
-#
-#        rangePixelSize = float(str.split(runCmd('fgrep "Range:" testGeogrid.txt'))[2])
-#        prf = float(str.split(runCmd('fgrep "Azimuth:" testGeogrid.txt'))[2])
-#        dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
-#        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-#        satv = np.array([float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[3]), float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[4]), float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[5])])
-#        print (str(rangePixelSize)+"      "+str(prf)+"      "+str(satv)+"      "+str(dt))
-#        azimuthPixelSize = np.sqrt(np.sum(satv**2)) / prf
-#        print (str(rangePixelSize)+"      "+str(azimuthPixelSize))


### PR DESCRIPTION
This refactor of the netCDF packaging script was primarily to re-order the attributes so they generally appear in alphabetical order where logical, and follow a consistent ordering across variables. 

Since this required moving around the vast majority of the lines in this file, I also did a cleanup first pass as I went.