### PR TITLE
Pin opencv to fix linking issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.7.5](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.7.4...v0.7.5)
 
-### Security
+### Added
 * It is now possible to inject Earthdata username and password using environment variables: `EARTHDATA_USERNAME`
   and `EARTHDATA_PASSWORD`.
+
+### Fixed
+* The `opencv` conda package has been pinned to `4.5.3` due to a braking change to its `libopencv_core.so.*`
+  naming scheme in `4.5.5`.
+
 
 ## [0.7.4](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.7.3...v0.7.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `opencv` conda package has been pinned to `4.5.3` due to a breaking change to its `libopencv_core.so.*`
   naming scheme in `4.5.5`.
 
-
 ## [0.7.4](https://github.com/ASFHyP3/hyp3-autorift/compare/v0.7.3...v0.7.4)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `EARTHDATA_PASSWORD`.
 
 ### Fixed
-* The `opencv` conda package has been pinned to `4.5.3` due to a braking change to its `libopencv_core.so.*`
+* The `opencv` conda package has been pinned to `4.5.3` due to a breaking change to its `libopencv_core.so.*`
   naming scheme in `4.5.5`.
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - hyp3lib=1.6.8
   - isce2=2.5.3.dev1
   - autorift=1.4.0
+  - opencv=4.5.3  # fix changed libopencv_core.so.* version scheme in v4.5.5
   - boto3
   - matplotlib-base
   - netCDF4


### PR DESCRIPTION
autoRIFT jobs have been failing with:
```
ImportError: libopencv_core.so.4.5: cannot open shared object file: No such file or directory
```
due to a change in how opencv aliases the `libopencv_core` shared libraries. autoRIFT [pins to `libopencv_core.so.4.5`](https://github.com/conda-forge/autorift-feedstock/blob/master/recipe/meta.yaml#L31), which exists for opencv 4.5.3:
```
/opt/conda/envs/hyp3-autorift/lib/libopencv_core.so
/opt/conda/envs/hyp3-autorift/lib/libopencv_core.so.4.5.3
/opt/conda/envs/hyp3-autorift/lib/libopencv_core.so.4.5
```
but in opencv 4.5.3, the shared libraries look like:
```
 /opt/conda/envs/hyp3-autorift/lib/libopencv_core.so
 /opt/conda/envs/hyp3-autorift/lib/libopencv_core.so.405
 /opt/conda/envs/hyp3-autorift/lib/libopencv_core.so.4.5.5
```
where the generic minor version link has been changed from `*.so.4.5` to `*.so.405`, which is due to an upstream change with how opencv is built (not sure if intentional or not; I suspect not). 

This pins opencv to `4.5.3` for now, and a true fix should be handled upstream in the autoRFT and/or opencv recipes. 