### PR TITLE
For S2, prefer duplicate in us-west-2 over canonical in eu-central-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.2]
+
+### Changed
+* When processing Sentinel-2 scenes, `hyp3_autorift` will now prefer scenes available in `s3://s2-l1c-us-west-2`
+  over the canonical `s3://sentinel-s2-l1c` bucket in the `eu-central-1` region.
+
 ## [0.8.1]
 
 ### Changed

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -92,9 +92,9 @@ def get_s2_metadata(scene_name):
     return response.json()['features'][0]
 
 
-def s3_object_is_accesible(bucket, key):
+def s3_object_is_accessible(bucket, key):
     try:
-        S3_CLIENT.Object(bucket, key).load()
+        S3_CLIENT.head_object(Bucket=bucket, Key=key)
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] in ['403', '404']:
             return False
@@ -103,11 +103,11 @@ def s3_object_is_accesible(bucket, key):
 
 
 def get_s2_path(metadata: dict) -> str:
-    s3_location = metadata['assets']['B08']['href']
+    s3_location = metadata['assets']['B08']['href'].replace('s3://', '').split('/')
     bucket = s3_location[0]
     key = '/'.join(s3_location[1:])
 
-    if s3_object_is_accesible(bucket=S2_WEST_BUCKET, key=key):
+    if s3_object_is_accessible(bucket=S2_WEST_BUCKET, key=key):
         return f'/vsis3/{S2_WEST_BUCKET}/{key}'
 
     return f'/vsis3/{bucket}/{key}'

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -13,6 +13,7 @@ from secrets import token_hex
 from typing import Tuple
 
 import boto3
+import botocore.exceptions
 import numpy as np
 import requests
 from hyp3lib.fetch import download_file
@@ -31,6 +32,7 @@ gdal.UseExceptions()
 
 S3_CLIENT = boto3.client('s3')
 S2_SEARCH_URL = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l1c/items'
+S2_WEST_BUCKET = 's2-l1c-us-west-2'
 LC2_SEARCH_URL = 'https://landsatlook.usgs.gov/sat-api/collections/landsat-c2l1/items'
 LANDSAT_BUCKET = 'usgs-landsat'
 
@@ -88,6 +90,32 @@ def get_s2_metadata(scene_name):
     if not response.json().get('numberReturned'):
         raise ValueError(f'Scene could not be found: {scene_name}')
     return response.json()['features'][0]
+
+
+def s3_object_is_accesible(bucket, key):
+    try:
+        S3_CLIENT.Object(bucket, key).load()
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] in ['403', '404']:
+            return False
+        raise
+    return True
+
+
+def get_s2_path(metadata: dict) -> str:
+    s3_location = metadata['assets']['B08']['href']
+    bucket = s3_location[0]
+    key = '/'.join(s3_location[1:])
+
+    if s3_object_is_accesible(bucket=S2_WEST_BUCKET, key=key):
+        return f'/vsis3/{S2_WEST_BUCKET}/{key}'
+
+    return f'/vsis3/{bucket}/{key}'
+
+
+def ensure_same_s3_buckets(reference_path: str, secondary_path: str):
+    if (S2_WEST_BUCKET in reference_path) != (S2_WEST_BUCKET in secondary_path):
+        raise ValueError(f'Only one Sentinel-2 scene is in s3://{S2_WEST_BUCKET}')
 
 
 def least_precise_orbit_of(orbits):
@@ -174,6 +202,13 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
     secondary_state_vec = None
     lat_limits, lon_limits = None, None
 
+    # Set config and env for new CXX threads in Geogrid/autoRIFT
+    gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
+    os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
+
+    gdal.SetConfigOption('AWS_REGION', 'us-west-2')
+    os.environ['AWS_REGION'] = 'us-west-2'
+
     platform = get_platform(reference)
     if platform == 'S1':
         for scene in [reference, secondary]:
@@ -191,32 +226,28 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         lat_limits, lon_limits = geometry.bounding_box(f'{reference}.zip', polarization=polarization, orbits=orbits)
 
     elif platform == 'S2':
-        gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
-        gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
-        gdal.SetConfigOption('AWS_REGION', 'eu-central-1')
-        # Also set for new CXX threads in Geogrid/autoRIFT
-        os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
-        os.environ['AWS_REQUEST_PAYER'] = 'requester'
-        os.environ['AWS_REGION'] = 'eu-central-1'
-
         reference_metadata = get_s2_metadata(reference)
-        reference_path = reference_metadata['assets']['B08']['href'].replace('s3://', '/vsis3/')
+        reference_path = get_s2_path(reference_metadata)
 
         secondary_metadata = get_s2_metadata(secondary)
-        secondary_path = secondary_metadata['assets']['B08']['href'].replace('s3://', '/vsis3/')
+        secondary_path = get_s2_path(secondary_metadata)
+
+        ensure_same_s3_buckets(reference_path, secondary_path)
+
+        if S2_WEST_BUCKET not in reference_path:
+            gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
+            os.environ['AWS_REQUEST_PAYER'] = 'requester'
+
+            gdal.SetConfigOption('AWS_REGION', 'eu-central-1')
+            os.environ['AWS_REGION'] = 'eu-central-1'
 
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
         lon_limits = (bbox[0], bbox[2])
 
     elif platform == 'L':
-        gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
         gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
-        gdal.SetConfigOption('AWS_REGION', 'us-west-2')
-        # Also set for new CXX threads in Geogrid/autoRIFT
-        os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
         os.environ['AWS_REQUEST_PAYER'] = 'requester'
-        os.environ['AWS_REGION'] = 'us-west-2'
 
         reference_metadata = get_lc2_metadata(reference)
         reference_path = get_lc2_path(reference_metadata)
@@ -227,6 +258,9 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         bbox = reference_metadata['bbox']
         lat_limits = (bbox[1], bbox[3])
         lon_limits = (bbox[0], bbox[2])
+
+    log.info(f'Reference scene path: {reference_path}')
+    log.info(f'Secondary scene path: {secondary_path}')
 
     scene_poly = geometry.polygon_from_bbox(x_limits=lat_limits, y_limits=lon_limits)
     parameter_info = io.find_jpl_parameter_info(scene_poly, parameter_file)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -6,7 +6,6 @@ from unittest import mock
 import botocore.exceptions
 import pytest
 import responses
-from botocore.stub import Stubber
 
 from hyp3_autorift import process
 


### PR DESCRIPTION
Egressing both scenes from `eu-central-1` to `us-west-2` while processing doubles the cost of a sentinel-2 job, and on a campaign scale, since we process a scene many times, ~36 folds the data transfer cost. 

This will look for scenes in a `us-west-2` bucket and use them if they exist, otherwise fall back to the canonical copy in `eu-central-1`, which will allow us to copy the unique set of scenes we're going to process ahead of the campaign to reduce processing costs.