### PR TITLE
Fix GDAL env variables preventing Sentinel-1 processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.4]
+
+### Fixed
+* A GDAL issue preventing Sentinel-1 processing introduced in v0.8.1
+
 ## [0.8.3]
 
 ### Fixed

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -206,13 +206,6 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
     secondary_state_vec = None
     lat_limits, lon_limits = None, None
 
-    # Set config and env for new CXX threads in Geogrid/autoRIFT
-    gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
-    os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
-
-    gdal.SetConfigOption('AWS_REGION', 'us-west-2')
-    os.environ['AWS_REGION'] = 'us-west-2'
-
     platform = get_platform(reference)
     if platform == 'S1':
         for scene in [reference, secondary]:
@@ -230,6 +223,13 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         lat_limits, lon_limits = geometry.bounding_box(f'{reference}.zip', polarization=polarization, orbits=orbits)
 
     elif platform == 'S2':
+        # Set config and env for new CXX threads in Geogrid/autoRIFT
+        gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
+        os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
+
+        gdal.SetConfigOption('AWS_REGION', 'us-west-2')
+        os.environ['AWS_REGION'] = 'us-west-2'
+
         reference_metadata = get_s2_metadata(reference)
         secondary_metadata = get_s2_metadata(secondary)
 
@@ -248,6 +248,13 @@ def process(reference: str, secondary: str, parameter_file: str = DEFAULT_PARAME
         lon_limits = (bbox[0], bbox[2])
 
     elif platform == 'L':
+        # Set config and env for new CXX threads in Geogrid/autoRIFT
+        gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
+        os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
+
+        gdal.SetConfigOption('AWS_REGION', 'us-west-2')
+        os.environ['AWS_REGION'] = 'us-west-2'
+
         gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
         os.environ['AWS_REQUEST_PAYER'] = 'requester'
 


### PR DESCRIPTION
When these environment variables are set for Sentinel-1 processing, jobs fail because the DEM file we `gdal.Warp` ends up empty, leading to a unkown file type error from GDAL. 

I have *no idea* why this is true.