### PR TITLE
Support Landsat-7 Imagery

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   # For running
   - gdal>=3
   - hyp3lib=1.7.0
-  - isce2=2.5.3.dev1
+  - isce2=2.6.1.dev1
   - autorift=1.4.1.dev4
   - opencv
   - boto3

--- a/environment.yml
+++ b/environment.yml
@@ -25,8 +25,8 @@ dependencies:
   - gdal>=3
   - hyp3lib=1.7.0
   - isce2=2.5.3.dev1
-  - autorift=1.4.0
-  - opencv=4.5.3  # fix changed libopencv_core.so.* version scheme in v4.5.5
+  - autorift=1.4.1.dev1
+  - opencv
   - boto3
   - matplotlib-base
   - netCDF4

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - gdal>=3
   - hyp3lib=1.7.0
   - isce2=2.5.3.dev1
-  - autorift=1.4.1.dev3
+  - autorift=1.4.1.dev4
   - opencv
   - boto3
   - matplotlib-base

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - gdal>=3
   - hyp3lib=1.7.0
   - isce2=2.5.3.dev1
-  - autorift=1.4.1.dev1
+  - autorift=1.4.1.dev3
   - opencv
   - boto3
   - matplotlib-base

--- a/hyp3_autorift/vend/testGeogridOptical.py
+++ b/hyp3_autorift/vend/testGeogridOptical.py
@@ -103,6 +103,9 @@ def coregisterLoadMetadata(indir_m, indir_s, **kwargs):
     if re.findall("L[CO]0[89]_",DS.GetDescription()).__len__() > 0:
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
+    elif re.findall("L[EO]07_",DS.GetDescription()).__len__() > 0:
+        nameString = os.path.basename(DS.GetDescription())
+        info.time = nameString.split('_')[3]
     elif 'sentinel-s2-l1c' in indir_m or 's2-l1c-us-west-2' in indir_m:
         s2_name = kwargs['reference_metadata']['id']
         info.time = s2_name.split('_')[2]
@@ -121,6 +124,9 @@ def coregisterLoadMetadata(indir_m, indir_s, **kwargs):
     info1 = Dummy()
 
     if re.findall("L[CO]0[89]_",DS1.GetDescription()).__len__() > 0:
+        nameString1 = os.path.basename(DS1.GetDescription())
+        info1.time = nameString1.split('_')[3]
+    elif re.findall("L[EO]07_",DS1.GetDescription()).__len__() > 0:
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif 'sentinel-s2-l1c' in indir_s or 's2-l1c-us-west-2' in indir_s:

--- a/hyp3_autorift/vend/testGeogrid_ISCE.py
+++ b/hyp3_autorift/vend/testGeogrid_ISCE.py
@@ -173,6 +173,9 @@ def coregisterLoadMetadataOptical(indir_m, indir_s, **kwargs):
     if re.findall("L[CO]0[89]_",DS.GetDescription()).__len__() > 0:
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
+    elif re.findall("L[EO]07_",DS.GetDescription()).__len__() > 0:
+        nameString = os.path.basename(DS.GetDescription())
+        info.time = nameString.split('_')[3]
     elif 'sentinel-s2-l1c' in indir_m or 's2-l1c-us-west-2' in indir_m:
         s2_name = kwargs['reference_metadata']['id']
         info.time = s2_name.split('_')[2]
@@ -191,6 +194,9 @@ def coregisterLoadMetadataOptical(indir_m, indir_s, **kwargs):
     info1 = Dummy()
 
     if re.findall("L[CO]0[89]_",DS1.GetDescription()).__len__() > 0:
+        nameString1 = os.path.basename(DS1.GetDescription())
+        info1.time = nameString1.split('_')[3]
+    elif re.findall("L[EO]07_",DS1.GetDescription()).__len__() > 0:
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif 'sentinel-s2-l1c' in indir_s or 's2-l1c-us-west-2' in indir_s:

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -504,7 +504,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         s_name = os.path.basename(indir_s)
 
         preprocessing_methods = ['hps', 'hps']
-        for ii, name in enumerate(m_name, s_name):
+        for ii, name in enumerate((m_name, s_name)):
             if name.startswith('L7'):
                 acquisition = datetime.strptime(name.spilt('_')[3], '%Y%m%d')
                 if acquisition >= date(2003, 5, 31):

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -27,14 +27,8 @@
 #
 # Author: Yang Lei
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-
-
-import pdb
-from osgeo import gdal, osr
-
-
+from osgeo import gdal
+from datetime import date, datetime, timedelta
 
 
 def runCmd(cmd):
@@ -131,7 +125,7 @@ def loadProductOptical(file_m, file_s):
 
 
 def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
-                nodata, mpflag, geogrid_run_info=None):
+                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps')):
     '''
     Wire and run geogrid.
     '''
@@ -283,7 +277,15 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     t1 = time.time()
     print("Pre-process Start!!!")
 #    obj.zeroMask = 1
-    obj.preprocess_filt_hps()
+
+    # TODO: Allow different filters to be applied images independently
+    # default to most stringent filtering
+    if 'wallis_fill' in preprocessing_methods:
+        obj.preprocess_filt_wal_nodata_fill()
+    elif 'wallis' in preprocessing_methods:
+        obj.preprocess_filt_wal()
+    else:
+        obj.preprocess_filt_hps()
 #    obj.I1 = np.abs(I1)
 #    obj.I2 = np.abs(I2)
     print("Pre-process Done!!!")
@@ -492,16 +494,25 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         ds=None
 
 
-
     intermediate_nc_file = 'autoRIFT_intermediate.nc'
 
     if os.path.exists(intermediate_nc_file):
         import hyp3_autorift.vend.netcdf_output as no
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = no.netCDF_read_intermediate(intermediate_nc_file)
     else:
+        m_name = os.path.basename(indir_m)
+        s_name = os.path.basename(indir_s)
+
+        preprocessing_methods = ['hps', 'hps']
+        for ii, name in enumerate(m_name, s_name):
+            if name.startswith('L7'):
+                acquisition = datetime.strptime(name.spilt('_')[3], '%Y%m%d')
+                if acquisition >= date(2003, 5, 31):
+                    preprocessing_methods[ii] = 'wallis_fill'
+
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
-            noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info,
+            noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
         )
         if nc_sensor is not None:
             import hyp3_autorift.vend.netcdf_output as no
@@ -810,7 +821,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
 
 
-                    from datetime import datetime, timedelta
 #                    d0 = datetime(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
 #                    d1 = datetime(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
                     d0 = datetime.strptime(master_dt,"%Y%m%dT%H:%M:%S.%f")
@@ -909,7 +919,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    from datetime import datetime, timedelta
                     d0 = datetime.strptime(kwargs['reference_metadata']['properties']['datetime'], '%Y-%m-%dT%H:%M:%S.%fZ')
                     d1 = datetime.strptime(kwargs['secondary_metadata']['properties']['datetime'], '%Y-%m-%dT%H:%M:%S.%fZ')
                     date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
@@ -965,6 +974,106 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         parameter_file=kwargs['parameter_file'],
                     )
 
+                elif nc_sensor == "L7":
+                    if geogrid_run_info is None:
+                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
+                        gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])
+                        XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
+                        YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
+                        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                    else:
+                        chipsizex0 = geogrid_run_info['chipsizex0']
+                        gridspacingx = geogrid_run_info['gridspacingx']
+                        XPixelSize = geogrid_run_info['XPixelSize']
+                        YPixelSize = geogrid_run_info['YPixelSize']
+                        epsg = geogrid_run_info['epsg']
+
+                    master_path = indir_m
+                    slave_path = indir_s
+
+                    master_filename = os.path.basename(master_path)
+                    slave_filename = os.path.basename(slave_path)
+
+                    master_split = str.split(master_filename,'_')
+                    slave_split = str.split(slave_filename,'_')
+
+#                    master_MTL_path = master_path[:-6]+'MTL.txt'
+#                    slave_MTL_path = slave_path[:-6]+'MTL.txt'
+#
+#                    master_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+master_MTL_path))[2][1:-2],':')
+#                    slave_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+slave_MTL_path))[2][1:-2],':')
+
+                    import netcdf_output as no
+                    pair_type = 'optical'
+                    detection_method = 'feature'
+                    coordinates = 'map'
+                    if np.sum(SEARCHLIMITX!=0)!=0:
+                        roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
+                    else:
+                        raise Exception('Input search range is all zero everywhere, thus no search conducted')
+    #                out_nc_filename = 'Jakobshavn_opt.nc'
+                    PPP = roi_valid_percentage * 100
+                    if ncname is None:
+                        out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
+                                          f"_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    else:
+                        out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
+
+                    d0 = datetime(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
+                    d1 = datetime(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
+                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
+                    date_dt = np.float64(date_dt_base)
+                    if date_dt < 0:
+                        raise Exception('Input image 1 must be older than input image 2')
+
+                    date_ct = d0 + (d1 - d0)/2
+                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    master_dt = d0.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+                    slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    IMG_INFO_DICT = {
+                        'acquisition_date_img1': master_dt,
+                        'acquisition_date_img2': slave_dt,
+                        'collection_category_img1': master_split[6],
+                        'collection_category_img2': slave_split[6],
+                        'collection_number_img1': np.float64(master_split[5]),
+                        'collection_number_img2': np.float64(slave_split[5]),
+                        'correction_level_img1': master_split[1],
+                        'correction_level_img2': slave_split[1],
+                        'mission_img1': master_split[0][0],
+                        'mission_img2': slave_split[0][0],
+                        'path_img1': np.float64(master_split[2][0:3]),
+                        'path_img2': np.float64(slave_split[2][0:3]),
+                        'processing_date_img1': master_split[4][0:8],
+                        'processing_date_img2': slave_split[4][0:8],
+                        'row_img1': np.float64(master_split[2][3:6]),
+                        'row_img2': np.float64(slave_split[2][3:6]),
+                        'satellite_img1': np.float64(master_split[0][2:4]),
+                        'satellite_img2': np.float64(slave_split[0][2:4]),
+                        'sensor_img1': master_split[0][1],
+                        'sensor_img2': slave_split[0][1],
+                        'time_standard_img1': 'UTC',
+                        'time_standard_img2': 'UTC',
+                        'date_center': date_center,
+                        'date_dt': date_dt,
+                        'latitude': cen_lat,
+                        'longitude': cen_lon,
+                        'roi_valid_percentage': PPP,
+                        'autoRIFT_software_version': version
+                    }
+
+                    error_vector = np.array([25.5,25.5])
+
+                    netcdf_file = no.netCDF_packaging(
+                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, MM, VXref, VYref,
+                        None, None, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
+                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
+                    )
+
                 elif nc_sensor == "S2":
                     if geogrid_run_info is None:
                         chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
@@ -1005,7 +1114,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    from datetime import datetime, timedelta
                     d0 = datetime.strptime(kwargs['reference_metadata']['properties']['datetime'], '%Y-%m-%dT%H:%M:%SZ')
                     d1 = datetime.strptime(kwargs['secondary_metadata']['properties']['datetime'], '%Y-%m-%dT%H:%M:%SZ')
                     date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -189,19 +189,18 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.xGrid = xGrid
         obj.yGrid = yGrid
 
-    # FIXME: This assumes the zero values in the image are only outside the valid image "frame",
+    # NOTE: This assumes the zero values in the image are only outside the valid image "frame",
     #        but is not true for Landsat-7 after the failure of the Scan Line Corrector, May 31, 2003.
-    #        We should not masked based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
-    #        and prevents autoRIFT from looking at large parts of the images.
+    #        We should not mask based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
+    #        and prevents autoRIFT from looking at large parts of the images, but untangling the logic here
+    #        has proved too difficult, so lets just turn it off if `wallis_fill` preprocessing is going to be used.
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
-    # for ii in range(obj.xGrid.shape[0]):
-    #     for jj in range(obj.xGrid.shape[1]):
-    #         if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
-    #             if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
-    #                 noDataMask[ii,jj] = True
-
-
-
+    if 'wallis_fill' not in preprocessing_methods:
+        for ii in range(obj.xGrid.shape[0]):
+            for jj in range(obj.xGrid.shape[1]):
+                if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
+                    if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
+                        noDataMask[ii,jj] = True
 
     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
 

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -189,8 +189,10 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.xGrid = xGrid
         obj.yGrid = yGrid
 
-
-
+    # FIXME: This assumes the zero values in the image are only outside the valid image "frame",
+    #        but is not true for Landsat-7 after the failure of the Scan Line Corrector, May 31, 2003.
+    #        We should not masked based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
+    #        and prevents autoRIFT from looking at large parts of the images.
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
     # for ii in range(obj.xGrid.shape[0]):
     #     for jj in range(obj.xGrid.shape[1]):

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -27,8 +27,9 @@
 #
 # Author: Yang Lei
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
 from osgeo import gdal
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 
 def runCmd(cmd):
@@ -505,10 +506,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
-            if name.startswith('L7'):
-                acquisition = datetime.strptime(name.spilt('_')[3], '%Y%m%d')
-                if acquisition >= date(2003, 5, 31):
+            if len(re.findall("L[EO]07_", name)) > 0:
+                acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
+                if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
+
+        print(f'Using preprocessing methods {preprocessing_methods}')
 
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
@@ -555,15 +558,18 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     # sio.savemat('offset.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX})
 
 #    #####################  Uncomment for debug mode
-#    sio.savemat('debug.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX,'ScaleChipSizeY':ScaleChipSizeY,'SearchLimitX':SEARCHLIMITX,'SearchLimitY':SEARCHLIMITY})
+#    sio.savemat('debug.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX,'GridSpacingX':GridSpacingX,'ScaleChipSizeY':ScaleChipSizeY,'SearchLimitX':SEARCHLIMITX,'SearchLimitY':SEARCHLIMITY,'origSize':origSize,'noDataMask':noDataMask})
 #    conts = sio.loadmat('debug.mat')
 #    DX = conts['Dx']
 #    DY = conts['Dy']
 #    INTERPMASK = conts['InterpMask']
 #    CHIPSIZEX = conts['ChipSizeX']
+#    GridSpacingX = conts['GridSpacingX']
 #    ScaleChipSizeY = conts['ScaleChipSizeY']
 #    SEARCHLIMITX = conts['SearchLimitX']
 #    SEARCHLIMITY = conts['SearchLimitY']
+#    origSize = (conts['origSize'][0][0],conts['origSize'][0][1])
+#    noDataMask = conts['noDataMask']
 #    #####################
 
     netcdf_file = None

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -192,11 +192,11 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
-    for ii in range(obj.xGrid.shape[0]):
-        for jj in range(obj.xGrid.shape[1]):
-            if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
-                if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
-                    noDataMask[ii,jj] = True
+    # for ii in range(obj.xGrid.shape[0]):
+    #     for jj in range(obj.xGrid.shape[1]):
+    #         if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
+    #             if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
+    #                 noDataMask[ii,jj] = True
 
 
 

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -188,14 +188,16 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.xGrid = xGrid
         obj.yGrid = yGrid
 
-
-
+    # FIXME: This assumes the zero values in the image are only outside the valid image "frame",
+    #        but is not true for Landsat-7 after the failure of the Scan Line Corrector, May 31, 2003.
+    #        We should not masked based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
+    #        and prevents autoRIFT from looking at large parts of the images.
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
-    for ii in range(obj.xGrid.shape[0]):
-        for jj in range(obj.xGrid.shape[1]):
-            if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
-                if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
-                    noDataMask[ii,jj] = True
+    # for ii in range(obj.xGrid.shape[0]):
+    #     for jj in range(obj.xGrid.shape[1]):
+    #         if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
+    #             if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
+    #                 noDataMask[ii,jj] = True
 
 
 

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -504,7 +504,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         s_name = os.path.basename(indir_s)
 
         preprocessing_methods = ['hps', 'hps']
-        for ii, name in enumerate(m_name, s_name):
+        for ii, name in enumerate((m_name, s_name)):
             if name.startswith('L7'):
                 acquisition = datetime.strptime(name.spilt('_')[3], '%Y%m%d')
                 if acquisition >= date(2003, 5, 31):

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -27,8 +27,9 @@
 #
 # Author: Yang Lei
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
 from osgeo import gdal
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 
 def runCmd(cmd):
@@ -488,7 +489,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         ds = gdal.Open(stable_surface_mask)
         band = ds.GetRasterBand(1)
         SSM = band.ReadAsArray()
-#        SSM = SSM * 0
         SSM = SSM.astype('bool')
         band=None
         ds=None
@@ -505,10 +505,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
-            if name.startswith('L7'):
-                acquisition = datetime.strptime(name.spilt('_')[3], '%Y%m%d')
-                if acquisition >= date(2003, 5, 31):
+            if len(re.findall("L[EO]07_", name)) > 0:
+                acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
+                if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
+
+        print(f'Using preprocessing methods {preprocessing_methods}')
 
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
@@ -554,7 +556,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     # import scipy.io as sio
     # sio.savemat('offset.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX})
 
-    #####################  Uncomment for debug mode
+#    #####################  Uncomment for debug mode
 #    sio.savemat('debug.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX,'GridSpacingX':GridSpacingX,'ScaleChipSizeY':ScaleChipSizeY,'SearchLimitX':SEARCHLIMITX,'SearchLimitY':SEARCHLIMITY,'origSize':origSize,'noDataMask':noDataMask})
 #    conts = sio.loadmat('debug.mat')
 #    DX = conts['Dx']
@@ -567,7 +569,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 #    SEARCHLIMITY = conts['SearchLimitY']
 #    origSize = (conts['origSize'][0][0],conts['origSize'][0][1])
 #    noDataMask = conts['noDataMask']
-    #####################
+#    #####################
 
     netcdf_file = None
     if grid_location is not None:

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -188,19 +188,18 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.xGrid = xGrid
         obj.yGrid = yGrid
 
-    # FIXME: This assumes the zero values in the image are only outside the valid image "frame",
+    # NOTE: This assumes the zero values in the image are only outside the valid image "frame",
     #        but is not true for Landsat-7 after the failure of the Scan Line Corrector, May 31, 2003.
-    #        We should not masked based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
-    #        and prevents autoRIFT from looking at large parts of the images.
+    #        We should not mask based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
+    #        and prevents autoRIFT from looking at large parts of the images, but untangling the logic here
+    #        has proved too difficult, so lets just turn it off if `wallis_fill` preprocessing is going to be used.
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
-    # for ii in range(obj.xGrid.shape[0]):
-    #     for jj in range(obj.xGrid.shape[1]):
-    #         if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
-    #             if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
-    #                 noDataMask[ii,jj] = True
-
-
-
+    if 'wallis_fill' not in preprocessing_methods:
+        for ii in range(obj.xGrid.shape[0]):
+            for jj in range(obj.xGrid.shape[1]):
+                if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
+                    if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
+                        noDataMask[ii,jj] = True
 
     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
 


### PR DESCRIPTION
This brings in the changes to autoRIFT since v1.4.0 that support Landsat-7 processing. Specifically:
* the changes shown in  https://github.com/nasa-jpl/autoRIFT/compare/v1.4.0...master and nasa-jpl/autoRIFT#59, that are reflected in the changed files below. 

Draft because:
- [x] a landsat-7 test pair needs to be identified and run
- [ ] the README in `hyp3_autorift/vend` needs to be updated, and a CHANGES file created for these changes
- [ ] our CHANGELOG needs to be updated
