### PR TITLE
Switch to new USGS STAC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.6]
+
+## [0.8.7]
+
 ### Fixed
-The datetime information can now be correctly extracted from 25-character S2 Earth Search names. Fixes #152.
+* Updated the USGS STAC catalog API endpoint
+
+## [0.8.6]
+
+### Fixed
+* Datetime information can now be correctly extracted from 25-character S2 Earth Search names. Fixes #152
 
 ## [0.8.5]
 
 ### Added
-* The Earth Search STAC catalog is incomplete for Sentinel-2 L1C, with many more scenes in the AWS bucket than the catalog. When a S2 scene cannot be found in the STAC catalog, `hyp3-autorift` will fall back to a bundled S2 metadata catalog derived from an inventory of scenes in the AWS bucket and the Google Earth catalog. 
+* The Earth Search STAC catalog is incomplete for Sentinel-2 L1C, with many more scenes in the AWS bucket than the catalog. When a S2 scene cannot be found in the STAC catalog, `hyp3-autorift` will fall back to a bundled S2 metadata catalog derived from an inventory of scenes in the AWS bucket and the Google Earth catalog
 
 ## [0.8.4]
 

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -34,7 +34,7 @@ gdal.UseExceptions()
 S3_CLIENT = boto3.client('s3')
 S2_SEARCH_URL = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l1c/items'
 S2_WEST_BUCKET = 's2-l1c-us-west-2'
-LC2_SEARCH_URL = 'https://landsatlook.usgs.gov/sat-api/collections/landsat-c2l1/items'
+LC2_SEARCH_URL = 'https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l1/items'
 LANDSAT_BUCKET = 'usgs-landsat'
 
 DEFAULT_PARAMETER_FILE = '/vsicurl/http://its-live-data.s3.amazonaws.com/' \


### PR DESCRIPTION
USGS has changed their STAC API from:
    https://landsatlook.usgs.gov/sat-api
to:
    https://landsatlook.usgs.gov/stac-server

As part of their July 11 update: 
https://www.usgs.gov/landsat-missions/news/stac-metadata-release-includes-improved-geometric-accuracy-standards-records
(I don't see anything indicating *that* specific change was made, annoyingly)