### PR TITLE
Enable dependabot for action version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      labels:
+        - "bumpless"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.4.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.4.0
     with:
       release_prefix: HyP3 autoRIFT
     secrets:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,10 +4,10 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.4.0
     with:
       local_package_names: hyp3_autorift
       excludes: hyp3_autorift/vend
 
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.4.0

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.4.0
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -12,19 +12,19 @@ on:
 
 jobs:
   call-pytest-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.4.0
     with:
       local_package_name: hyp3_autorift
       conda_env_name: hyp3-autorift
 
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.4.0
     with:
       conda_env_name: hyp3-autorift
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.4.0
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
     secrets:


### PR DESCRIPTION
This pins all the actions used and adds dependabot to open PR to keep them up to date.