### PR TITLE
fix landsat 4/5 fft filename bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.9.1]
+
+### Fixed 
+* Changed save path for fft-filtered images so that sensor file naming conventions are preserved
+
 ## [0.9.0]
 
 ### Added

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -201,10 +201,12 @@ def get_s1_primary_polarization(granule_name):
 
 
 def create_fft_filepath(path: str):
-    name, extension = Path(path).name.split('.')
-    out_name = name + '_fft.' + extension
-    out_path = str(Path('.').resolve() / out_name)
-    return out_path
+    parent = (Path.cwd() / 'fft').resolve()
+    if not parent.exists():
+        parent.mkdir()
+
+    out_path = parent / Path(path).name
+    return str(out_path)
 
 
 def apply_fft_filter(array: np.ndarray, nodata: int):

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -202,8 +202,7 @@ def get_s1_primary_polarization(granule_name):
 
 def create_fft_filepath(path: str):
     parent = (Path.cwd() / 'fft').resolve()
-    if not parent.exists():
-        parent.mkdir()
+    parent.mkdir(exist_ok=True)
 
     out_path = parent / Path(path).name
     return str(out_path)


### PR DESCRIPTION
This PR makes a small change to the file path that FFT-filtered images are written to. Instead of writing them to `/working/directory/{BASE_NAME}_fft.tif`, we now write them to `/working/directory/fft/{BASE_NAME}.tif`. This ensures that routines that rely on string indexes of standard Landsat image names work correctly.
<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/hyp3-autorift/compare/main...develop?template=release.md
 
If this PR does not include changes that should be reflected in CHANGELOG.md,
please indicate so by affixing the `bumpless` label to this PR.

NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->