### PR TITLE
use different wallis filter for Sentinel-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.9.1]
-
-### Fixed 
-* Changed save path for fft-filtered images so that sensor file naming conventions are preserved
-
 ## [0.9.0]
 
 ### Added

--- a/hyp3_autorift/vend/CHANGES-WALLIS-WIDTH.diff
+++ b/hyp3_autorift/vend/CHANGES-WALLIS-WIDTH.diff
@@ -1,0 +1,96 @@
+diff --git a/testautoRIFT.py b/testautoRIFT.py
+index ade3d07..3cd09ef 100755
+--- a/testautoRIFT.py
++++ b/testautoRIFT.py
+@@ -127,7 +127,8 @@ def loadProductOptical(file_m, file_s):
+ 
+ 
+ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
+-                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps')):
++                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
++                preprocessing_filter_width=5):
+     '''
+     Wire and run geogrid.
+     '''
+@@ -142,6 +143,9 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+ 
+ 
+     obj = autoRIFT()
++
++    obj.WallisFilterWidth = preprocessing_filter_width
++
+ #    obj.configure()
+ 
+ #    ##########     uncomment if starting from preprocessed images
+@@ -282,6 +286,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     ######## preprocessing
+     t1 = time.time()
+     print("Pre-process Start!!!")
++    print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
+ #    obj.zeroMask = 1
+ 
+     # TODO: Allow different filters to be applied images independently
+@@ -509,6 +514,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+         m_name = os.path.basename(indir_m)
+         s_name = os.path.basename(indir_s)
+ 
++        # FIXME: Filter width is a magic variable here and not exposed well.
++        preprocessing_filter_width = 5
++        for ii, name in enumerate((m_name, s_name)):
++            if len(re.findall("S1[AB]_", name)) > 0:
++                preprocessing_filter_width = 21
++
+         preprocessing_methods = ['hps', 'hps']
+         for ii, name in enumerate((m_name, s_name)):
+             if len(re.findall("L[EO]07_", name)) > 0:
+@@ -521,6 +532,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
+             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
+             noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
++            preprocessing_filter_width=preprocessing_filter_width,
+         )
+         if nc_sensor is not None:
+             import netcdf_output as no
+diff --git a/testautoRIFT_ISCE.py b/testautoRIFT_ISCE.py
+index 7f8ed58..1712bfb 100755
+--- a/testautoRIFT_ISCE.py
++++ b/testautoRIFT_ISCE.py
+@@ -127,7 +127,8 @@ def loadProductOptical(file_m, file_s):
+ 
+ 
+ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
+-                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps')):
++                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
++                preprocessing_filter_width=5):
+     '''
+     Wire and run geogrid.
+     '''
+@@ -281,6 +282,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     ######## preprocessing
+     t1 = time.time()
+     print("Pre-process Start!!!")
++    print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
+ #    obj.zeroMask = 1
+ 
+     # TODO: Allow different filters to be applied images independently
+@@ -508,6 +510,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+         m_name = os.path.basename(indir_m)
+         s_name = os.path.basename(indir_s)
+ 
++        # FIXME: Filter width is a magic variable here and not exposed well.
++        preprocessing_filter_width = 5
++        for ii, name in enumerate((m_name, s_name)):
++            if len(re.findall("S1[AB]_", name)) > 0:
++                preprocessing_filter_width = 21
++
+         preprocessing_methods = ['hps', 'hps']
+         for ii, name in enumerate((m_name, s_name)):
+             if len(re.findall("L[EO]07_", name)) > 0:
+@@ -520,6 +528,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
+             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
+             noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
++            preprocessing_filter_width=preprocessing_filter_width,
+         )
+         if nc_sensor is not None:
+             import netcdf_output as no

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -52,3 +52,6 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
    included in the next autoRIFT release.
 5. The changes listed in `CHANGES-S2-WEST.diff` were applied to allow `testGeogrid_ISCE.py`
    and `testGeogridOptical.py` to process scenes in the `s3://s2-l1c-us-west-2` bucket
+6. The changes listed in `CHANGES-WALLLIS-WIDTH.diff` were applied to select the correct
+   Wallis filter width for Sentinel-1 scenes. These changes should be included in the next
+   autoRIFT release.

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -127,7 +127,8 @@ def loadProductOptical(file_m, file_s):
 
 
 def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
-                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps')):
+                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
+                preprocessing_filter_width=5):
     '''
     Wire and run geogrid.
     '''
@@ -142,6 +143,9 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     obj = autoRIFT()
+
+    obj.WallisFilterWidth = preprocessing_filter_width
+
 #    obj.configure()
 
 #    ##########     uncomment if starting from preprocessed images
@@ -279,6 +283,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     ######## preprocessing
     t1 = time.time()
     print("Pre-process Start!!!")
+    print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
 #    obj.zeroMask = 1
 
     # TODO: Allow different filters to be applied images independently
@@ -516,6 +521,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         m_name = os.path.basename(indir_m)
         s_name = os.path.basename(indir_s)
 
+        # FIXME: Filter width is a magic variable here and not exposed well.
+        preprocessing_filter_width = 5
+        for ii, name in enumerate((m_name, s_name)):
+            if len(re.findall("S1[AB]_", name)) > 0:
+                preprocessing_filter_width = 21
+
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
             if len(re.findall("L[EO]07_", name)) > 0:
@@ -530,6 +541,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
             noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
+            preprocessing_filter_width=preprocessing_filter_width,
         )
         if nc_sensor is not None:
             import hyp3_autorift.vend.netcdf_output as no

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -127,7 +127,8 @@ def loadProductOptical(file_m, file_s):
 
 
 def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
-                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps')):
+                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
+                preprocessing_filter_width=5):
     '''
     Wire and run geogrid.
     '''
@@ -278,6 +279,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     ######## preprocessing
     t1 = time.time()
     print("Pre-process Start!!!")
+    print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
 #    obj.zeroMask = 1
 
     # TODO: Allow different filters to be applied images independently
@@ -515,6 +517,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         m_name = os.path.basename(indir_m)
         s_name = os.path.basename(indir_s)
 
+        # FIXME: Filter width is a magic variable here and not exposed well.
+        preprocessing_filter_width = 5
+        for ii, name in enumerate((m_name, s_name)):
+            if len(re.findall("S1[AB]_", name)) > 0:
+                preprocessing_filter_width = 21
+
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
             if len(re.findall("L[EO]07_", name)) > 0:
@@ -529,6 +537,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
             noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
+            preprocessing_filter_width=preprocessing_filter_width,
         )
         if nc_sensor is not None:
             import hyp3_autorift.vend.netcdf_output as no


### PR DESCRIPTION
When we added L4,5,7 we changed the default filter width to 5, but we want Sentinel-1 to keep the original value. 

Also done upstream: https://github.com/nasa-jpl/autoRIFT/pull/69