### PR TITLE
Apply filter change to ISCE based stript (buxfix; also applied upstream)

### DIFF
--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -146,6 +146,9 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     obj = autoRIFT_ISCE()
+
+    obj.WallisFilterWidth = preprocessing_filter_width
+
     obj.configure()
 
 #    ##########     uncomment if starting from preprocessed images


### PR DESCRIPTION
We applied the filter width change in `testautoRIFT.py` but not in `testautoRIFT_ISCE.py`