### PR TITLE
Update stac from landsat bucket for different missions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 * Added support for processing Landsat-4, Landsat-5, and Landsat-9 Collection 2 scenes
+* `hyp3_autorift.process.get_lc2_stac_json_key` will now work for landsat missions 4-9, for all levels, and for all sensors
 
 ### Fixed 
 * Pinned Python to `<3.10` as ISCE2 is currently [incompatible with Python 3.10](https://github.com/isce-framework/isce2/issues/458).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 * Added support for processing Landsat-4, Landsat-5, and Landsat-9 Collection 2 scenes
-* `hyp3_autorift.process.get_lc2_stac_json_key` will now work for landsat missions 4-9, for all levels, and for all sensors
+* `hyp3_autorift.process.get_lc2_stac_json_key` will now work for landsat missions 4-9 and for all sensors
 
 ### Fixed 
 * Pinned Python to `<3.10` as ISCE2 is currently [incompatible with Python 3.10](https://github.com/isce-framework/isce2/issues/458).

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -38,10 +38,11 @@ S2_WEST_BUCKET = 's2-l1c-us-west-2'
 LC2_SEARCH_URL = 'https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l1/items'
 LANDSAT_BUCKET = 'usgs-landsat'
 LANDSAT_SENSOR_MAPPING = {
-    'L8': {'C': 'oli-tirs'},
+    'L9': {'C': 'oli-tirs', 'O': 'oli-tirs', 'T': 'oli-tirs'},
+    'L8': {'C': 'oli-tirs', 'O': 'oli-tirs', 'T': 'oli-tirs'},
     'L7': {'E': 'etm'},
-    'L5': {'T': 'tm'},
-    'L4': {'T': 'tm'},
+    'L5': {'T': 'tm', 'M': 'mss'},
+    'L4': {'T': 'tm', 'M': 'mss'},
 }
 
 DEFAULT_PARAMETER_FILE = '/vsicurl/http://its-live-data.s3.amazonaws.com/' \
@@ -50,13 +51,14 @@ DEFAULT_PARAMETER_FILE = '/vsicurl/http://its-live-data.s3.amazonaws.com/' \
 
 def get_lc2_stac_json_key(scene_name: str) -> str:
     platform = get_platform(scene_name)
+    level = scene_name[6]
     year = scene_name[17:21]
     path = scene_name[10:13]
     row = scene_name[13:16]
 
     sensor = LANDSAT_SENSOR_MAPPING[platform][scene_name[1]]
 
-    return f'collection02/level-1/standard/{sensor}/{year}/{path}/{row}/{scene_name}/{scene_name}_stac.json'
+    return f'collection02/level-{level}/standard/{sensor}/{year}/{path}/{row}/{scene_name}/{scene_name}_stac.json'
 
 
 def get_lc2_metadata(scene_name):

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -34,18 +34,29 @@ gdal.UseExceptions()
 S3_CLIENT = boto3.client('s3')
 S2_SEARCH_URL = 'https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l1c/items'
 S2_WEST_BUCKET = 's2-l1c-us-west-2'
+
 LC2_SEARCH_URL = 'https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l1/items'
 LANDSAT_BUCKET = 'usgs-landsat'
+LANDSAT_SENSOR_MAPPING = {
+    'L8': {'C': 'oli-tirs'},
+    'L7': {'E': 'etm'},
+    'L5': {'T': 'tm'},
+    'L4': {'T': 'tm'},
+}
 
 DEFAULT_PARAMETER_FILE = '/vsicurl/http://its-live-data.s3.amazonaws.com/' \
                          'autorift_parameters/v001/autorift_landice_0120m.shp'
 
 
-def get_lc2_stac_json_key(scene_name):
+def get_lc2_stac_json_key(scene_name: str) -> str:
+    platform = get_platform(scene_name)
     year = scene_name[17:21]
     path = scene_name[10:13]
     row = scene_name[13:16]
-    return f'collection02/level-1/standard/oli-tirs/{year}/{path}/{row}/{scene_name}/{scene_name}_stac.json'
+
+    sensor = LANDSAT_SENSOR_MAPPING[platform][scene_name[1]]
+
+    return f'collection02/level-1/standard/{sensor}/{year}/{path}/{row}/{scene_name}/{scene_name}_stac.json'
 
 
 def get_lc2_metadata(scene_name):

--- a/hyp3_autorift/process.py
+++ b/hyp3_autorift/process.py
@@ -51,14 +51,13 @@ DEFAULT_PARAMETER_FILE = '/vsicurl/http://its-live-data.s3.amazonaws.com/' \
 
 def get_lc2_stac_json_key(scene_name: str) -> str:
     platform = get_platform(scene_name)
-    level = scene_name[6]
     year = scene_name[17:21]
     path = scene_name[10:13]
     row = scene_name[13:16]
 
     sensor = LANDSAT_SENSOR_MAPPING[platform][scene_name[1]]
 
-    return f'collection02/level-{level}/standard/{sensor}/{year}/{path}/{row}/{scene_name}/{scene_name}_stac.json'
+    return f'collection02/level-1/standard/{sensor}/{year}/{path}/{row}/{scene_name}/{scene_name}_stac.json'
 
 
 def get_lc2_metadata(scene_name):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -36,21 +36,49 @@ def test_get_platform():
 
 
 def test_get_lc2_stac_json_key():
-    expected = 'collection02/level-1/standard/oli-tirs/2019/041/001/LC08_L1TP_041001_20191005_20200825_02_T1/' \
-               'LC08_L1TP_041001_20191005_20200825_02_T1_stac.json'
-    assert process.get_lc2_stac_json_key('LC08_L1TP_041001_20191005_20200825_02_T1') == expected
+    expected = 'collection02/level-1/standard/oli-tirs/2021/122/028/LC09_L1GT_122028_20211107_20220119_02_T2/' \
+               'LC09_L1GT_122028_20211107_20220119_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LC09_L1GT_122028_20211107_20220119_02_T2') == expected
 
-    expected = 'collection02/level-1/standard/oli-tirs/2020/226/012/LO08_L1TP_226012_20201108_20201120_02_T2/' \
-               'LO08_L1TP_226012_20201108_20201120_02_T2_stac.json'
-    assert process.get_lc2_stac_json_key('LO08_L1TP_226012_20201108_20201120_02_T2') == expected
+    expected = 'collection02/level-1/standard/oli-tirs/2022/060/002/LO09_L1TP_060002_20220316_20220316_02_T1/' \
+               'LO09_L1TP_060002_20220316_20220316_02_T1_stac.json'
+    assert process.get_lc2_stac_json_key('LO09_L1TP_060002_20220316_20220316_02_T1') == expected
 
-    expected = 'collection02/level-1/standard/etm/2001/063/017/LE07_L1TP_063017_20011208_20200917_02_T2/' \
-               'LE07_L1TP_063017_20011208_20200917_02_T2_stac.json'
-    assert process.get_lc2_stac_json_key('LE07_L1TP_063017_20011208_20200917_02_T2') == expected
+    expected = 'collection02/level-1/standard/oli-tirs/2022/137/206/LT09_L1GT_137206_20220107_20220123_02_T2/' \
+               'LT09_L1GT_137206_20220107_20220123_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LT09_L1GT_137206_20220107_20220123_02_T2') == expected
 
-    expected = 'collection02/level-1/standard/tm/1986/060/018/LT05_L1TP_060018_19860116_20200918_02_T2/' \
-               'LT05_L1TP_060018_19860116_20200918_02_T2_stac.json'
-    assert process.get_lc2_stac_json_key('LT05_L1TP_060018_19860116_20200918_02_T2') == expected
+    expected = 'collection02/level-2/standard/oli-tirs/2022/028/042/LC08_L2SP_028042_20220831_20220910_02_T1/' \
+               'LC08_L2SP_028042_20220831_20220910_02_T1_stac.json'
+    assert process.get_lc2_stac_json_key('LC08_L2SP_028042_20220831_20220910_02_T1') == expected
+
+    expected = 'collection02/level-1/standard/oli-tirs/2019/157/021/LO08_L1GT_157021_20191221_20200924_02_T2/' \
+               'LO08_L1GT_157021_20191221_20200924_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LO08_L1GT_157021_20191221_20200924_02_T2') == expected
+
+    expected = 'collection02/level-1/standard/oli-tirs/2014/141/212/LT08_L1GT_141212_20140902_20200925_02_T2/' \
+               'LT08_L1GT_141212_20140902_20200925_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LT08_L1GT_141212_20140902_20200925_02_T2') == expected
+
+    expected = 'collection02/level-1/standard/etm/2006/024/035/LE07_L1TP_024035_20061119_20200913_02_T1/' \
+               'LE07_L1TP_024035_20061119_20200913_02_T1_stac.json'
+    assert process.get_lc2_stac_json_key('LE07_L1TP_024035_20061119_20200913_02_T1') == expected
+
+    expected = 'collection02/level-2/standard/tm/1987/224/075/LT05_L2SP_224075_19871031_20201014_02_T1/' \
+               'LT05_L2SP_224075_19871031_20201014_02_T1_stac.json'
+    assert process.get_lc2_stac_json_key('LT05_L2SP_224075_19871031_20201014_02_T1') == expected
+
+    expected = 'collection02/level-1/standard/mss/1995/098/068/LM05_L1GS_098068_19950831_20200823_02_T2/' \
+               'LM05_L1GS_098068_19950831_20200823_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LM05_L1GS_098068_19950831_20200823_02_T2') == expected
+
+    expected = 'collection02/level-1/standard/tm/1988/183/062/LT04_L1TP_183062_19880706_20200917_02_T1/' \
+               'LT04_L1TP_183062_19880706_20200917_02_T1_stac.json'
+    assert process.get_lc2_stac_json_key('LT04_L1TP_183062_19880706_20200917_02_T1') == expected
+
+    expected = 'collection02/level-1/standard/mss/1983/117/071/LM04_L1GS_117071_19830609_20200903_02_T2/' \
+               'LM04_L1GS_117071_19830609_20200903_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LM04_L1GS_117071_19830609_20200903_02_T2') == expected
 
 
 @responses.activate

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -48,7 +48,7 @@ def test_get_lc2_stac_json_key():
                'LT09_L1GT_137206_20220107_20220123_02_T2_stac.json'
     assert process.get_lc2_stac_json_key('LT09_L1GT_137206_20220107_20220123_02_T2') == expected
 
-    expected = 'collection02/level-2/standard/oli-tirs/2022/028/042/LC08_L2SP_028042_20220831_20220910_02_T1/' \
+    expected = 'collection02/level-1/standard/oli-tirs/2022/028/042/LC08_L2SP_028042_20220831_20220910_02_T1/' \
                'LC08_L2SP_028042_20220831_20220910_02_T1_stac.json'
     assert process.get_lc2_stac_json_key('LC08_L2SP_028042_20220831_20220910_02_T1') == expected
 
@@ -56,17 +56,17 @@ def test_get_lc2_stac_json_key():
                'LO08_L1GT_157021_20191221_20200924_02_T2_stac.json'
     assert process.get_lc2_stac_json_key('LO08_L1GT_157021_20191221_20200924_02_T2') == expected
 
-    expected = 'collection02/level-1/standard/oli-tirs/2014/141/212/LT08_L1GT_141212_20140902_20200925_02_T2/' \
-               'LT08_L1GT_141212_20140902_20200925_02_T2_stac.json'
-    assert process.get_lc2_stac_json_key('LT08_L1GT_141212_20140902_20200925_02_T2') == expected
+    expected = 'collection02/level-1/standard/oli-tirs/2015/138/206/LT08_L1GT_138206_20150628_20200925_02_T2/' \
+               'LT08_L1GT_138206_20150628_20200925_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LT08_L1GT_138206_20150628_20200925_02_T2') == expected
 
     expected = 'collection02/level-1/standard/etm/2006/024/035/LE07_L1TP_024035_20061119_20200913_02_T1/' \
                'LE07_L1TP_024035_20061119_20200913_02_T1_stac.json'
     assert process.get_lc2_stac_json_key('LE07_L1TP_024035_20061119_20200913_02_T1') == expected
 
-    expected = 'collection02/level-2/standard/tm/1987/224/075/LT05_L2SP_224075_19871031_20201014_02_T1/' \
-               'LT05_L2SP_224075_19871031_20201014_02_T1_stac.json'
-    assert process.get_lc2_stac_json_key('LT05_L2SP_224075_19871031_20201014_02_T1') == expected
+    expected = 'collection02/level-1/standard/tm/1995/124/064/LT05_L1TP_124064_19950211_20200912_02_T1/' \
+               'LT05_L1TP_124064_19950211_20200912_02_T1_stac.json'
+    assert process.get_lc2_stac_json_key('LT05_L1TP_124064_19950211_20200912_02_T1') == expected
 
     expected = 'collection02/level-1/standard/mss/1995/098/068/LM05_L1GS_098068_19950831_20200823_02_T2/' \
                'LM05_L1GS_098068_19950831_20200823_02_T2_stac.json'

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -48,9 +48,9 @@ def test_get_lc2_stac_json_key():
                'LT09_L1GT_137206_20220107_20220123_02_T2_stac.json'
     assert process.get_lc2_stac_json_key('LT09_L1GT_137206_20220107_20220123_02_T2') == expected
 
-    expected = 'collection02/level-1/standard/oli-tirs/2022/028/042/LC08_L2SP_028042_20220831_20220910_02_T1/' \
-               'LC08_L2SP_028042_20220831_20220910_02_T1_stac.json'
-    assert process.get_lc2_stac_json_key('LC08_L2SP_028042_20220831_20220910_02_T1') == expected
+    expected = 'collection02/level-1/standard/oli-tirs/2016/138/039/LC08_L1TP_138039_20161105_20200905_02_T1/' \
+               'LC08_L1TP_138039_20161105_20200905_02_T1_stac.json'
+    assert process.get_lc2_stac_json_key('LC08_L1TP_138039_20161105_20200905_02_T1') == expected
 
     expected = 'collection02/level-1/standard/oli-tirs/2019/157/021/LO08_L1GT_157021_20191221_20200924_02_T2/' \
                'LO08_L1GT_157021_20191221_20200924_02_T2_stac.json'

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -53,7 +53,6 @@ def test_get_lc2_stac_json_key():
     assert process.get_lc2_stac_json_key('LT05_L1TP_060018_19860116_20200918_02_T2') == expected
 
 
-
 @responses.activate
 def test_get_lc2_metadata():
     responses.add(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -44,6 +44,15 @@ def test_get_lc2_stac_json_key():
                'LO08_L1TP_226012_20201108_20201120_02_T2_stac.json'
     assert process.get_lc2_stac_json_key('LO08_L1TP_226012_20201108_20201120_02_T2') == expected
 
+    expected = 'collection02/level-1/standard/etm/2001/063/017/LE07_L1TP_063017_20011208_20200917_02_T2/' \
+               'LE07_L1TP_063017_20011208_20200917_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LE07_L1TP_063017_20011208_20200917_02_T2') == expected
+
+    expected = 'collection02/level-1/standard/tm/1986/060/018/LT05_L1TP_060018_19860116_20200918_02_T2/' \
+               'LT05_L1TP_060018_19860116_20200918_02_T2_stac.json'
+    assert process.get_lc2_stac_json_key('LT05_L1TP_060018_19860116_20200918_02_T2') == expected
+
+
 
 @responses.activate
 def test_get_lc2_metadata():


### PR DESCRIPTION
When looking up a scene's metadata, if the STAC catalog did not have an item for a scene, we'd fall back to looking for a STAC item JSON in the AWS S3 bucket. This, however, doesn't work for legacy missions (L4,5,7) as the bucket is organized by sensor and we hard-coded the L8,9 sensor.

Example scene: LE07_L1GT_063018_20170915_20200830_02_T2

This add the sensor mapping and dynamic sensor value in S3 path.

<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/hyp3-autorift/compare/main...develop?template=release.md
 
If this PR does not include changes that should be reflected in CHANGELOG.md,
please indicate so by affixing the `bumpless` label to this PR.

NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->