### PR TITLE
Fix dtype error in netcdf packaging for landsat

### DIFF
--- a/hyp3_autorift/vend/CHANGES-176.diff
+++ b/hyp3_autorift/vend/CHANGES-176.diff
@@ -1,6 +1,15 @@
 diff -u netcdf_output.py netcdf_output.py
 --- netcdf_output.py
 +++ netcdf_output.py
+@@ -339,7 +339,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+     if IMG_INFO_DICT['mission_img1'].startswith('S'):
+         source += f'. Contains modified Copernicus Sentinel data {IMG_INFO_DICT["date_center"][0:4]}, processed by ESA'
+     if IMG_INFO_DICT['mission_img1'].startswith('L'):
+-        source += f'. Landsat-{IMG_INFO_DICT["satellite_img1"]:.0f} images courtesy of the U.S. Geological Survey'
++        source += f'. Landsat-{IMG_INFO_DICT["satellite_img1"]} images courtesy of the U.S. Geological Survey'
+ 
+     references = 'When using this data, please acknowledge the source (see global source attribute) and cite:\n' \
+                  '* Gardner, A. S., Moholdt, G., Scambos, T., Fahnestock, M., Ligtenberg, S., van den Broeke, M.,\n' \
 @@ -517,7 +517,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
      elif stable_shift_applied == 1:
          var.setncattr('stable_shift', int(round(vx_mean_shift*10))/10)

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -29,7 +29,7 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
 ## Additional Patches
 
 1. The changes listed in `CHANGES-176.diff` were applied in [ASFHyP3/hyp3-autorift#176](https://github.com/ASFHyP3/hyp3-autorift/pull/176)
-   to:
+   and [ASFHyP3/hyp3-autorift#180](https://github.com/ASFHyP3/hyp3-autorift/pull/180) to:
    * Ensure Landsat `satellite_img1` and `satellite_img2` netCDF attributes were string like `'4'` to match the
      convention of other missions
    * Set the fallback value of `stable_shift` netCDF attribute to `0` instead `np.nan`

--- a/hyp3_autorift/vend/netcdf_output.py
+++ b/hyp3_autorift/vend/netcdf_output.py
@@ -339,7 +339,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     if IMG_INFO_DICT['mission_img1'].startswith('S'):
         source += f'. Contains modified Copernicus Sentinel data {IMG_INFO_DICT["date_center"][0:4]}, processed by ESA'
     if IMG_INFO_DICT['mission_img1'].startswith('L'):
-        source += f'. Landsat-{IMG_INFO_DICT["satellite_img1"]:.0f} images courtesy of the U.S. Geological Survey'
+        source += f'. Landsat-{IMG_INFO_DICT["satellite_img1"]} images courtesy of the U.S. Geological Survey'
 
     references = 'When using this data, please acknowledge the source (see global source attribute) and cite:\n' \
                  '* Gardner, A. S., Moholdt, G., Scambos, T., Fahnestock, M., Ligtenberg, S., van den Broeke, M.,\n' \


### PR DESCRIPTION
The landsat golden tests failed due to the type change for `satallite_img1` in #176 which gets formatted like a number here (woops). This removes the formatting and a L5 pair does run through fully on my laptop with this change.