### PR TITLE
Metadata fix: comma- to space-seperated list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.10.2]
+
+### Changed
+* Patch [196](hyp3_autorift/vend/CHANGES-189.diff) was applied to update the `flag_meanings` netCDF attribute to be
+  inline with CF-Convention 1.8, as described in the [vendored software README.md](hyp3_autorift/vend/README.md)
+
 ## [0.10.1]
 
 ### Changed

--- a/hyp3_autorift/vend/CHANGES-196.diff
+++ b/hyp3_autorift/vend/CHANGES-196.diff
@@ -1,0 +1,12 @@
+diff --git netcdf_output.py netcdf_output.py
+--- netcdf_output.py
++++ netcdf_output.py
+@@ -1211,7 +1211,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+     var.setncattr('standard_name', 'interpolated_value_mask')
+     var.setncattr('description', 'true where values have been interpolated')
+     var.setncattr('flag_values', [np.uint8(0), np.uint8(1)])
+-    var.setncattr('flag_meanings', 'measured, interpolated')
++    var.setncattr('flag_meanings', 'measured interpolated')
+     var.setncattr('grid_mapping', mapping_var_name)
+ 
+     # var[:] = np.flipud(vx_nomask).astype('float32')

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -38,10 +38,11 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
 2. The changes listed in `CHANGES-183.diff` were applied in [ASFHyP3/hyp3-autorift#183](https://github.com/ASFHyP3/hyp3-autorift/pull/183)
    to correctly set the netcdf `img_pair_info:correction_level_img` attribute values for Sentinel-2 scenes after the transition from
    Earth Search COG IDs to ESA IDs.
-3. The changes listed in `CHANGES-189.diff`,  `CHANGES-191.diff` and `CHANGES-194.diff` were applied in
+3. The changes listed in `CHANGES-189.diff`,  `CHANGES-191.diff`, `CHANGES-194.diff`, and  `CHANGES-194.diff` were applied in
    [ASFHyP3/hyp3-autorift#189](https://github.com/ASFHyP3/hyp3-autorift/pull/189),
    [ASFHyP3/hyp3-autorift#191](https://github.com/ASFHyP3/hyp3-autorift/pull/191), 
-   and [ASFHyP3/hyp3-autorift#194](https://github.com/ASFHyP3/hyp3-autorift/pull/194)  
+   [ASFHyP3/hyp3-autorift#194](https://github.com/ASFHyP3/hyp3-autorift/pull/194),
+   and [ASFHyP3/hyp3-autorift#196](https://github.com/ASFHyP3/hyp3-autorift/pull/196),
    after an extensive metadata review to prepare netCDF output for ingest to NSIDC DAAC. These changes have been
    [proposed upstream](https://github.com/nasa-jpl/autoRIFT/pull/74) and should be applied in the next
    `nasa-jpl/autoRIFT` release.

--- a/hyp3_autorift/vend/netcdf_output.py
+++ b/hyp3_autorift/vend/netcdf_output.py
@@ -1211,7 +1211,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     var.setncattr('standard_name', 'interpolated_value_mask')
     var.setncattr('description', 'true where values have been interpolated')
     var.setncattr('flag_values', [np.uint8(0), np.uint8(1)])
-    var.setncattr('flag_meanings', 'measured, interpolated')
+    var.setncattr('flag_meanings', 'measured interpolated')
     var.setncattr('grid_mapping', mapping_var_name)
 
     # var[:] = np.flipud(vx_nomask).astype('float32')


### PR DESCRIPTION
According to CF-Conventions, the `flag_meanings` attribute should be space separated even though the values should be comma separated for "reasons":
https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags

While the conventions also says
>  If the string contains any commas, it is assumed to be a comma-separated list.

https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#identification-of-conventions

we should still fix this as tools expect the data to come as a space-separated list.

Pointed out upstream here: https://github.com/nasa-jpl/autoRIFT/pull/74#pullrequestreview-1201516515