### PR TITLE
Document vendored changes; sync testautoRIFT* scripts

### DIFF
--- a/hyp3_autorift/vend/CHANGES-173.diff
+++ b/hyp3_autorift/vend/CHANGES-173.diff
@@ -1,0 +1,222 @@
+diff -u testautoRIFT.py testautoRIFT.py
+--- testautoRIFT.py
++++ testautoRIFT.py
+@@ -132,7 +132,7 @@ def loadProductOptical(file_m, file_s):
+ 
+ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
+                 nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
+-                preprocessing_filter_width=5):
++                preprocessing_filter_width=5, zero_mask=None):
+     '''
+     Wire and run geogrid.
+     '''
+@@ -152,10 +152,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     obj.WallisFilterWidth = preprocessing_filter_width
+     print(f'Setting Wallis Filter Width to {preprocessing_filter_width}')
+ 
+-#    ##########     uncomment if starting from preprocessed images
+-#    I1 = I1.astype(np.uint8)
+-#    I2 = I2.astype(np.uint8)
+-
+     obj.MultiThread = mpflag
+ 
+     # take the amplitude only for the radar images
+@@ -287,33 +283,44 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     t1 = time.time()
+     print("Pre-process Start!!!")
+     print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
+-#    obj.zeroMask = 1
++    # obj.zeroMask = 1
+ 
+-    # TODO: Allow different filters to be applied images independently
+-    # default to most stringent filtering
++    # TODO: Allow different filters to be applied images independently; default to most stringent filtering
+     if 'wallis_fill' in preprocessing_methods:
+-        obj.preprocess_filt_wal_nodata_fill()
++        # FIXME: Ensuring landsat 7 images are projected correctly requires wallis_fill filtering and then reprojecting the
++        #        secondary scene before processing with Geogrid or autoRIFT; this now occurs in hyp3-autorift/process.py
++        warnings.warn('Wallis filtering must be done before processing with geogrid! Be careful when using this method',
++                      UserWarning)
++        obj.zeroMask = zero_mask
++        # obj.preprocess_filt_wal_nodata_fill()
+     elif 'wallis' in preprocessing_methods:
+-        obj.preprocess_filt_wal()
++        # FIXME: Ensuring landsat 7 images are projected correctly requires wallis filtering and then reprojecting the
++        #       secondary scene before processing with Geogrid or autoRIFT; this now occurs in hyp3-autorift/process.py
++        warnings.warn('Wallis filtering must be done before processing with geogrid! Be careful when using this method',
++                      UserWarning)
++        obj.zeroMask = zero_mask
++        # obj.preprocess_filt_wal()
+     elif 'fft' in preprocessing_methods:
+-        # FIXME: The Landsat 4/5 FFT preprocessor looks for the image corners to
+-        #        determine the scene rotation, but Geogrid + autoRIFT rond the
+-        #        corners when co-registering and chop the non-overlapping corners
+-        #        when subsetting to the common image overlap. FFT filer needs to
+-        #        be applied to the native images before they are processed by
+-        #        Geogrid or autoRIFT.
++        # FIXME: Ensuring landsat 7 images are projected correctly requires fft filtering and then reprojecting the
++        #        secondary scene before processing with Geogrid or autoRIFT. Furthermore, the Landsat 4/5 FFT
++        #        preprocessor looks for the image corners to determine the scene rotation, but Geogrid + autoRIFT round
++        #        corners when co-registering and chop the non-overlapping corners when subsetting to the common image
++        #        overlap. FFT filer needs to  be applied to the native images before they are processed by Geogrid or
++        #        autoRIFT; this now occurs in hyp3-autorift/process.py
+         # obj.preprocess_filt_wal()
+         # obj.preprocess_filt_fft()
+-        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method', UserWarning)
++        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method',
++                      UserWarning)
+     else:
+         obj.preprocess_filt_hps()
+-#    obj.I1 = np.abs(I1)
+-#    obj.I2 = np.abs(I2)
++
++    # obj.I1 = np.abs(I1)
++    # obj.I2 = np.abs(I2)
+     print("Pre-process Done!!!")
+     print(time.time()-t1)
+ 
+     t1 = time.time()
+-#    obj.DataType = 0
++    # obj.DataType = 0
+     obj.uniform_data_type()
+     print("Uniform Data Type Done!!!")
+     print(time.time()-t1)
+@@ -539,6 +546,17 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+                     preprocessing_methods[ii] = 'wallis_fill'
+             elif len(re.findall("LT0[45]_", name)) > 0:
+                 preprocessing_methods[ii] = 'fft'
++        
++        zero_mask = None
++        indir_m_zero = f'{indir_m.split(".")[0]}_zeroMask.{indir_m.split(".")[1]}'
++        indir_s_zero = f'{indir_s.split(".")[0]}_zeroMask.{indir_s.split(".")[1]}'
++        if os.path.exists(indir_m_zero) or os.path.exists(indir_s_zero):
++            m_zero, s_zero = loadProductOptical(indir_m_zero, indir_s_zero)
++            m_zero = m_zero.astype(np.uint8)
++            s_zero = s_zero.astype(np.uint8)
++
++            # FIXME: AND? Wallis uses "or" here, while wallis_fill uses "and" here.
++            zero_mask = m_zero & s_zero
+ 
+         print(f'Using preprocessing methods {preprocessing_methods}')
+ 
+@@ -547,7 +565,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+                 data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
+                 noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info,
+                 preprocessing_methods=preprocessing_methods, preprocessing_filter_width=preprocessing_filter_width,
+-        )
++                zero_mask=zero_mask
++            )
+         if nc_sensor is not None:
+             import hyp3_autorift.vend.netcdf_output as no
+             no.netCDF_packaging_intermediate(Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask, intermediate_nc_file)
+diff -u testautoRIFT_ISCE.py testautoRIFT_ISCE.py
+--- testautoRIFT_ISCE.py
++++ testautoRIFT_ISCE.py
+@@ -132,7 +132,7 @@ def loadProductOptical(file_m, file_s):
+ 
+ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
+                 nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
+-                preprocessing_filter_width=5):
++                preprocessing_filter_width=5, zero_mask=None):
+     '''
+     Wire and run geogrid.
+     '''
+@@ -151,10 +151,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     obj.WallisFilterWidth = preprocessing_filter_width
+     print(f'Setting Wallis Filter Width to {preprocessing_filter_width}')
+ 
+-#    ##########     uncomment if starting from preprocessed images
+-#    I1 = I1.astype(np.uint8)
+-#    I2 = I2.astype(np.uint8)
+-
+     obj.MultiThread = mpflag
+ 
+     # take the amplitude only for the radar images
+@@ -286,33 +282,44 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     t1 = time.time()
+     print("Pre-process Start!!!")
+     print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
+-#    obj.zeroMask = 1
++    # obj.zeroMask = 1
+ 
+-    # TODO: Allow different filters to be applied images independently
+-    # default to most stringent filtering
++    # TODO: Allow different filters to be applied images independently; default to most stringent filtering
+     if 'wallis_fill' in preprocessing_methods:
+-        obj.preprocess_filt_wal_nodata_fill()
++        # FIXME: Ensuring landsat 7 images are projected correctly requires wallis_fill filtering and then reprojecting the
++        #        secondary scene before processing with Geogrid or autoRIFT; this now occurs in hyp3-autorift/process.py
++        warnings.warn('Wallis filtering must be done before processing with geogrid! Be careful when using this method',
++                      UserWarning)
++        obj.zeroMask = zero_mask
++        # obj.preprocess_filt_wal_nodata_fill()
+     elif 'wallis' in preprocessing_methods:
+-        obj.preprocess_filt_wal()
++        # FIXME: Ensuring landsat 7 images are projected correctly requires wallis filtering and then reprojecting the
++        #       secondary scene before processing with Geogrid or autoRIFT; this now occurs in hyp3-autorift/process.py
++        warnings.warn('Wallis filtering must be done before processing with geogrid! Be careful when using this method',
++                      UserWarning)
++        obj.zeroMask = zero_mask
++        # obj.preprocess_filt_wal()
+     elif 'fft' in preprocessing_methods:
+-        # FIXME: The Landsat 4/5 FFT preprocessor looks for the image corners to
+-        #        determine the scene rotation, but Geogrid + autoRIFT rond the
+-        #        corners when co-registering and chop the non-overlapping corners
+-        #        when subsetting to the common image overlap. FFT filer needs to
+-        #        be applied to the native images before they are processed by
+-        #        Geogrid or autoRIFT.
++        # FIXME: Ensuring landsat 7 images are projected correctly requires fft filtering and then reprojecting the
++        #        secondary scene before processing with Geogrid or autoRIFT. Furthermore, the Landsat 4/5 FFT
++        #        preprocessor looks for the image corners to determine the scene rotation, but Geogrid + autoRIFT round
++        #        corners when co-registering and chop the non-overlapping corners when subsetting to the common image
++        #        overlap. FFT filer needs to  be applied to the native images before they are processed by Geogrid or
++        #        autoRIFT; this now occurs in hyp3-autorift/process.py
+         # obj.preprocess_filt_wal()
+         # obj.preprocess_filt_fft()
+-        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method', UserWarning)
++        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method',
++                      UserWarning)
+     else:
+         obj.preprocess_filt_hps()
+-#    obj.I1 = np.abs(I1)
+-#    obj.I2 = np.abs(I2)
++
++    # obj.I1 = np.abs(I1)
++    # obj.I2 = np.abs(I2)
+     print("Pre-process Done!!!")
+     print(time.time()-t1)
+ 
+     t1 = time.time()
+-#    obj.DataType = 0
++    # obj.DataType = 0
+     obj.uniform_data_type()
+     print("Uniform Data Type Done!!!")
+     print(time.time()-t1)
+@@ -539,6 +546,17 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+             elif len(re.findall("LT0[45]_", name)) > 0:
+                 preprocessing_methods[ii] = 'fft'
+ 
++        zero_mask = None
++        indir_m_zero = f'{indir_m.split(".")[0]}_zeroMask.{indir_m.split(".")[1]}'
++        indir_s_zero = f'{indir_s.split(".")[0]}_zeroMask.{indir_s.split(".")[1]}'
++        if os.path.exists(indir_m_zero) or os.path.exists(indir_s_zero):
++            m_zero, s_zero = loadProductOptical(indir_m_zero, indir_s_zero)
++            m_zero = m_zero.astype(np.uint8)
++            s_zero = s_zero.astype(np.uint8)
++
++            # FIXME: AND? Wallis uses "or" here, while wallis_fill uses "and" here.
++            zero_mask = m_zero & s_zero
++
+         print(f'Using preprocessing methods {preprocessing_methods}')
+ 
+         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = \
+@@ -546,7 +564,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+                 data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
+                 noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info,
+                 preprocessing_methods=preprocessing_methods, preprocessing_filter_width=preprocessing_filter_width,
+-        )
++                zero_mask=zero_mask
++            )
+         if nc_sensor is not None:
+             import hyp3_autorift.vend.netcdf_output as no
+             no.netCDF_packaging_intermediate(Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask, intermediate_nc_file)

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -46,3 +46,7 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
    after an extensive metadata review to prepare netCDF output for ingest to NSIDC DAAC. These changes have been
    [proposed upstream](https://github.com/nasa-jpl/autoRIFT/pull/74) and should be applied in the next
    `nasa-jpl/autoRIFT` release.
+4. The changes listed in `CHANGES-173.diff` were applied in [ASFHyP3/hyp3-autorift#173](https://github.com/ASFHyP3/hyp3-autorift/pull/173)
+   to handle Landsat scene pairs in differing projections. These changes are *not* expected to be applied upstream to
+   `nasa-jpl/autoRIFT` because they are a significant departure of the "expected" upstream workflow and there's no easy
+   way to communicated or document those changes upstream.

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -285,7 +285,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
     # obj.zeroMask = 1
 
-    # TODO: Allow different filters to be applied images independently default to most stringent filtering
+    # TODO: Allow different filters to be applied images independently; default to most stringent filtering
     if 'wallis_fill' in preprocessing_methods:
         # FIXME: Ensuring landsat 7 images are projected correctly requires wallis_fill filtering and then reprojecting the
         #        secondary scene before processing with Geogrid or autoRIFT; this now occurs in hyp3-autorift/process.py
@@ -312,10 +312,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method',
                       UserWarning)
     else:
-
-        ##########     uncomment if starting from preprocessed images
-        obj.I1 = obj.I1.astype(np.uint8)
-        obj.I2 = obj.I2.astype(np.uint8)
         obj.preprocess_filt_hps()
 
     # obj.I1 = np.abs(I1)

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -132,7 +132,7 @@ def loadProductOptical(file_m, file_s):
 
 def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
                 nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
-                preprocessing_filter_width=5):
+                preprocessing_filter_width=5, zero_mask=None):
     '''
     Wire and run geogrid.
     '''
@@ -150,10 +150,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
     obj.WallisFilterWidth = preprocessing_filter_width
     print(f'Setting Wallis Filter Width to {preprocessing_filter_width}')
-
-#    ##########     uncomment if starting from preprocessed images
-#    I1 = I1.astype(np.uint8)
-#    I2 = I2.astype(np.uint8)
 
     obj.MultiThread = mpflag
 
@@ -286,33 +282,44 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     t1 = time.time()
     print("Pre-process Start!!!")
     print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
-#    obj.zeroMask = 1
+    # obj.zeroMask = 1
 
-    # TODO: Allow different filters to be applied images independently
-    # default to most stringent filtering
+    # TODO: Allow different filters to be applied images independently; default to most stringent filtering
     if 'wallis_fill' in preprocessing_methods:
-        obj.preprocess_filt_wal_nodata_fill()
+        # FIXME: Ensuring landsat 7 images are projected correctly requires wallis_fill filtering and then reprojecting the
+        #        secondary scene before processing with Geogrid or autoRIFT; this now occurs in hyp3-autorift/process.py
+        warnings.warn('Wallis filtering must be done before processing with geogrid! Be careful when using this method',
+                      UserWarning)
+        obj.zeroMask = zero_mask
+        # obj.preprocess_filt_wal_nodata_fill()
     elif 'wallis' in preprocessing_methods:
-        obj.preprocess_filt_wal()
+        # FIXME: Ensuring landsat 7 images are projected correctly requires wallis filtering and then reprojecting the
+        #       secondary scene before processing with Geogrid or autoRIFT; this now occurs in hyp3-autorift/process.py
+        warnings.warn('Wallis filtering must be done before processing with geogrid! Be careful when using this method',
+                      UserWarning)
+        obj.zeroMask = zero_mask
+        # obj.preprocess_filt_wal()
     elif 'fft' in preprocessing_methods:
-        # FIXME: The Landsat 4/5 FFT preprocessor looks for the image corners to
-        #        determine the scene rotation, but Geogrid + autoRIFT rond the
-        #        corners when co-registering and chop the non-overlapping corners
-        #        when subsetting to the common image overlap. FFT filer needs to
-        #        be applied to the native images before they are processed by
-        #        Geogrid or autoRIFT.
+        # FIXME: Ensuring landsat 7 images are projected correctly requires fft filtering and then reprojecting the
+        #        secondary scene before processing with Geogrid or autoRIFT. Furthermore, the Landsat 4/5 FFT
+        #        preprocessor looks for the image corners to determine the scene rotation, but Geogrid + autoRIFT round
+        #        corners when co-registering and chop the non-overlapping corners when subsetting to the common image
+        #        overlap. FFT filer needs to  be applied to the native images before they are processed by Geogrid or
+        #        autoRIFT; this now occurs in hyp3-autorift/process.py
         # obj.preprocess_filt_wal()
         # obj.preprocess_filt_fft()
-        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method', UserWarning)
+        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method',
+                      UserWarning)
     else:
         obj.preprocess_filt_hps()
-#    obj.I1 = np.abs(I1)
-#    obj.I2 = np.abs(I2)
+
+    # obj.I1 = np.abs(I1)
+    # obj.I2 = np.abs(I2)
     print("Pre-process Done!!!")
     print(time.time()-t1)
 
     t1 = time.time()
-#    obj.DataType = 0
+    # obj.DataType = 0
     obj.uniform_data_type()
     print("Uniform Data Type Done!!!")
     print(time.time()-t1)
@@ -539,6 +546,17 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
             elif len(re.findall("LT0[45]_", name)) > 0:
                 preprocessing_methods[ii] = 'fft'
 
+        zero_mask = None
+        indir_m_zero = f'{indir_m.split(".")[0]}_zeroMask.{indir_m.split(".")[1]}'
+        indir_s_zero = f'{indir_s.split(".")[0]}_zeroMask.{indir_s.split(".")[1]}'
+        if os.path.exists(indir_m_zero) or os.path.exists(indir_s_zero):
+            m_zero, s_zero = loadProductOptical(indir_m_zero, indir_s_zero)
+            m_zero = m_zero.astype(np.uint8)
+            s_zero = s_zero.astype(np.uint8)
+
+            # FIXME: AND? Wallis uses "or" here, while wallis_fill uses "and" here.
+            zero_mask = m_zero & s_zero
+
         print(f'Using preprocessing methods {preprocessing_methods}')
 
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = \
@@ -546,7 +564,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
                 noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info,
                 preprocessing_methods=preprocessing_methods, preprocessing_filter_width=preprocessing_filter_width,
-        )
+                zero_mask=zero_mask
+            )
         if nc_sensor is not None:
             import hyp3_autorift.vend.netcdf_output as no
             no.netCDF_packaging_intermediate(Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask, intermediate_nc_file)


### PR DESCRIPTION
Also, drop silly cast to `uint8`:
https://github.com/ASFHyP3/hyp3-autorift/compare/landsat_reproject...sync-changes?expand=1#diff-aec97127e1a0f9c669793fef4650bdfcd75ea2522b8826a4df963ef623d937a7L316-L318