### PR TITLE
Only filter SLC-On Landsat-7 scenes once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 * The zero mask and nodata value for wallis-filtered Landsat-7 images are now set appropriately
+* Early (SLC-On) Landsat-7 images are no longer incorrectly filtered a second time with the high-pass filter
 
 ## [0.10.4]
 

--- a/hyp3_autorift/vend/CHANGES-213.diff
+++ b/hyp3_autorift/vend/CHANGES-213.diff
@@ -1,0 +1,28 @@
+diff --git testautoRIFT.py testautoRIFT.py
+--- testautoRIFT.py
++++ testautoRIFT.py
+@@ -541,9 +541,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+         preprocessing_methods = ['hps', 'hps']
+         for ii, name in enumerate((m_name, s_name)):
+             if len(re.findall("L[EO]07_", name)) > 0:
+-                acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
+-                if acquisition >= datetime(2003, 5, 31):
+-                    preprocessing_methods[ii] = 'wallis_fill'
++                preprocessing_methods[ii] = 'wallis_fill'
+             elif len(re.findall("LT0[45]_", name)) > 0:
+                 preprocessing_methods[ii] = 'fft'
+ 
+diff --git testautoRIFT_ISCE.py testautoRIFT_ISCE.py
+--- testautoRIFT_ISCE.py
++++ testautoRIFT_ISCE.py
+@@ -540,9 +540,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
+         preprocessing_methods = ['hps', 'hps']
+         for ii, name in enumerate((m_name, s_name)):
+             if len(re.findall("L[EO]07_", name)) > 0:
+-                acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
+-                if acquisition >= datetime(2003, 5, 31):
+-                    preprocessing_methods[ii] = 'wallis_fill'
++                preprocessing_methods[ii] = 'wallis_fill'
+             elif len(re.findall("LT0[45]_", name)) > 0:
+                 preprocessing_methods[ii] = 'fft'
+ 

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -50,6 +50,9 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
    to handle Landsat scene pairs in differing projections. These changes are *not* expected to be applied upstream to
    `nasa-jpl/autoRIFT` because they are a significant departure of the "expected" upstream workflow and there's no easy
    way to communicated or document those changes upstream.
-5. The changes listed in `CHANGES-211.idff` were applied in [ASFHyP3/hyp3-autorift#173](https://github.com/ASFHyP3/hyp3-autorift/pull/173)
+5. The changes listed in `CHANGES-211.diff` were applied in [ASFHyP3/hyp3-autorift#211](https://github.com/ASFHyP3/hyp3-autorift/pull/211)
    to fix bug in the zero mask used for Landsat 7 scenes. Like (4), these changes are *not* expected to be applied
+   upstream to `nasa-jpl/autoRIFT`.
+6. The changes listed in `CHANGES-213.diff` were applied in [ASFHyP3/hyp3-autorift#213](https://github.com/ASFHyP3/hyp3-autorift/pull/213)
+   to fix bug where early (SLC-On) Landsat 7 scenes would be filtered twice. Like (4), these changes are *not* expected to be applied
    upstream to `nasa-jpl/autoRIFT`.

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -541,9 +541,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
             if len(re.findall("L[EO]07_", name)) > 0:
-                acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
-                if acquisition >= datetime(2003, 5, 31):
-                    preprocessing_methods[ii] = 'wallis_fill'
+                preprocessing_methods[ii] = 'wallis_fill'
             elif len(re.findall("LT0[45]_", name)) > 0:
                 preprocessing_methods[ii] = 'fft'
 

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -540,9 +540,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
             if len(re.findall("L[EO]07_", name)) > 0:
-                acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
-                if acquisition >= datetime(2003, 5, 31):
-                    preprocessing_methods[ii] = 'wallis_fill'
+                preprocessing_methods[ii] = 'wallis_fill'
             elif len(re.findall("LT0[45]_", name)) > 0:
                 preprocessing_methods[ii] = 'fft'
 


### PR DESCRIPTION
Since we *always* pre-filter Lansat 7 now, we want to always set the L7 filter to wallis_fill so that we don't later high-pass filter the scene again.

<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/hyp3-autorift/compare/main...develop?template=release.md
 
If this PR does not include changes that should be reflected in CHANGELOG.md,
please indicate so by affixing the `bumpless` label to this PR.

NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->