### PR TITLE
Fix Landsat-7 output product noDataMask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 * The zero mask and nodata value for wallis-filtered Landsat-7 images are now set appropriately
 * Early (SLC-On) Landsat-7 images are no longer incorrectly filtered a second time with the high-pass filter
+* The search range and %-valid pixels are now correctly calculated for Landsat-7 images
 
 ## [0.10.4]
 

--- a/hyp3_autorift/vend/CHANGES-214.diff
+++ b/hyp3_autorift/vend/CHANGES-214.diff
@@ -1,0 +1,46 @@
+diff --git testautoRIFT.py testautoRIFT.py
+--- testautoRIFT.py
++++ testautoRIFT.py
+@@ -199,6 +199,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     #        We should not mask based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
+     #        and prevents autoRIFT from looking at large parts of the images, but untangling the logic here
+     #        has proved too difficult, so lets just turn it off if `wallis_fill` preprocessing is going to be used.
++    #        However, we do have the image zero_mask already, so we can use that to create the output product noDataMask
+     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
+     if 'wallis_fill' not in preprocessing_methods:
+         for ii in range(obj.xGrid.shape[0]):
+@@ -206,6 +207,11 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+                 if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
+                     if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
+                         noDataMask[ii,jj] = True
++    elif zero_mask is not None:
++        for ii in range(obj.xGrid.shape[0]):
++            for jj in range(obj.xGrid.shape[1]):
++                if (obj.yGrid[ii, jj] != nodata) & (obj.xGrid[ii, jj] != nodata):
++                    noDataMask[ii, jj] = zero_mask[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]
+ 
+     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
+ 
+diff --git testautoRIFT_ISCE.py testautoRIFT_ISCE.py
+--- testautoRIFT_ISCE.py
++++ testautoRIFT_ISCE.py
+@@ -198,6 +198,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+     #        We should not mask based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
+     #        and prevents autoRIFT from looking at large parts of the images, but untangling the logic here
+     #        has proved too difficult, so lets just turn it off if `wallis_fill` preprocessing is going to be used.
++    #        However, we do have the image zero_mask already, so we can use that to create the output product noDataMask
+     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
+     if 'wallis_fill' not in preprocessing_methods:
+         for ii in range(obj.xGrid.shape[0]):
+@@ -205,6 +206,11 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
+                 if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
+                     if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
+                         noDataMask[ii,jj] = True
++    elif zero_mask is not None:
++        for ii in range(obj.xGrid.shape[0]):
++            for jj in range(obj.xGrid.shape[1]):
++                if (obj.yGrid[ii, jj] != nodata) & (obj.xGrid[ii, jj] != nodata):
++                    noDataMask[ii, jj] = zero_mask[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]
+ 
+     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
+ 

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -56,3 +56,7 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
 6. The changes listed in `CHANGES-213.diff` were applied in [ASFHyP3/hyp3-autorift#213](https://github.com/ASFHyP3/hyp3-autorift/pull/213)
    to fix bug where early (SLC-On) Landsat 7 scenes would be filtered twice. Like (4), these changes are *not* expected to be applied
    upstream to `nasa-jpl/autoRIFT`.
+7. The changes listed in `CHANGES-214.diff` were applied in [ASFHyP3/hyp3-autorift#214](https://github.com/ASFHyP3/hyp3-autorift/pull/214)
+   to fix the `noDataMask` used for the search range and %-valid pixel calculations. Unfortunately, this bug exists
+   upstream but this fix is dependent on changes in (4) which are not easily applied upstream. Therefore, these changes
+   are *not* expected to be applied upstream to `nasa-jpl/autoRIFT` without a significant refactor upstream.

--- a/hyp3_autorift/vend/testautoRIFT.py
+++ b/hyp3_autorift/vend/testautoRIFT.py
@@ -199,6 +199,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     #        We should not mask based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
     #        and prevents autoRIFT from looking at large parts of the images, but untangling the logic here
     #        has proved too difficult, so lets just turn it off if `wallis_fill` preprocessing is going to be used.
+    #        However, we do have the image zero_mask already, so we can use that to create the output product noDataMask
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
     if 'wallis_fill' not in preprocessing_methods:
         for ii in range(obj.xGrid.shape[0]):
@@ -206,6 +207,11 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
                 if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
                     if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
                         noDataMask[ii,jj] = True
+    elif zero_mask is not None:
+        for ii in range(obj.xGrid.shape[0]):
+            for jj in range(obj.xGrid.shape[1]):
+                if (obj.yGrid[ii, jj] != nodata) & (obj.xGrid[ii, jj] != nodata):
+                    noDataMask[ii, jj] = zero_mask[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]
 
     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
 

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -198,6 +198,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     #        We should not mask based on zero values in the L7 images as this percolates into SearchLimit{X,Y}
     #        and prevents autoRIFT from looking at large parts of the images, but untangling the logic here
     #        has proved too difficult, so lets just turn it off if `wallis_fill` preprocessing is going to be used.
+    #        However, we do have the image zero_mask already, so we can use that to create the output product noDataMask
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
     if 'wallis_fill' not in preprocessing_methods:
         for ii in range(obj.xGrid.shape[0]):
@@ -205,6 +206,11 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
                 if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
                     if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
                         noDataMask[ii,jj] = True
+    elif zero_mask is not None:
+        for ii in range(obj.xGrid.shape[0]):
+            for jj in range(obj.xGrid.shape[1]):
+                if (obj.yGrid[ii, jj] != nodata) & (obj.xGrid[ii, jj] != nodata):
+                    noDataMask[ii, jj] = zero_mask[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]
 
     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
 


### PR DESCRIPTION
We previously decided to skip creating the `noDataMask` (which is in the final product coordinates) because the logic was hard to reconcile with Landsat-7 scenes with no-data stripes due to the Scan Line Corrector failure (SLC-Off).

We incorrectly thought this only affected the search range and would just cause some additional unnecessary computational overhead. It turns out that it also affects the final output product size and the %-valid pixels calculation. 

Fortunately, now that we always wallis filter up front, we have the `zero_mask` (no data in image coordinates after filling the stripes) available to us, which we can use to create the `noDataMask`. The figure below shows the `zero_mask` on the left and the (now computed) `noDataMask` on the right:
![image](https://github.com/ASFHyP3/hyp3-autorift/assets/7882693/5278fa9d-819b-4f6c-8564-d18af062f2b5)

