### PR TITLE
switch to pair-wise S1 correction workflow

### DIFF
--- a/hyp3_autorift/s1_correction.py
+++ b/hyp3_autorift/s1_correction.py
@@ -8,33 +8,38 @@ from hyp3lib.get_orb import downloadSentinelOrbitFile
 from hyp3lib.scene import get_download_url
 
 from hyp3_autorift import geometry, io
-from hyp3_autorift.process import DEFAULT_PARAMETER_FILE, get_s1_primary_polarization
+from hyp3_autorift.process import DEFAULT_PARAMETER_FILE, get_datetime, get_s1_primary_polarization
 from hyp3_autorift.vend.testGeogrid_ISCE import loadParsedata, runGeogrid
 log = logging.getLogger(__name__)
 
 
-def generate_correction_data(scene: str, buffer: int = 0, parameter_file: str = DEFAULT_PARAMETER_FILE):
-    scene_path = Path(f'{scene}.zip')
-    if not scene_path.exists():
-        scene_url = get_download_url(scene)
-        scene_path = download_file(scene_url, chunk_size=5242880)
-
+def generate_correction_data(reference: str, secondary: str, buffer: int = 0,
+                             parameter_file: str = DEFAULT_PARAMETER_FILE):
+    reference_path = Path(f'{reference}.zip')
+    secondary_path = Path(f'{secondary}.zip')
     orbits = Path('Orbits').resolve()
     orbits.mkdir(parents=True, exist_ok=True)
-    state_vec, oribit_provider = downloadSentinelOrbitFile(scene, directory=str(orbits))
-    log.info(f'Downloaded orbit file {state_vec} from {oribit_provider}')
 
-    polarization = get_s1_primary_polarization(scene)
-    lat_limits, lon_limits = geometry.bounding_box(f'{scene}.zip', polarization=polarization, orbits=orbits)
+    for scene_path in [reference_path, secondary_path]:
+        if not scene_path.exists():
+            scene_url = get_download_url(scene_path.stem)
+            _ = download_file(scene_url, chunk_size=5242880)
+
+        state_vec, oribit_provider = downloadSentinelOrbitFile(scene_path.stem, directory=str(orbits))
+        log.info(f'Downloaded orbit file {state_vec} from {oribit_provider}')
+
+    polarization = get_s1_primary_polarization(reference)
+    lat_limits, lon_limits = geometry.bounding_box(f'{reference}.zip', polarization=polarization, orbits=orbits)
 
     scene_poly = geometry.polygon_from_bbox(x_limits=lat_limits, y_limits=lon_limits)
     parameter_info = io.find_jpl_parameter_info(scene_poly, parameter_file)
 
     isce_dem = geometry.prep_isce_dem(parameter_info['geogrid']['dem'], lat_limits, lon_limits)
-    io.format_tops_xml(scene, scene, polarization, isce_dem, orbits)
+    io.format_tops_xml(reference, secondary, polarization, isce_dem, orbits)
 
-    scene_meta = loadParsedata(str(scene_path), orbit_dir=orbits, aux_dir=orbits, buffer=buffer)
-    geogrid_info = runGeogrid(scene_meta, scene_meta, epsg=parameter_info['epsg'], **parameter_info['geogrid'])
+    reference_meta = loadParsedata(str(reference_path), orbit_dir=orbits, aux_dir=orbits, buffer=buffer)
+    secondary_meta = loadParsedata(str(secondary_path), orbit_dir=orbits, aux_dir=orbits, buffer=buffer)
+    geogrid_info = runGeogrid(reference_meta, secondary_meta, epsg=parameter_info['epsg'], **parameter_info['geogrid'])
 
     return geogrid_info
 
@@ -49,10 +54,16 @@ def main():
     parser.add_argument('--parameter-file', default=DEFAULT_PARAMETER_FILE,
                         help='Shapefile for determining the correct search parameters by geographic location. '
                              'Path to shapefile must be understood by GDAL')
-    parser.add_argument('granule', help='Reference granule to process')
+    parser.add_argument('granules', type=str.split, nargs='+', help='Granules to process')
     args = parser.parse_args()
 
-    _ = generate_correction_data(args.granule, buffer=args.buffer)
+    args.granules = [item for sublist in args.granules for item in sublist]
+    if len(args.granules) != 2:
+        parser.error('Must provide exactly two granules')
+
+    reference, secondary = sorted(args.granules, key=get_datetime)
+
+    _ = generate_correction_data(reference=reference, secondary=secondary, buffer=args.buffer)
 
     if args.bucket:
         for geotiff in Path.cwd().glob('*.tif'):


### PR DESCRIPTION
In the geogrid workflow, the time separation between the reference scene and the secondary scene is used in the denominator of some calculations, leading to dividing by zero issues when using the same scene as the reference and secondary scene. 

This switches to accepting different reference and secondary scenes. Instead of processing only the unique reference scenes, each granule pair will need a set of geogrid tifs created to run the correction. 

<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/hyp3-autorift/compare/main...develop?template=release.md
 
If this PR does not include changes that should be reflected in CHANGELOG.md,
please indicate so by affixing the `bumpless` label to this PR.

NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->