### PR TITLE
apply scale factor to M11,M22 matrices (rdr_off2vel_x_vec.tif) in netCDF Packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.12.1]
+
+### Fixed
+* Patch [235](hyp3_autorift/vend/CHANGES-227.diff) was applied  to make it easier for users to correct for ionosphere
+  streaks without needing to know the scale factor.
+
 ## [0.12.0]
 
 ### Added

--- a/hyp3_autorift/vend/CHANGES-235.diff
+++ b/hyp3_autorift/vend/CHANGES-235.diff
@@ -1,0 +1,21 @@
+diff --git netcdf_output.py netcdf_output.py
+--- netcdf_output.py
++++ netcdf_output.py
+@@ -1113,7 +1113,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
+                                                      'pixel displacement dr to slant range velocity vr')
+ 
+-        M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
++        M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
+ 
+         x1 = np.nanmin(M11[:])
+         x2 = np.nanmax(M11[:])
+@@ -1145,7 +1145,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
+         var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
+                                                      'pixel displacement dr to slant range velocity vr')
+ 
+-        M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
++        M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
+ 
+         x1 = np.nanmin(M12[:])
+         x2 = np.nanmax(M12[:])

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -73,4 +73,4 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
 11. The changes listed in `CHANGES-235.diff` were applied in [ASFHyP3/hyp3-autorift#235](https://github.com/ASFHyP3/hyp3-autorift/pull/235)
     were applied to make it easier for users to correct for ionosphere streaks without needing to know the scale
     factor. These changes have been [proposed upstream](https://github.com/nasa-jpl/autoRIFT/pull/92) and should be
-    applied in the next `nasa-jpl/autoRIFT` release.    
+    applied in the next `nasa-jpl/autoRIFT` release.

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -70,3 +70,7 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
     were applied to align the S1 granules velocity description with the optical products. These changes have been
     [proposed upstream](https://github.com/nasa-jpl/autoRIFT/pull/87) and should be applied in the next 
     `nasa-jpl/autoRIFT` release.    
+11. The changes listed in `CHANGES-235.diff` were applied in [ASFHyP3/hyp3-autorift#235](https://github.com/ASFHyP3/hyp3-autorift/pull/235)
+    were applied to make it easier for users to correct for ionosphere streaks with out needing to know the scale
+    factor. These changes have been [proposed upstream](https://github.com/nasa-jpl/autoRIFT/pull/92) and should be
+    applied in the next `nasa-jpl/autoRIFT` release.    

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -71,6 +71,6 @@ We've replaced it  with `hyp3_autorift.io.get_topsinsar_config`.
     [proposed upstream](https://github.com/nasa-jpl/autoRIFT/pull/87) and should be applied in the next 
     `nasa-jpl/autoRIFT` release.    
 11. The changes listed in `CHANGES-235.diff` were applied in [ASFHyP3/hyp3-autorift#235](https://github.com/ASFHyP3/hyp3-autorift/pull/235)
-    were applied to make it easier for users to correct for ionosphere streaks with out needing to know the scale
+    were applied to make it easier for users to correct for ionosphere streaks without needing to know the scale
     factor. These changes have been [proposed upstream](https://github.com/nasa-jpl/autoRIFT/pull/92) and should be
     applied in the next `nasa-jpl/autoRIFT` release.    

--- a/hyp3_autorift/vend/netcdf_output.py
+++ b/hyp3_autorift/vend/netcdf_output.py
@@ -1113,7 +1113,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
                                                      'pixel displacement dr to slant range velocity vr')
 
-        M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
+        M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
 
         x1 = np.nanmin(M11[:])
         x2 = np.nanmax(M11[:])
@@ -1145,7 +1145,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
                                                      'pixel displacement dr to slant range velocity vr')
 
-        M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1)
+        M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
 
         x1 = np.nanmin(M12[:])
         x2 = np.nanmax(M12[:])


### PR DESCRIPTION
As suggested in this ITS_LIVE slack comment:
https://itslive.slack.com/archives/CA1B8N740/p1688110892979159?thread_ts=1686824081.457019&cid=CA1B8N740

@mliukis can you confirm?

Proposed upstream in NASA-jpl/autoRIFT#92