### PR TITLE
Fix entrypoint path in Dockerfile for src directory change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,5 @@ RUN wget https://github.com/nasa-jpl/autoRIFT/pull/79.diff && \
     patch -d ${PYTHON_SITE_PACKAGES}/isce/components/contrib/geo_autoRIFT/autoRIFT < 79.diff && \
     rm 79.diff
 
-ENTRYPOINT ["/hyp3-autorift/hyp3_autorift/etc/entrypoint.sh"]
+ENTRYPOINT ["/hyp3-autorift/src/hyp3_autorift/etc/entrypoint.sh"]
 CMD ["-h"]


### PR DESCRIPTION
Missed a path change in the docker file. If I pull the latest and over ride the entrypoint it runs just fine:

```shell
$ docker pull ghcr.io/asfhyp3/hyp3-autorift:test
$ docker run ghcr.io/asfhyp3/hyp3-autorift:test --help
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/hyp3-autorift/hyp3_autorift/etc/entrypoint.sh": stat /hyp3-autorift/hyp3_autorift/etc/entrypoint.sh: no such file or directory: unknown.
```
```shell
$  docker run --entrypoint /hyp3-autorift/src/hyp3_autorift/etc/entrypoint.sh ghcr.io/asfhyp3/hyp3-autorift:test --help
/opt/conda/envs/hyp3-autorift/lib/python3.9/site-packages/hyp3_autorift/__main__.py:35: UserWarning: Earthdata credentials must be present as environment variables, or in your netrc.
  warnings.warn('Earthdata credentials must be present as environment variables, or in your netrc.', UserWarning)
This is the Open Source version of ISCE.
Some of the workflows depend on a separate licensed package.
To obtain the licensed package, please make a request for ISCE
through the website: https://download.jpl.nasa.gov/ops/request/index.cfm.
Alternatively, if you are a member, or can become a member of WinSAR
you may be able to obtain access to a version of the licensed sofware at
https://winsar.unavco.org/software/isce
2023-10-20 22:32:26,233 - matplotlib - DEBUG - matplotlib data path: /opt/conda/envs/hyp3-autorift/lib/python3.9/site-packages/matplotlib/mpl-data
2023-10-20 22:32:26,236 - matplotlib - DEBUG - CONFIGDIR=/home/conda/.config/matplotlib
2023-10-20 22:32:26,236 - matplotlib - DEBUG - interactive is False
2023-10-20 22:32:26,236 - matplotlib - DEBUG - platform is linux
2023-10-20 22:32:26,259 - matplotlib - DEBUG - CACHEDIR=/home/conda/.cache/matplotlib
2023-10-20 22:32:26,259 - matplotlib.font_manager - DEBUG - font search path [PosixPath('/opt/conda/envs/hyp3-autorift/lib/python3.9/site-packages/matplotlib/mpl-data/fonts/ttf'), PosixPath('/opt/conda/envs/hyp3-autorift/lib/python3.9/site-packages/matplotlib/mpl-data/fonts/afm'), PosixPath('/opt/conda/envs/hyp3-autorift/lib/python3.9/site-packages/matplotlib/mpl-data/fonts/pdfcorefonts')]
2023-10-20 22:32:26,334 - matplotlib.font_manager - INFO - generated new fontManager
usage: hyp3_autorift [-h] [--bucket BUCKET] [--bucket-prefix BUCKET_PREFIX]
                     [--parameter-file PARAMETER_FILE]
                     [--naming-scheme {ITS_LIVE_OD,ITS_LIVE_PROD,ASF}]
                     granules [granules ...]

positional arguments:
  granules              Granule pair to process

optional arguments:
  -h, --help            show this help message and exit
  --bucket BUCKET       AWS bucket to upload product files to (default: None)
  --bucket-prefix BUCKET_PREFIX
                        AWS prefix (location in bucket) to add to product
                        files (default: )
  --parameter-file PARAMETER_FILE
                        Shapefile for determining the correct search
                        parameters by geographic location. Path to shapefile
                        must be understood by GDAL (default:
                        /vsicurl/http://its-live-data.s3.amazonaws.com/autorif
                        t_parameters/v001/autorift_landice_0120m.shp)
  --naming-scheme {ITS_LIVE_OD,ITS_LIVE_PROD,ASF}
                        Naming scheme to use for product files (default:
                        ITS_LIVE_OD)

```
