### PR TITLE
Set up access key use for open data upload

### DIFF
--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -28,7 +28,7 @@ from osgeo import gdal
 
 from hyp3_autorift import geometry, image, io
 from hyp3_autorift.crop import crop_netcdf_product
-from hyp3_autorift.utils import get_esa_credentials
+from hyp3_autorift.utils import get_esa_credentials, upload_file_to_s3_with_upload_access_keys
 
 log = logging.getLogger(__name__)
 
@@ -601,6 +601,6 @@ def main():
 
     if args.publish:
         prefix = get_opendata_prefix(product_file)
-        upload_file_to_s3(product_file, OPEN_DATA_BUCKET, prefix)
-        upload_file_to_s3(browse_file, OPEN_DATA_BUCKET, prefix)
-        upload_file_to_s3(thumbnail_file, OPEN_DATA_BUCKET, prefix)
+        upload_file_to_s3_with_upload_access_keys(product_file, OPEN_DATA_BUCKET, prefix)
+        upload_file_to_s3_with_upload_access_keys(browse_file, OPEN_DATA_BUCKET, prefix)
+        upload_file_to_s3_with_upload_access_keys(thumbnail_file, OPEN_DATA_BUCKET, prefix)

--- a/src/hyp3_autorift/utils.py
+++ b/src/hyp3_autorift/utils.py
@@ -1,8 +1,12 @@
+import logging
 import netrc
 import os
 from pathlib import Path
 from platform import system
 from typing import Tuple
+
+import boto3
+from hyp3lib.aws import get_content_type, get_tag_set
 
 
 ESA_HOST = 'dataspace.copernicus.eu'
@@ -28,3 +32,25 @@ def get_esa_credentials() -> Tuple[str, str]:
         "Please provide Copernicus Data Space Ecosystem (CDSE) credentials via the "
         "ESA_USERNAME and ESA_PASSWORD environment variables, or your netrc file."
     )
+
+
+def upload_file_to_s3_with_upload_access_keys(path_to_file: Path, bucket: str, prefix: str = ''):
+    if 'UPLOAD_ACCESS_KEY_ID' in os.environ and 'UPLOAD_ACCESS_KEY_SECRET' in os.environ:
+        access_key_id = os.environ['UPLOAD_ACCESS_KEY_ID']
+        access_key_secret = os.environ['UPLOAD_ACCESS_KEY_SECRET']
+    else:
+        raise ValueError(
+            'Please provide S3 Bucket upload access key credentials via the '
+            'UPLOAD_ACCESS_KEY_ID and UPLOAD_ACCESS_KEY_SECRET environment variables'
+        )
+
+    s3_client = boto3.client('s3', aws_access_key_id=access_key_id, aws_secret_access_key=access_key_secret)
+    key = str(Path(prefix) / path_to_file.name)
+    extra_args = {'ContentType': get_content_type(key)}
+
+    logging.info(f'Uploading s3://{bucket}/{key}')
+    s3_client.upload_file(str(path_to_file), bucket, key, extra_args)
+
+    tag_set = get_tag_set(path_to_file.name)
+
+    s3_client.put_object_tagging(Bucket=bucket, Key=key, Tagging=tag_set)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hyp3_autorift.utils import ESA_HOST, get_esa_credentials
+from hyp3_autorift.utils import ESA_HOST, get_esa_credentials, upload_file_to_s3_with_upload_access_keys
 
 
 def test_get_esa_credentials_env(tmp_path, monkeypatch):
@@ -45,3 +45,19 @@ def test_get_esa_credentials_missing(tmp_path, monkeypatch):
         msg = 'Please provide.*'
         with pytest.raises(ValueError, match=msg):
             get_esa_credentials()
+
+
+def test_upload_file_to_s3_credentials_missing(tmp_path, monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv('UPLOAD_ACCESS_KEY_ID', raising=False)
+        m.setenv('UPLOAD_ACCESS_KEY_SECRET', 'upload_access_key_secret')
+        msg = 'Please provide.*'
+        with pytest.raises(ValueError, match=msg):
+            upload_file_to_s3_with_upload_access_keys('file.zip', 'myBucket')
+
+    with monkeypatch.context() as m:
+        m.setenv('UPLOAD_ACCESS_KEY_ID', 'upload_access_key_id')
+        m.delenv('UPLOAD_ACCESS_KEY_SECRET', raising=False)
+        msg = 'Please provide.*'
+        with pytest.raises(ValueError, match=msg):
+            upload_file_to_s3_with_upload_access_keys('file.zip', 'myBucket')


### PR DESCRIPTION
In concert with [HyP3 PR #2153](https://github.com/ASFHyP3/hyp3/pull/2153/files), this PR adds support for uploading data to the ITS_LIVE open data bucket with access key permissions.

Since hyp3lib's `upload_file_to_s3` does not allow you to pass an S3 client as an argument, I had to create a modified version of this function. We could modify hyp3lib's `upload_file_to_s3` to accommodate this, but not sure we want to do this when we only have use case.