### PR TITLE
Add creation of conversion matrices to S1 Correction workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [ 0.18.0]
+### Added
+* The Sentinel-1 correction workflow will now calculate and write the M11/M12 conversion matrices to a netCDF file.
+
 ## [0.17.0]
 ## Changed
 * In preparation for a major update, the Sentinel-1 processing workflow has been isolated to a new `hyp3_autorift.s1_isce2` module. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [ 0.18.0]
+## [0.18.0]
 ### Added
 * The Sentinel-1 correction workflow will now calculate and write the M11/M12 conversion matrices to a netCDF file.
 

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -242,7 +242,7 @@ def apply_wallis_nodata_fill_filter(array: np.ndarray, nodata: int) -> Tuple[np.
 
 
 def _apply_filter_function(image_path: str, filter_function: Callable) -> Tuple[str, Optional[str]]:
-    image_array, image_transform, image_projection, image_nodata = utils.load_geospatial(image_path)
+    image_array, image_transform, image_projection, _, image_nodata = utils.load_geospatial(image_path)
     image_array = image_array.astype(np.float32)
 
     image_filtered, zero_mask = filter_function(image_array, image_nodata)

--- a/src/hyp3_autorift/s1_correction.py
+++ b/src/hyp3_autorift/s1_correction.py
@@ -16,8 +16,6 @@ def main():
     )
     parser.add_argument('--bucket', help='AWS bucket to upload product files to')
     parser.add_argument('--bucket-prefix', default='', help='AWS prefix (location in bucket) to add to product files')
-    parser.add_argument('--esa-username', default=None, help="Username for ESA's Copernicus Data Space Ecosystem")
-    parser.add_argument('--esa-password', default=None, help="Password for ESA's Copernicus Data Space Ecosystem")
     parser.add_argument('--buffer', type=int, default=0, help='Number of pixels to buffer each edge of the input scene')
     parser.add_argument('--parameter-file', default=DEFAULT_PARAMETER_FILE,
                         help='Shapefile for determining the correct search parameters by geographic location. '

--- a/src/hyp3_autorift/s1_correction.py
+++ b/src/hyp3_autorift/s1_correction.py
@@ -23,8 +23,9 @@ def main():
     parser.add_argument('granule', help='Reference granule to process')
     args = parser.parse_args()
 
-    _ = generate_correction_data(args.granule, buffer=args.buffer)
+    _, conversion_nc = generate_correction_data(args.granule, buffer=args.buffer)
 
     if args.bucket:
+        upload_file_to_s3(conversion_nc, args.bucket, args.bucket_prefix)
         for geotiff in Path.cwd().glob('*.tif'):
             upload_file_to_s3(geotiff, args.bucket, args.bucket_prefix)

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -93,7 +93,6 @@ def process_sentinel1_with_isce2(reference, secondary, parameter_file):
 def write_conversion_file(*, file_name: str, srs, epsg, tran, x, y, M11, M12, dr_2_vr_factor, ChunkSize,
                           NoDataValue=np.nan, parameter_file: str) -> str:
 
-    # FIXME: what else needs to be added to the netCDF file
     nc_outfile = Dataset(file_name, 'w', clobber=True, format='NETCDF4')
 
     nc_outfile.setncattr('GDAL_AREA_OR_POINT', 'Area')

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -166,7 +166,7 @@ def write_conversion_file(
         var.setncattr('spatial_epsg', epsg)
         var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))
     else:
-        raise Exception('Projection {0} not recognized for this program'.format(srs.GetAttrValue('PROJECTION')))
+        raise Exception(f'Projection {srs.GetAttrValue('PROJECTION')} not recognized for this program')
 
     var = nc_outfile.createVariable('M11', np.dtype('float64'), ('y', 'x'), fill_value=NoDataValue,
                                     zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
@@ -211,7 +211,7 @@ def create_conversion_matrices(
         scale_factor: str = 'window_scale_factor.tif',
         epsg: int = 4326,
         parameter_file: str = DEFAULT_PARAMETER_FILE,
-        **kwargs,  # noqa: consume kwargs we don't care about for convenience
+        **kwargs,
 ) -> str:
     xGrid, tran, _, srs, nodata = utils.load_geospatial(grid_location, band=1)
     yGrid, _, _, _, _ = utils.load_geospatial(grid_location, band=2)
@@ -302,7 +302,7 @@ def generate_correction_data(
     geogrid_info = runGeogrid(reference_meta, secondary_meta, epsg=parameter_info['epsg'], **parameter_info['geogrid'])
 
     # NOTE: After Geogrid is run, all drivers are no longer registered.
-    #       I've got no idea why, or if there are other affects...
+    #       I've got no idea why, or if there are other effects...
     gdal.AllRegister()
 
     conversion_nc = create_conversion_matrices(

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -1,15 +1,17 @@
 import copy
+import json
 import logging
 import os
 import sys
 import textwrap
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
 from hyp3lib.fetch import download_file
 from hyp3lib.get_orb import downloadSentinelOrbitFile
 from hyp3lib.scene import get_download_url
+from netCDF4 import Dataset
 from osgeo import gdal
 
 from hyp3_autorift import geometry, utils
@@ -88,6 +90,164 @@ def process_sentinel1_with_isce2(reference, secondary, parameter_file):
     return netcdf_file
 
 
+def write_conversion_file(*, file_name, srs, epsg, tran, x, y, M11, M12, dr_2_vr_factor, ChunkSize,
+                          NoDataValue=-32767) -> Path:
+
+    # FIXME: what else needs to be added to the nextCDF file
+    nc_outfile = Dataset(file_name, 'w', clobber=True, format='NETCDF4')
+
+    nc_outfile.setncattr('GDAL_AREA_OR_POINT', 'Area')
+    nc_outfile.setncattr('Conventions', 'CF-1.8')
+    nc_outfile.setncattr('date_created', datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
+    nc_outfile.setncattr('title', 'autoRIFT S1 Corrections')
+    # nc_outfile.setncattr('autoRIFT_software_version', 'FIXME')
+    # nc_outfile.setncattr('autoRIFT_parameter_file', 'FIXME')
+
+    nc_outfile.createDimension('x', len(x))
+    nc_outfile.createDimension('y', len(y))
+
+    var = nc_outfile.createVariable('x', np.dtype('float64'), 'x', fill_value=None)
+    var.setncattr('standard_name', 'projection_x_coordinate')
+    var.setncattr('description', 'x coordinate of projection')
+    var.setncattr('units', 'm')
+    var[:] = x
+
+    var = nc_outfile.createVariable('y', np.dtype('float64'), 'y', fill_value=None)
+    var.setncattr('standard_name', 'projection_y_coordinate')
+    var.setncattr('description', 'y coordinate of projection')
+    var.setncattr('units', 'm')
+    var[:] = y
+
+    mapping_var_name = 'mapping'
+    var = nc_outfile.createVariable(mapping_var_name, 'U1', (), fill_value=None)
+    if srs.GetAttrValue('PROJECTION') == 'Polar_Stereographic':
+        var.setncattr('grid_mapping_name', 'polar_stereographic')
+        var.setncattr('straight_vertical_longitude_from_pole', srs.GetProjParm('central_meridian'))
+        var.setncattr('false_easting', srs.GetProjParm('false_easting'))
+        var.setncattr('false_northing', srs.GetProjParm('false_northing'))
+        var.setncattr('latitude_of_projection_origin', np.sign(srs.GetProjParm('latitude_of_origin')) * 90.0)
+        var.setncattr('latitude_of_origin', srs.GetProjParm('latitude_of_origin'))
+        var.setncattr('semi_major_axis', float(srs.GetAttrValue('GEOGCS|SPHEROID', 1)))
+        var.setncattr('scale_factor_at_projection_origin', 1)
+        var.setncattr('inverse_flattening', float(srs.GetAttrValue('GEOGCS|SPHEROID', 2)))
+        var.setncattr('spatial_ref', srs.ExportToWkt())
+        var.setncattr('crs_wkt', srs.ExportToWkt())
+        var.setncattr('proj4text', srs.ExportToProj4())
+        var.setncattr('spatial_epsg', epsg)
+        var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))
+
+    elif srs.GetAttrValue('PROJECTION') == 'Transverse_Mercator':
+        var.setncattr('grid_mapping_name', 'universal_transverse_mercator')
+        zone = epsg - np.floor(epsg / 100) * 100
+        var.setncattr('utm_zone_number', zone)
+        var.setncattr('longitude_of_central_meridian', srs.GetProjParm('central_meridian'))
+        var.setncattr('false_easting', srs.GetProjParm('false_easting'))
+        var.setncattr('false_northing', srs.GetProjParm('false_northing'))
+        var.setncattr('latitude_of_projection_origin', srs.GetProjParm('latitude_of_origin'))
+        var.setncattr('semi_major_axis', float(srs.GetAttrValue('GEOGCS|SPHEROID', 1)))
+        var.setncattr('scale_factor_at_central_meridian', srs.GetProjParm('scale_factor'))
+        var.setncattr('inverse_flattening', float(srs.GetAttrValue('GEOGCS|SPHEROID', 2)))
+        var.setncattr('spatial_ref', srs.ExportToWkt())
+        var.setncattr('crs_wkt', srs.ExportToWkt())
+        var.setncattr('proj4text', srs.ExportToProj4())
+        var.setncattr('spatial_epsg', epsg)
+        var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))
+    else:
+        raise Exception('Projection {0} not recognized for this program'.format(srs.GetAttrValue('PROJECTION')))
+
+    var = nc_outfile.createVariable('M11', np.dtype('float32'), ('y', 'x'), fill_value=NoDataValue,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'conversion_matrix_element_11')
+    var.setncattr(
+        'description',
+        'conversion matrix element (1st row, 1st column) that can be multiplied with vx to give range pixel '
+        'displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)'
+    )
+    var.setncattr('units', 'pixel/(meter/year)')
+    var.setncattr('grid_mapping', mapping_var_name)
+    var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
+    var.setncattr('dr_to_vr_factor_description', 'multiplicative factor that converts slant range '
+                                                 'pixel displacement dr to slant range velocity vr')
+    var[:] = M11
+
+    var = nc_outfile.createVariable('M12', np.dtype('float32'), ('y', 'x'), fill_value=NoDataValue,
+                                    zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)
+    var.setncattr('standard_name', 'conversion_matrix_element_12')
+    var.setncattr(
+        'description',
+        'conversion matrix element (1st row, 2nd column) that can be multiplied with vy to give range pixel '
+        'displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)'
+    )
+    var.setncattr('units', 'pixel/(meter/year)')
+    var.setncattr('grid_mapping', mapping_var_name)
+    var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
+    var.setncattr('dr_to_vr_factor_description',
+                  'multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr')
+    var[:] = M12
+
+    return Path(nc_outfile.filepath())
+
+
+def create_conversion_matrices(
+        *,
+        scene: str,
+        grid_location: str = 'window_location.tif',
+        search_range: str = 'window_search_range.tif',
+        offset2vx: str = 'window_rdr_off2vel_x_vec.tif',
+        offset2vy: str = 'window_rdr_off2vel_y_vec.tif',
+        scale_factor: str = 'window_scale_factor.tif',
+        epsg: int = 4326,
+        **kwargs,  # noqa: consume kwargs we don't care about for convenience
+) -> Path:
+    xGrid, tran, _, srs, nodata = utils.load_geospatial(grid_location, band=1)
+    yGrid, _, _, _, _ = utils.load_geospatial(grid_location, band=2)
+
+    offset2vy_1, _, _, _, _ = utils.load_geospatial(offset2vy, band=1)
+    offset2vy_1[offset2vy_1 == nodata] = np.nan
+
+    offset2vy_2, _, _, _, _ = utils.load_geospatial(offset2vy, band=2)
+    offset2vy_2[offset2vy_2 == nodata] = np.nan
+
+    offset2vx_1, _, _, _, _ = utils.load_geospatial(offset2vx, band=1)
+    offset2vx_1[offset2vx_1 == nodata] = np.nan
+
+    offset2vx_2, _, _, _, _ = utils.load_geospatial(offset2vx, band=2)
+    offset2vx_2[offset2vx_2 == nodata] = np.nan
+
+    offset2vr, _, _, _, _ = utils.load_geospatial(offset2vx, band=3)
+    offset2vr[offset2vr == nodata] = np.nan
+
+    scale_factor_1, _, _, _, _ = utils.load_geospatial(scale_factor, band=1)
+    scale_factor_1[scale_factor_1 == nodata] = np.nan
+
+    scale_factor_2, _, _, _, _ = utils.load_geospatial(scale_factor, band=2)
+    scale_factor_2[scale_factor_2 == nodata] = np.nan
+
+    SRx0, _, _, _, _ = utils.load_geospatial(search_range, band=1)
+    SRx0 = SRx0.astype('float32')
+    SRx0[SRx0 == nodata] = np.nan
+
+    dimidY, dimidX = xGrid.shape
+
+    y = np.arange(tran[3], tran[3] + tran[5] * dimidY, tran[5])
+    x = np.arange(tran[0], tran[0] + tran[1] * dimidX, tran[1])
+
+    M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
+    M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
+
+    dr_2_vr_factor = np.median(offset2vr[np.logical_not(np.isnan(offset2vr))])
+
+    chunk_lines = np.min([np.ceil(8192 / dimidY) * 128, dimidY])
+    ChunkSize = [chunk_lines, dimidX]
+
+    conversion_nc = write_conversion_file(
+        file_name=f'{scene}_conversion_matrices.nc', srs=srs, epsg=epsg, tran=tran, x=x, y=y, M11=M11, M12=M12,
+        dr_2_vr_factor=dr_2_vr_factor, ChunkSize=ChunkSize
+    )
+
+    return conversion_nc
+
+
 def generate_correction_data(
     scene: str,
     buffer: int = 0,
@@ -127,7 +287,9 @@ def generate_correction_data(
 
     geogrid_info = runGeogrid(reference_meta, secondary_meta, epsg=parameter_info['epsg'], **parameter_info['geogrid'])
 
-    return geogrid_info
+    conversion_nc = create_conversion_matrices(scene=scene, epsg=parameter_info['epsg'], **parameter_info['autorift'])
+
+    return geogrid_info, conversion_nc
 
 
 class SysArgvManager:

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -5,7 +5,6 @@ import sys
 import textwrap
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 from hyp3lib.fetch import download_file
@@ -93,8 +92,6 @@ def generate_correction_data(
     scene: str,
     buffer: int = 0,
     parameter_file: str = DEFAULT_PARAMETER_FILE,
-    esa_username: Optional[str] = None,
-    esa_password: Optional[str] = None,
 ):
     from hyp3_autorift.vend.testGeogrid_ISCE import loadParsedata, runGeogrid
     scene_path = Path(f'{scene}.zip')
@@ -105,8 +102,7 @@ def generate_correction_data(
     orbits = Path('Orbits').resolve()
     orbits.mkdir(parents=True, exist_ok=True)
 
-    if (esa_username is None) or (esa_password is None):
-        esa_username, esa_password = get_esa_credentials()
+    esa_username, esa_password = get_esa_credentials()
 
     state_vec, oribit_provider = downloadSentinelOrbitFile(
         scene, directory=str(orbits), esa_credentials=(esa_username, esa_password)

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -166,7 +166,7 @@ def write_conversion_file(
         var.setncattr('spatial_epsg', epsg)
         var.setncattr('GeoTransform', ' '.join(str(x) for x in tran))
     else:
-        raise Exception(f'Projection {srs.GetAttrValue('PROJECTION')} not recognized for this program')
+        raise Exception(f'Projection {srs.GetAttrValue("PROJECTION")} not recognized for this program')
 
     var = nc_outfile.createVariable('M11', np.dtype('float64'), ('y', 'x'), fill_value=NoDataValue,
                                     zlib=True, complevel=2, shuffle=True, chunksizes=ChunkSize)

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import logging
 import os
 import sys
@@ -90,8 +89,8 @@ def process_sentinel1_with_isce2(reference, secondary, parameter_file):
     return netcdf_file
 
 
-def write_conversion_file(*, file_name, srs, epsg, tran, x, y, M11, M12, dr_2_vr_factor, ChunkSize,
-                          NoDataValue=-32767) -> Path:
+def write_conversion_file(*, file_name: str, srs, epsg, tran, x, y, M11, M12, dr_2_vr_factor, ChunkSize,
+                          NoDataValue=-32767) -> str:
 
     # FIXME: what else needs to be added to the nextCDF file
     nc_outfile = Dataset(file_name, 'w', clobber=True, format='NETCDF4')
@@ -185,7 +184,7 @@ def write_conversion_file(*, file_name, srs, epsg, tran, x, y, M11, M12, dr_2_vr
                   'multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr')
     var[:] = M12
 
-    return Path(nc_outfile.filepath())
+    return file_name
 
 
 def create_conversion_matrices(
@@ -198,7 +197,7 @@ def create_conversion_matrices(
         scale_factor: str = 'window_scale_factor.tif',
         epsg: int = 4326,
         **kwargs,  # noqa: consume kwargs we don't care about for convenience
-) -> Path:
+) -> str:
     xGrid, tran, _, srs, nodata = utils.load_geospatial(grid_location, band=1)
     yGrid, _, _, _, _ = utils.load_geospatial(grid_location, band=2)
 
@@ -252,7 +251,7 @@ def generate_correction_data(
     scene: str,
     buffer: int = 0,
     parameter_file: str = DEFAULT_PARAMETER_FILE,
-):
+) -> (dict, str):
     from hyp3_autorift.vend.testGeogrid_ISCE import loadParsedata, runGeogrid
     scene_path = Path(f'{scene}.zip')
     if not scene_path.exists():

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -3,8 +3,8 @@ import logging
 import os
 import sys
 import textwrap
-from typing import List
 from datetime import datetime, timedelta
+from typing import List
 from pathlib import Path
 
 import numpy as np

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -92,7 +92,7 @@ def process_sentinel1_with_isce2(reference, secondary, parameter_file):
 def write_conversion_file(*, file_name: str, srs, epsg, tran, x, y, M11, M12, dr_2_vr_factor, ChunkSize,
                           NoDataValue=-32767) -> str:
 
-    # FIXME: what else needs to be added to the nextCDF file
+    # FIXME: what else needs to be added to the netCDF file
     nc_outfile = Dataset(file_name, 'w', clobber=True, format='NETCDF4')
 
     nc_outfile.setncattr('GDAL_AREA_OR_POINT', 'Area')

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -4,8 +4,8 @@ import os
 import sys
 import textwrap
 from datetime import datetime, timedelta
-from typing import List
 from pathlib import Path
+from typing import List
 
 import numpy as np
 from autoRIFT import __version__ as version

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -286,6 +286,10 @@ def generate_correction_data(
 
     geogrid_info = runGeogrid(reference_meta, secondary_meta, epsg=parameter_info['epsg'], **parameter_info['geogrid'])
 
+    # NOTE: After Geogrid is run, all drivers are no longer registered.
+    #       I've got no idea why, or if there are other affects...
+    gdal.AllRegister()
+
     conversion_nc = create_conversion_matrices(scene=scene, epsg=parameter_info['epsg'], **parameter_info['autorift'])
 
     return geogrid_info, conversion_nc

--- a/src/hyp3_autorift/utils.py
+++ b/src/hyp3_autorift/utils.py
@@ -125,10 +125,13 @@ def load_geospatial(infile: str, band: int = 1):
 
     data = ds.GetRasterBand(band).ReadAsArray()
     nodata = ds.GetRasterBand(band).GetNoDataValue()
-    projection = ds.GetProjection()
+
     transform = ds.GetGeoTransform()
+    projection = ds.GetProjection()
+    srs = ds.GetSpatialRef()
+
     del ds
-    return data, transform, projection, nodata
+    return data, transform, projection, srs, nodata
 
 
 def write_geospatial(outfile: str, data, transform, projection, nodata,


### PR DESCRIPTION
Run like:
```shell
python -m hyp3_autorift ++process s1_correction --buffer 10 S1A_IW_SLC__1SDV_20170203T162106_20170203T162132_015121_018B9A_1380
```

And should produce these files:
```
.
├── demLat_S01_N02_Lon_E027_E031.dem.hdr
├── demLat_S01_N02_Lon_E027_E031.dem.wgs84
├── demLat_S01_N02_Lon_E027_E031.dem.wgs84.aux.xml
├── demLat_S01_N02_Lon_E027_E031.dem.wgs84.vrt
├── demLat_S01_N02_Lon_E027_E031.dem.wgs84.xml
├── Orbits
│   └── S1A_OPER_AUX_POEORB_OPOD_20210315T173916_V20170202T225942_20170204T005942.EOF
├── S1A_IW_SLC__1SDV_20170203T162106_20170203T162132_015121_018B9A_1380_conversion_matrices.nc
├── S1A_IW_SLC__1SDV_20170203T162106_20170203T162132_015121_018B9A_1380.zip
├── topsApp.xml
├── window_chip_size_max.tif
├── window_chip_size_min.tif
├── window_location.tif
├── window_offset.tif
├── window_rdr_off2vel_x_vec.tif
├── window_rdr_off2vel_y_vec.tif
├── window_scale_factor.tif
├── window_search_range.tif
└── window_stable_surface_mask.tif
```

JPL is checking the actual values produced for us.