### PR TITLE
Dropped Support for Python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0]
+### Removed
+* Support for Python 3.8 has been dropped.
 
 ## [0.18.0]
 ### Added

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - boto3
   - botocore
-  - python>=3.8,<3.10  # Top pin to fix ISCE2 incompatibility: https://github.com/isce-framework/isce2/issues/458
+  - python>=3.9,<3.10  # Top pin to fix ISCE2 incompatibility: https://github.com/isce-framework/isce2/issues/458
   - pip
   # For packaging, and testing
   - build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyp3_autorift"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name="ASF APD/Tools Team", email="uaf-asf-apd@alaska.edu"},
 ]
@@ -17,9 +17,7 @@ classifiers=[
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
     'boto3',


### PR DESCRIPTION
The only version available now is 3.9, since there is no support for 3.10.