### PR TITLE
Ensure all encoding attributes are carried over when cropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.18.0]
 ### Added
 * The Sentinel-1 correction workflow will now calculate and write the M11/M12 conversion matrices to a netCDF file.
+
+### Fixed
+* `hyp3_autorift.crop` will now preserve the `add_offset` and `scale_factor` encoding attributes for all variables, and in particular, for the M11/M12 conversion matrices. 
+
 ### Removed
 * Support for Python 3.8 has been dropped.
 


### PR DESCRIPTION
For Sentinel-1 granules, the M11/M12 variables lost their `scale_factor` and `add_offset` attributes when cropping, leading to corrupted data. This ensures those attributes are preserved. 

Refs:
* https://docs.xarray.dev/en/stable/user-guide/io.html#reading-encoded-data
* https://docs.xarray.dev/en/stable/user-guide/io.html#writing-encoded-data

To test you can download this uncropped S1 product:
```
aws s3 ls --no-sign-request s3://jhk-shenanigans/ITS_LIVE/crop/S1A_IW_SLC__1SDV_20170203T162106_20170203T162132_015121_018B9A_1380_X_S1A_IW_SLC__1SDV_20170215T162105_20170215T162133_015296_019127_6E1E_G0120V02_P099_IL_ASF_OD.nc
```
and then run:
```python
from pathlib import Path

from hyp3_autorift.crop import crop_netcdf_product

netcdf_file = Path('S1A_IW_SLC__1SDV_20170203T162106_20170203T162132_015121_018B9A_1380_X_S1A_IW_SLC__1SDV_20170215T162105_20170215T162133_015296_019127_6E1E_G0120V02_P099_IL_ASF_OD.nc')

cropped_file = crop_netcdf_product(netcdf_file)
```

You should see a `scale_factor` and `add_offset` attribute for the M11/M12 variables (easiest to check with `ncdump -h`) using this branch, and not using the develop branch.