### PR TITLE
check aws s3 for sentinel-2 scenes prior to checking google cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0]
+### Changed
+* Fetch Sentinel-2 scenes from AWS S3 (if present); otherwise continue to fetch from Google Cloud Storage.  
+
 ## [0.20.0]
 ### Changed
 * The M11/M12 variables produced by the hyp3_autorift and s1_correction workflows will be written as `float32` instead of the previous compressed `int16` variables that did not take advantage of the full dynamic range and thus lost a significant amount of precision.

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -108,7 +108,13 @@ def get_s2_manifest(scene_name):
     return response.text
 
 
-def get_s2_path(manifest_text: str, scene_name: str) -> str:
+def get_s2_path(scene_name: str) -> str:
+    bucket = 'its-live-project'
+    key = f's2-cache/{scene_name}_B08.jp2'
+    if s3_object_is_accessible(bucket, key):
+        return f'/vsis3/{bucket}/{key}'
+
+    manifest_text = get_s2_manifest(scene_name)
     root = ET.fromstring(manifest_text)
     elements = root.findall(".//fileLocation[@locatorType='URL'][@href]")
     hrefs = [element.attrib['href'] for element in elements if
@@ -140,8 +146,7 @@ def get_raster_bbox(path: str):
 
 
 def get_s2_metadata(scene_name):
-    manifest = get_s2_manifest(scene_name)
-    path = get_s2_path(manifest, scene_name)
+    path = get_s2_path(scene_name)
     bbox = get_raster_bbox(path)
     acquisition_start = datetime.strptime(scene_name.split('_')[2], '%Y%m%dT%H%M%S')
 


### PR DESCRIPTION
Note that GDAL doesn't support AWS profiles that reference a `role_arn` in `.aws/config`, e.g. 

```
[profile foo]
region = us-west-2
source_profile = default
role_arn = arn:aws:iam::123456789012:role/OrganizationAccountAccessRole
```

When using such a profile, `s3_object_is_accessible` may return True (because it uses boto3), but `get_raster_bbox` would immediately fail with `RuntimeError: Access Denied` (because it uses gdal).