### PR TITLE
upgrade to mypy action v0.15.0

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,4 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.14.0
 
   call-mypy-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ warn_unused_ignores = true
 warn_unreachable = true
 strict_equality = true
 check_untyped_defs = true
+install_types = true
+non_interactive = true
+pretty = true
+disable_error_code = ["import-untyped"]
 exclude = ["/vend/"]
 
 [[tool.mypy.overrides]]

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -32,8 +32,8 @@ def get_s1_primary_polarization(granule_name):
 
 
 def process_sentinel1_with_isce2(reference, secondary, parameter_file):
-    import isce  # noqa
-    from topsApp import TopsInSAR
+    import isce  # noqa: F401, I001
+    from topsApp import TopsInSAR  # type: ignore[import-not-found]
     from hyp3_autorift.vend.testGeogrid_ISCE import loadMetadata, runGeogrid
     from hyp3_autorift.vend.testautoRIFT_ISCE import generateAutoriftProduct
 
@@ -438,9 +438,9 @@ def bounding_box(safe, priority='reference', polarization='hh', orbits='Orbits',
         lat_limits: list containing the [minimum, maximum] longitudes
     """
     import isce  # noqa: F401
-    from contrib.geo_autoRIFT.geogrid import Geogrid
-    from isceobj.Orbit.Orbit import Orbit
-    from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
+    from contrib.geo_autoRIFT.geogrid import Geogrid  # type: ignore[import-not-found]
+    from isceobj.Orbit.Orbit import Orbit  # type: ignore[import-not-found]
+    from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1  # type: ignore[import-not-found]
 
     frames = []
     for swath in range(1, 4):
@@ -501,8 +501,8 @@ def bounding_box(safe, priority='reference', polarization='hh', orbits='Orbits',
 
 def prep_isce_dem(input_dem, lat_limits, lon_limits, isce_dem=None):
     import isce  # noqa: F401
-    import isceobj
-    from contrib.demUtils import createDemStitcher
+    import isceobj  # type: ignore[import-not-found]
+    from contrib.demUtils import createDemStitcher  # type: ignore[import-not-found]
 
     if isce_dem is None:
         seamstress = createDemStitcher()


### PR DESCRIPTION
`mypy` can't find several libraries:

```
src/hyp3_autorift/s1_isce2.py:36: error: Cannot find implementation or library stub for module named "topsApp"  [import-not-found]
        from topsApp import TopsInSAR
    ^
src/hyp3_autorift/s1_isce2.py:441: error: Cannot find implementation or library stub for module named "contrib.geo_autoRIFT.geogrid"  [import-not-found]
        from contrib.geo_autoRIFT.geogrid import Geogrid
    ^
src/hyp3_autorift/s1_isce2.py:442: error: Cannot find implementation or library stub for module named "isceobj.Orbit.Orbit"  [import-not-found]
        from isceobj.Orbit.Orbit import Orbit
    ^
src/hyp3_autorift/s1_isce2.py:443: error: Cannot find implementation or library stub for module named "isceobj.Sensor.TOPS.Sentinel1"  [import-not-found]
        from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
    ^
src/hyp3_autorift/s1_isce2.py:443: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
src/hyp3_autorift/s1_isce2.py:504: error: Cannot find implementation or library stub for module named "isceobj"  [import-not-found]
        import isceobj
    ^
src/hyp3_autorift/s1_isce2.py:505: error: Cannot find implementation or library stub for module named "contrib.demUtils"  [import-not-found]
        from contrib.demUtils import createDemStitcher
    ^
Found 6 errors in 1 file (checked 17 source files)
```

I also can't execute these imports within the mamba environment. How are those libraries installed?