### PR TITLE
Update CODEOWNERS to facilitate x-team collaboration 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # These owners will be requested for review when someone opens a pull request.
-*       @ASFHyP3/plugins
-
+*       @ASFHyP3/Tools @ASFHyP3/SciDev


### PR DESCRIPTION
Tools and SciDev, I expect, will collaborate on this repository since this plugin is available in EDC (HyP3 production) and is owned by the ITS_LIVE project.

Notably, I do not expect or want to require approvals from both teams; this is just to facilitate communication. One approval from anyone on either of these three teams should generally be sufficient.

Parent tracking issue is here: https://github.com/ASFHyP3/.github-private/issues/7