### PR TITLE
Fixes and Updates for ISCE3 Workflow

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -16,12 +16,12 @@ jobs:
     with:
       local_package_name: hyp3_autorift
       python_versions: >-
-        ["3.9"]
+        ["3.10"]
 
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.17.1
     with:
-      python_version: '3.9'
+      python_version: '3.10'
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - boto3
   - botocore
-  - python>=3.9
+  - python>=3.10
   - pip
   # For packaging, and testing
   - pillow>=7.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - python>=3.10
   - pip
   # For packaging, and testing
+  - mypy
   - pillow>=7.0
   - pluggy
   - pytest
@@ -15,8 +16,10 @@ dependencies:
   - pytest-cov
   - pytest-order
   - responses
+  - ruff
   - setuptools>=61
   - setuptools_scm>=6.2
+  - ruff
   # For running
   - eigen
   - gdal>=3

--- a/environment_isce2.yml
+++ b/environment_isce2.yml
@@ -14,11 +14,13 @@ dependencies:
   - flake8-import-order
   - flake8-blind-except
   - flake8-builtins
+  - mypy
   - pillow
   - pytest
   - pytest-console-scripts
   - pytest-cov
   - responses
+  - ruff
   - setuptools>=61
   - setuptools_scm>=6.2
   # For running

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ lines-after-imports = 2
 
 [tool.mypy]
 python_version = "3.10"
+ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ lines-after-imports = 2
 "tests/*" = ["D100", "D103", "ANN"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -344,16 +344,16 @@ def get_opendata_prefix(file: Path):
 
 
 def process(
-    reference: str,
-    secondary: str,
+    reference: str | list[str],
+    secondary: str | list[str],
     parameter_file: str = DEFAULT_PARAMETER_FILE,
     naming_scheme: Literal['ITS_LIVE_OD', 'ITS_LIVE_PROD'] = 'ITS_LIVE_OD',
 ) -> Tuple[Path, Path, Path]:
     """Process a Sentinel-1, Sentinel-2, or Landsat-8 image pair
 
     Args:
-        reference: Name of the reference Sentinel-1, Sentinel-2, or Landsat-8 Collection 2 scene
-        secondary: Name of the secondary Sentinel-1, Sentinel-2, or Landsat-8 Collection 2 scene
+        reference: Name of the reference Sentinel-1 (or list of bursts), Sentinel-2, or Landsat-8 Collection 2 scene
+        secondary: Name of the secondary Sentinel-1 (or list of bursts), Sentinel-2, or Landsat-8 Collection 2 scene
         parameter_file: Shapefile for determining the correct search parameters by geographic location
         naming_scheme: Naming scheme to use for product files
 

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -523,8 +523,12 @@ def main():
         help='Naming scheme to use for product files',
     )
     parser.add_argument('granules', type=nullable_granule_list, nargs='+', help='Granule pair to process')
-    parser.add_argument('--reference', type=nullable_granule_list, default=[], nargs='+', help='List of reference scenes"')
-    parser.add_argument('--secondary', type=nullable_granule_list, default=[], nargs='+', help='List of secondary scenes"')
+    parser.add_argument(
+        '--reference', type=nullable_granule_list, default=[], nargs='+', help='List of reference scenes"'
+    )
+    parser.add_argument(
+        '--secondary', type=nullable_granule_list, default=[], nargs='+', help='List of secondary scenes"'
+    )
     args = parser.parse_args()
 
     granules = [item for sublist in args.granules for item in sublist]
@@ -560,7 +564,7 @@ def main():
     else:
         if get_datetime(reference[0]) < get_datetime(secondary[0]):
             reference, secondary = secondary, reference
-        
+
         product_file, browse_file, thumbnail_file = process(
             reference, secondary, parameter_file=args.parameter_file, naming_scheme=args.naming_scheme
         )

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -205,7 +205,7 @@ def get_datetime(scene_name):
     raise ValueError(f'Unsupported scene format: {scene_name}')
 
 
-def get_platform(scene: str) -> str:
+def get_platform(scene: str | list[str]) -> str:
     if 'BURST' in scene or isinstance(scene, list):
         return 'S1-BURST'
     if scene.startswith('S1'):
@@ -372,12 +372,16 @@ def process(
     if platform == 'S1-SLC':
         from hyp3_autorift.s1_isce3 import process_sentinel1_slc_isce3
 
+        assert isinstance(reference, str) and isinstance(secondary, str)
+
         netcdf_file = process_sentinel1_slc_isce3(reference, secondary)
     elif platform == 'S1-BURST':
         from hyp3_autorift.s1_isce3 import process_sentinel1_burst_isce3
 
         netcdf_file = process_sentinel1_burst_isce3(reference, secondary)
     else:
+        assert isinstance(reference, str) and isinstance(secondary, str)
+
         # Set config and env for new CXX threads in Geogrid/autoRIFT
         gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')
         os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -522,7 +522,7 @@ def main():
         choices=['ITS_LIVE_OD', 'ITS_LIVE_PROD'],
         help='Naming scheme to use for product files',
     )
-    parser.add_argument('granules', type=nullable_granule_list, nargs='+', help='Granule pair to process')
+    parser.add_argument('granules', type=nullable_granule_list, nargs='*', help='Granule pair to process')
     parser.add_argument(
         '--reference', type=nullable_granule_list, default=[], nargs='+', help='List of reference scenes"'
     )

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -555,7 +555,7 @@ def main():
     )
 
     if has_granules:
-        g1, g2 = sorted(args.granules, key=get_datetime)
+        g1, g2 = sorted(granules, key=get_datetime)
 
         product_file, browse_file, thumbnail_file = process(
             g1, g2, parameter_file=args.parameter_file, naming_scheme=args.naming_scheme

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -562,7 +562,7 @@ def main():
         )
 
     else:
-        if get_datetime(reference[0]) < get_datetime(secondary[0]):
+        if get_datetime(reference[0]) > get_datetime(secondary[0]):
             reference, secondary = secondary, reference
 
         product_file, browse_file, thumbnail_file = process(

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -528,10 +528,10 @@ def main():
     )
     parser.add_argument('granules', type=nullable_granule_list, nargs='*', help='Granule pair to process')
     parser.add_argument(
-        '--reference', type=nullable_granule_list, default=[], nargs='+', help='List of reference scenes"'
+        '--reference', type=nullable_granule_list, default=[], nargs='+', help='List of reference S1-BURST scenes"'
     )
     parser.add_argument(
-        '--secondary', type=nullable_granule_list, default=[], nargs='+', help='List of secondary scenes"'
+        '--secondary', type=nullable_granule_list, default=[], nargs='+', help='List of secondary S1-BURST scenes"'
     )
     args = parser.parse_args()
 
@@ -544,15 +544,17 @@ def main():
 
     if not (has_granules or has_ref_sec):
         parser.error('Must provide either `granules` or `--reference` and `--secondary`.')
-
     if has_granules and has_ref_sec:
         parser.error('Must provide granules OR --reference and --secondary, not both.')
-
     if has_granules and len(granules) != 2:
         parser.error('Must provide exactly two granules')
-
     if len(reference) != len(secondary):
         parser.error('Must provide the same number of reference and secondary scenes.')
+    if has_ref_sec:
+        check_ref = ['BURST' not in scene for scene in reference]
+        check_sec = ['BURST' not in scene for scene in secondary]
+        if sum(check_ref) or sum(check_sec):
+            parser.error('Reference and Secondary lists are only supported for Sentinel-1 Bursts.')
 
     logging.basicConfig(
         format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO

--- a/src/hyp3_autorift/s1_isce2.py
+++ b/src/hyp3_autorift/s1_isce2.py
@@ -33,7 +33,7 @@ def get_s1_primary_polarization(granule_name):
 
 def process_sentinel1_with_isce2(reference, secondary, parameter_file):
     import isce  # noqa: F401, I001
-    from topsApp import TopsInSAR  # type: ignore[import-not-found]
+    from topsApp import TopsInSAR
     from hyp3_autorift.vend.testGeogrid_ISCE import loadMetadata, runGeogrid
     from hyp3_autorift.vend.testautoRIFT_ISCE import generateAutoriftProduct
 
@@ -438,9 +438,9 @@ def bounding_box(safe, priority='reference', polarization='hh', orbits='Orbits',
         lat_limits: list containing the [minimum, maximum] longitudes
     """
     import isce  # noqa: F401
-    from contrib.geo_autoRIFT.geogrid import Geogrid  # type: ignore[import-not-found]
-    from isceobj.Orbit.Orbit import Orbit  # type: ignore[import-not-found]
-    from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1  # type: ignore[import-not-found]
+    from contrib.geo_autoRIFT.geogrid import Geogrid
+    from isceobj.Orbit.Orbit import Orbit
+    from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
 
     frames = []
     for swath in range(1, 4):
@@ -501,8 +501,8 @@ def bounding_box(safe, priority='reference', polarization='hh', orbits='Orbits',
 
 def prep_isce_dem(input_dem, lat_limits, lon_limits, isce_dem=None):
     import isce  # noqa: F401
-    import isceobj  # type: ignore[import-not-found]
-    from contrib.demUtils import createDemStitcher  # type: ignore[import-not-found]
+    import isceobj
+    from contrib.demUtils import createDemStitcher
 
     if isce_dem is None:
         seamstress = createDemStitcher()

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -37,7 +37,7 @@ def process_sentinel1_burst_isce3(reference, secondary):
 
         swaths = [int(g.split('_')[2][2]) for g in reference]
 
-        return process_sentinel1_slc_isce3(
+        return process_slc(
             safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_ids_sec, swaths
         )
 

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -230,14 +230,14 @@ def merge_swaths(safe, orbit, is_ref=True, swaths=[1, 2, 3]):
         # TODO: min(swaths) was previously 1
         #       Does this intentially not support passing something like swaths=[2, 3]?
         if swath > min(swaths):
-            rng_offset = (burst_start_rng - bursts_from_swath[0].starting_range) / bursts_from_swath[
+            rng_offset = (burst_start_rng - bursts[0].starting_range) / bursts_from_swath[
                 0
             ].range_pixel_spacing
             rng_offsets.append(int(np.round(rng_offset)))
+            last_rng_samples = num_rng_samples
 
     first_start_rng = bursts[0].starting_range
     last_start_rng = bursts[-1].starting_range
-    last_rng_samples = bursts[-1].shape[1]
     rng_pixel_spacing = bursts[0].range_pixel_spacing
 
     assert sensing_start and sensing_stop and rng_pixel_spacing

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -65,7 +65,7 @@ def process_burst(safe_ref, safe_sec, orbit_ref, orbit_sec, granule_ref, burst_i
     meta_s.sensingStart = meta_temp.sensingStart
     meta_s.sensingStop = meta_temp.sensingStop
 
-    lat_limits, lon_limits = bounding_box(safe_ref, orbit_ref, swaths=[swath])
+    lat_limits, lon_limits = bounding_box(safe_ref, orbit_ref, False, swaths=[swath])
 
     download_dem([lon_limits[0], lat_limits[0], lon_limits[1], lat_limits[1]])
 
@@ -117,7 +117,7 @@ def process_sentinel1_slc_isce3(slc_ref, slc_sec):
 
 
 def process_slc(safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_ids_sec, swaths=[1, 2, 3]):
-    lat_limits, lon_limits = bounding_box(safe_ref, orbit_ref, swaths=swaths)
+    lat_limits, lon_limits = bounding_box(safe_ref, orbit_ref, True, swaths=swaths)
 
     download_dem([lon_limits[0], lat_limits[0], lon_limits[1], lat_limits[1]])
 
@@ -497,7 +497,7 @@ def get_topsinsar_config():
     return config_data
 
 
-def bounding_box(safe, orbit_file, swaths=[1, 2, 3], epsg=4326):
+def bounding_box(safe, orbit_file, is_slc, swaths=[1, 2, 3], epsg=4326):
     """Determine the geometric bounding box of a Sentinel-1 image
 
     :param safe: Path to the Sentinel-1 SAFE zip archive
@@ -512,7 +512,7 @@ def bounding_box(safe, orbit_file, swaths=[1, 2, 3], epsg=4326):
     """
     from geogrid import GeogridRadar
 
-    if len(swaths) == 1:
+    if not is_slc:
         info = loadMetadata(safe, orbit_file, swath=swaths[0])
     else:
         info = loadMetadataSlc(safe, orbit_file, swaths=swaths)

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -270,6 +270,7 @@ def merge_swaths(safe, orbit, is_ref=True, swaths=[1, 2, 3]):
             cond = np.logical_and(np.abs(temp) == 0, np.logical_not(np.abs(slc_array) == 0))
             merged_array[az_offset:az_end_index, rng_offset:rng_end_index][cond] = slc_array[cond]
             temp = np.array([])
+        swath_index += 1
 
     write_slc_gdal(merged_array, output_path, tran, proj, total_rng_samples, total_az_samples)
 

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -39,9 +39,7 @@ def process_sentinel1_burst_isce3(reference, secondary):
 
         get_dem_for_safes(safe_ref, safe_sec)
 
-        return process_slc(
-            safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_ids_sec, swaths
-        )
+        return process_slc(safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_ids_sec, swaths)
 
     burst_id_ref = get_burst_id(safe_ref, reference, orbit_ref)
     burst_id_sec = get_burst_id(safe_sec, secondary, orbit_sec)
@@ -601,7 +599,7 @@ def write_yaml(safe, orbit_file, burst_id=None):
         output_folder = './output'
     else:
         s1_ref_file = os.path.abspath(glob.glob('./product/' + burst_id + '/*')[0])
-        burst_id_str =  '[' + burst_id + ']'
+        burst_id_str = '[' + burst_id + ']'
         bool_reference = 'False'
         product_folder = './product_sec'
         scratch_folder = './product_sec'

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -326,7 +326,7 @@ def get_burst_path(burst_filename):
     return glob.glob(glob.glob(burst_filename + '/*')[0] + '/*.slc')[0]
 
 
-def merge_bursts_in_swath(ref_bursts, ref_burst_files, sec_burst_files, swath):
+def merge_bursts_in_swath(ref_bursts, ref_burst_files, sec_burst_files, swath, top_burst_overlap=True):
     """Merges the bursts within the provided swath.
        The secondary bursts are merged according to the reference bursts's metadata.
 
@@ -384,11 +384,12 @@ def merge_bursts_in_swath(ref_bursts, ref_burst_files, sec_burst_files, swath):
             print(f'Burst Overlap: {burst_overlap}')
 
             def merge(burst_arr, prev_burst_arr):
-                current_slice = slice(burst.first_valid_line, burst.last_valid_line + 1)
-                previous_slice = slice(prev_burst.first_valid_line, prev_burst.last_valid_line + 1)
-                burst_subset = burst_arr[current_slice, :][: burst_overlap + 1, :]
-                prev_burst_subset = prev_burst_arr[previous_slice, :][-burst_overlap - 1 :, :]
-                return np.fmax(burst_subset, prev_burst_subset)[:-1]
+                if top_burst_overlap:
+                    current_slice = slice(burst.first_valid_line, burst.last_valid_line + 1)
+                    return burst_arr[current_slice, :][:burst_overlap, :]
+                else:
+                    previous_slice = slice(prev_burst.first_valid_line, prev_burst.last_valid_line + 1)
+                    return prev_burst_arr[previous_slice, :][-burst_overlap:, :]
 
             ref_merged_arr[merge_start_index : merge_start_index + burst_overlap, :] = merge(
                 burst_arr_ref, prev_burst_arr_ref

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -220,7 +220,9 @@ def merge_swaths(safe, orbit, is_ref=True, swaths=[1, 2, 3]):
         # TODO: min(swaths) was previously 1
         #       Does this intentially not support passing something like swaths=[2, 3]?
         if swath > min(swaths):
-            rng_offset = (burst_start_rng - bursts_from_swath[0].starting_range) / bursts_from_swath[0].range_pixel_spacing
+            rng_offset = (burst_start_rng - bursts_from_swath[0].starting_range) / bursts_from_swath[
+                0
+            ].range_pixel_spacing
             rng_offsets.append(int(np.round(rng_offset)))
 
     first_start_rng = bursts[0].starting_range
@@ -349,7 +351,9 @@ def merge_bursts_in_swath(bursts, burst_files, swath, outfile='output.slc', meth
             burst_end_index = burst.last_valid_line - burst.first_valid_line + 1
 
         burst_length = burst_end_index - burst_start_index
-        burst_arr = burst_arr[burst.first_valid_line : burst.last_valid_line + 1, :][burst_start_index:burst_end_index, :]
+        burst_arr = burst_arr[burst.first_valid_line : burst.last_valid_line + 1, :][
+            burst_start_index:burst_end_index, :
+        ]
         merged_arr[merge_start_index : merge_start_index + burst_length, :] = burst_arr
 
         merge_start_index += burst_length
@@ -379,11 +383,11 @@ def get_topsinsar_config():
         safes = glob.glob('*.zip')
         fechas_safes = [datetime.strptime(os.path.basename(file).split('_')[5], '%Y%m%dT%H%M%S') for file in safes]
 
-    safe_ref = safes[np.argmin(fechas_safes)]  # type: ignore[arg-type] 
+    safe_ref = safes[np.argmin(fechas_safes)]  # type: ignore[arg-type]
     orbit_path_ref = orbits[np.argmin(fechas_orbits)]  # type: ignore[arg-type]
 
-    safe_sec = safes[np.argmax(fechas_safes)]  # type: ignore[arg-type] 
-    orbit_path_sec = orbits[np.argmax(fechas_orbits)]  # type: ignore[arg-type] 
+    safe_sec = safes[np.argmax(fechas_safes)]  # type: ignore[arg-type]
+    orbit_path_sec = orbits[np.argmax(fechas_orbits)]  # type: ignore[arg-type]
 
     if len(glob.glob('*_ref*.slc')) > 0:
         swath = int(os.path.basename(glob.glob('*_ref*.slc')[0]).split('_')[2][2])

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -6,8 +6,6 @@ import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import time
-
 import numpy as np
 import rasterio
 import s1reader
@@ -281,7 +279,10 @@ def merge_swaths(safe_ref: str, orbit_ref: str, num_lines: int, num_samples: int
             rng_end_index = rng_offset + slc_array.shape[1]
 
             if slc == 'ref':
-                cond = np.logical_and(np.abs(merged_arr[az_offset:az_end_index, rng_offset:rng_end_index]) == 0, np.logical_not(np.abs(slc_array) == 0))
+                cond = np.logical_and(
+                    np.abs(merged_arr[az_offset:az_end_index, rng_offset:rng_end_index]) == 0,
+                    np.logical_not(np.abs(slc_array) == 0),
+                )
                 conds.append(cond)
             else:
                 cond = conds[swath_index]

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -423,7 +423,6 @@ def get_topsinsar_config():
     burst = None
     safe = None
 
-
     config_data = {}
     for name in ['reference', 'secondary']:
         # Find the first swath with data in it

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -251,7 +251,7 @@ def merge_swaths(safe, orbit, is_ref=True, swaths=[1, 2, 3]):
     swath_index = 0
     merged_array = np.zeros((total_az_samples, total_rng_samples), dtype=complex)
     for swath in swaths:
-        az_offset = int(np.round((sensing_starts[swath_index] - sensing_start).total_seconds() / az_time_interval))
+        az_offset = int(np.floor((sensing_starts[swath_index] - sensing_start).total_seconds() / az_time_interval))
         rng_offset = rng_offsets[swath_index]
 
         print(f'IW{swath} Range and Azimuth Offsets: {rng_offset} {az_offset}')

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -86,8 +86,8 @@ def process_sentinel1_slc_isce3(slc_ref, slc_sec):
 
     safe_ref = sorted(glob.glob('./*.zip'))[0]
     safe_sec = sorted(glob.glob('./*.zip'))[1]
-    orbit_ref = str(fetch_for_scene(slc_ref.stem))
-    orbit_sec = str(fetch_for_scene(slc_sec.stem))
+    orbit_ref = str(fetch_for_scene(slc_ref.split('.')[0]))
+    orbit_sec = str(fetch_for_scene(slc_sec.split('.')[0]))
     burst_ids_ref = get_burst_ids(safe_ref, orbit_ref)
     burst_ids_sec = get_burst_ids(safe_sec, orbit_sec)
 

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -35,7 +35,7 @@ def process_sentinel1_burst_isce3(reference, secondary):
         burst_ids_ref = [get_burst_id(safe_ref, g, orbit_ref) for g in reference]
         burst_ids_sec = [get_burst_id(safe_sec, g, orbit_sec) for g in secondary]
 
-        swaths = sorted([int(g.split('_')[2][2]) for g in reference])
+        swaths = set([int(g.split('_')[2][2]) for g in reference])
 
         get_dem_for_safes(safe_ref, safe_sec)
 

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -37,7 +37,9 @@ def process_sentinel1_burst_isce3(reference, secondary):
 
         swaths = [int(g.split('_')[2][2]) for g in reference]
 
-        return process_sentinel1_slc_isce3(safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_ids_sec, swaths)
+        return process_sentinel1_slc_isce3(
+            safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_ids_sec, swaths
+        )
 
     burst_id_ref = get_burst_id(safe_ref, reference, orbit_ref)
     burst_id_sec = get_burst_id(safe_sec, secondary, orbit_sec)

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -35,7 +35,7 @@ def process_sentinel1_burst_isce3(reference, secondary):
         burst_ids_ref = [get_burst_id(safe_ref, g, orbit_ref) for g in reference]
         burst_ids_sec = [get_burst_id(safe_sec, g, orbit_sec) for g in secondary]
 
-        swaths = [int(g.split('_')[2][2]) for g in reference]
+        swaths = sorted([int(g.split('_')[2][2]) for g in reference])
 
         get_dem_for_safes(safe_ref, safe_sec)
 

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -190,9 +190,9 @@ def merge_swaths(safe, orbit, is_ref=True, swaths=[1, 2, 3]):
     pol = getPol(safe, orbit)
 
     for swath in swaths:
-        merge_bursts_in_swath(swath, is_ref)
-
         bursts_from_swath = s1reader.load_bursts(safe, orbit, swath, pol)
+
+        merge_bursts_in_swath(bursts_from_swath, burst_files, swath)
 
         num_az_samples, num_rng_samples = bursts_from_swath.shape
         total_rng_samples += num_rng_samples
@@ -282,7 +282,7 @@ def get_azimuth_reference_offsets(bursts):
     return az_reference_offsets, start_index
 
 
-def merge_bursts_in_swath(bursts, burst_files, swath, pol, is_ref=True, outfile='output.slc', method='top'):
+def merge_bursts_in_swath(bursts, burst_files, swath, outfile='output.slc', method='top'):
     """
     Merge burst products into single file.
     Simple numpy based stitching

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -244,6 +244,7 @@ def merge_swaths(safe, orbit, is_ref=True, swaths=[1, 2, 3]):
     rng_pixel_spacing = bursts[0].range_pixel_spacing
 
     assert sensing_start and sensing_stop and rng_pixel_spacing
+
     total_rng_samples = last_rng_samples + int(np.round((last_start_rng - first_start_rng) / rng_pixel_spacing))
     total_az_samples = 1 + int(np.round((sensing_stop - sensing_start).total_seconds() / az_time_interval))
 
@@ -591,14 +592,14 @@ def write_yaml(safe, orbit_file, burst_id=None):
     if burst_id is None:
         s1_ref_file = ''
         burst_id_str = ''
-        bool_reference = True
+        bool_reference = 'True'
         product_folder = './product'
         scratch_folder = './scratch'
         output_folder = './output'
     else:
         s1_ref_file = os.path.abspath(glob.glob('./product/' + burst_id + '/*')[0])
         burst_id_str =  '[' + burst_id + ']'
-        bool_reference = False
+        bool_reference = 'False'
         product_folder = './product_sec'
         scratch_folder = './product_sec'
         output_folder = './output_sec'

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -417,18 +417,28 @@ def get_topsinsar_config():
     if len(glob.glob('*_ref*.slc')) > 0:
         swath = int(os.path.basename(glob.glob('*_ref*.slc')[0]).split('_')[2][2])
     else:
-        swath = 1
+        swath = None
 
     pol = getPol(safe_ref, orbit_path_ref)
+    burst = None
+    safe = None
+
 
     config_data = {}
     for name in ['reference', 'secondary']:
-        if name == 'reference':
-            burst = load_bursts(safe_ref, orbit_path_ref, swath, pol)[0]
-            safe = safe_ref
-        else:
-            burst = load_bursts(safe_sec, orbit_path_sec, swath, pol)[0]
-            safe = safe_sec
+        # Find the first swath with data in it
+        swath_range = [swath] if swath else [1, 2, 3]
+        for swath in swath_range:
+            try:
+                if name == 'reference':
+                    burst = load_bursts(safe_ref, orbit_path_ref, swath, pol)[0]
+                    safe = safe_ref
+                else:
+                    burst = load_bursts(safe_sec, orbit_path_sec, swath, pol)[0]
+                    safe = safe_sec
+            except:
+                continue
+            break
 
         sensing_start = burst.sensing_start
         length, width = burst.shape

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -31,12 +31,6 @@ def process_sentinel1_burst_isce3(reference, secondary):
     orbit_ref = str(fetch_for_scene(safe_ref.stem))
     orbit_sec = str(fetch_for_scene(safe_sec.stem))
 
-    # safe_ref = "S1A_IW_SLC__1SSH_20170221T204731_20170221T204732_015387_0193F6_6A78.SAFE"
-    # safe_sec = "S1A_IW_SLC__1SSH_20170221T204731_20170221T204732_015387_0193F6_6A78.SAFE"
-
-    # orbit_ref = "S1A_OPER_AUX_POEORB_OPOD_20210301T135718_V20170220T225942_20170222T005942.EOF"
-    # orbit_sec = "S1B_OPER_AUX_POEORB_OPOD_20210306T120402_V20170226T225942_20170228T005942.EOF"
-
     if isinstance(reference, list):
         burst_ids_ref = [get_burst_id(safe_ref, g, orbit_ref) for g in reference]
         burst_ids_sec = [get_burst_id(safe_sec, g, orbit_sec) for g in secondary]

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -37,6 +37,8 @@ def process_sentinel1_burst_isce3(reference, secondary):
 
         swaths = [int(g.split('_')[2][2]) for g in reference]
 
+        get_dem_for_safes(safe_ref, safe_sec)
+
         return process_slc(
             safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_ids_sec, swaths
         )
@@ -116,8 +118,8 @@ def process_slc(safe_ref, safe_sec, orbit_ref, orbit_sec, burst_ids_ref, burst_i
         write_yaml(safe_sec, orbit_sec, burst_id_sec)
         s1_cslc.run('s1_cslc.yaml', 'radar')
 
-    merge_swaths(safe_ref, orbit_ref)
-    merge_swaths(safe_sec, orbit_sec, is_ref=False)
+    merge_swaths(safe_ref, orbit_ref, swaths=swaths)
+    merge_swaths(safe_sec, orbit_sec, is_ref=False, swaths=swaths)
 
     meta_r = loadMetadataSlc(safe_ref, orbit_ref)
     meta_temp = loadMetadataSlc(safe_sec, orbit_sec)
@@ -247,8 +249,13 @@ def merge_swaths(safe, orbit, is_ref=True, swaths=[1, 2, 3]):
 
     merged_array = np.zeros((total_az_samples, total_rng_samples), dtype=complex)
     for swath in swaths:
-        az_offset = int(np.round((sensing_starts[swath - 1] - sensing_start).total_seconds() / az_time_interval))
-        rng_offset = rng_offsets[swath - 1]
+        if swath != min(swaths):
+            az_offset = int(np.round((sensing_starts[swath - 1] - sensing_start).total_seconds() / az_time_interval))
+            rng_offset = rng_offsets[swath - 1]
+        else:
+            az_offset = 0
+            rng_offset = 0
+
         print(f'IW{swath} Range and Azimuth Offsets: {rng_offset} {az_offset}')
 
         slc = 'swath_iw' + str(swath) + '.slc'

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -288,7 +288,9 @@ def merge_bursts_in_swath(bursts, burst_files, swath, outfile='output.slc', meth
     """
     num_bursts = len(bursts)
     az_time_interval = bursts[0].azimuth_time_interval
-    num_az_samples, num_rng_samples = bursts[0].shape
+    first_burst = glob.glob(glob.glob(burst_files[0] + '/*')[0] + '/*.slc')[0]
+    first_burst_arr, _, _ = read_slc_gdal(first_burst)
+    num_az_samples, num_rng_samples = first_burst_arr.shape
 
     last_burst_sensing_start = bursts[-1].sensing_start
     burst_length = timedelta(seconds=(num_az_samples - 1.0) * az_time_interval)

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -1,13 +1,10 @@
 import copy
 import glob
 import math
-import netrc
 import os
 import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
-from platform import system
-from typing import Tuple
 
 import numpy as np
 import rasterio
@@ -18,8 +15,8 @@ from dem_stitcher import stitch_dem
 from hyp3lib.fetch import download_file
 from hyp3lib.scene import get_download_url
 from osgeo import gdal
-from s1reader import s1_info
 from s1_orbits import fetch_for_scene
+from s1reader import s1_info
 
 import hyp3_autorift
 from hyp3_autorift import geometry, utils
@@ -31,8 +28,6 @@ from hyp3_autorift.vend.testautoRIFT import generateAutoriftProduct
 def process_sentinel1_burst_isce3(burst_granule_ref, burst_granule_sec, is_opera=False):
     safe_ref = download_burst(burst_granule_ref)
     safe_sec = download_burst(burst_granule_sec)
-    safe_granule_ref = os.path.basename(safe_ref).split('.')[0]
-    safe_granule_sec = os.path.basename(safe_sec).split('.')[0]
     orbit_ref = str(fetch_for_scene(safe_ref.stem))
     orbit_sec = str(fetch_for_scene(safe_sec.stem))
     burst_id_ref = get_burst_id(safe_ref, burst_granule_ref, orbit_ref)

--- a/src/hyp3_autorift/vend/netcdf_output.py
+++ b/src/hyp3_autorift/vend/netcdf_output.py
@@ -1324,22 +1324,24 @@ def loadMetadata(indir):
         safe = safes[np.argmax(fechas_safes)]
         orbit_path = orbits[np.argmax(fechas_orbits)]
 
+    pol = getPol(safe, orbit_path)
+
     if '_' in indir:
         swath = int(indir.split('_')[2][2])
-    else:
-        swath = 1 
-        
-    pol = getPol(safe, orbit_path)
-    
-    bursts = load_bursts(safe, orbit_path, swath, pol)
-    
-    if '_' in indir:
+        bursts = load_bursts(safe, orbit_path, swath, pol) 
         for bur in bursts:
             if int(bur.burst_id.subswath[2])==swath:
                 burst = bur
     else:
-        burst = bursts[0]
-        
+        # Find the first swath containing data
+        for swath in [1, 2, 3]:
+            try: 
+                bursts = load_bursts(safe, orbit_path, swath, pol) 
+                burst = bursts[0]
+            except:
+                continue
+            break
+
     return burst, burst.orbit_direction
 
 

--- a/src/hyp3_autorift/vend/testGeogrid_ISCE.py
+++ b/src/hyp3_autorift/vend/testGeogrid_ISCE.py
@@ -199,7 +199,7 @@ def loadMetadataSlc(safe,orbit_path,buffer=0,swaths=None):
         dt = bursts[0].azimuth_time_interval
         sensingStopt = burstst[-1].sensing_start + timedelta(seconds=(burstst[-1].shape[0]-1) * dt)
         sensingStartt = burstst[0].sensing_start
-        if swath==1:
+        if swath==min(swaths):
             info.prf = 1 / burstst[0].azimuth_time_interval
             info.sensingStart = sensingStartt
             info.startingRange = burstst[0].starting_range

--- a/src/hyp3_autorift/vend/testGeogrid_ISCE.py
+++ b/src/hyp3_autorift/vend/testGeogrid_ISCE.py
@@ -225,7 +225,7 @@ def loadMetadataSlc(safe,orbit_path,buffer=0,swaths=None):
     info.numberOfSamples = int( np.round( (info.farRange - info.startingRange)/info.rangePixelSize)) + 1  + 2 * buffer
     print('SIZE',info.numberOfLines,info.numberOfSamples)
     
-    info.orbit = getMergedOrbit(safe,orbit_path,2)
+    info.orbit = getMergedOrbit(safe, orbit_path, swaths[0])
 
     return info
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -14,10 +14,12 @@ from hyp3_autorift import process
 
 def test_get_platform():
     assert process.get_platform('S1_191569_IW1_20170703T204652_HV_1093-BURST') == 'S1-BURST'
-    assert process.get_platform([
-        'S1_191569_IW1_20170703T204652_HV_1093-BURST',
-        'S1_191569_IW2_20170703T204652_HV_1093-BURST'
-    ]) == 'S1-BURST'
+    assert (
+        process.get_platform(
+            ['S1_191569_IW1_20170703T204652_HV_1093-BURST', 'S1_191569_IW2_20170703T204652_HV_1093-BURST']
+        )
+        == 'S1-BURST'
+    )
     assert process.get_platform('S1A_IW_SLC__1SDV_20180605T233148_20180605T233215_022228_0267AD_48B2') == 'S1-SLC'
     assert process.get_platform('S2A_1UCR_20210124_0_L1C') == 'S2'
     assert process.get_platform('S2B_22WEB_20200913_0_L2A') == 'S2'

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -13,8 +13,12 @@ from hyp3_autorift import process
 
 
 def test_get_platform():
-    assert process.get_platform('S1B_IW_GRDH_1SSH_20201203T095903_20201203T095928_024536_02EAB3_6D81') == 'S1'
-    assert process.get_platform('S1A_IW_SLC__1SDV_20180605T233148_20180605T233215_022228_0267AD_48B2') == 'S1'
+    assert process.get_platform('S1_191569_IW1_20170703T204652_HV_1093-BURST') == 'S1-BURST'
+    assert process.get_platform([
+        'S1_191569_IW1_20170703T204652_HV_1093-BURST',
+        'S1_191569_IW2_20170703T204652_HV_1093-BURST'
+    ]) == 'S1-BURST'
+    assert process.get_platform('S1A_IW_SLC__1SDV_20180605T233148_20180605T233215_022228_0267AD_48B2') == 'S1-SLC'
     assert process.get_platform('S2A_1UCR_20210124_0_L1C') == 'S2'
     assert process.get_platform('S2B_22WEB_20200913_0_L2A') == 'S2'
     assert process.get_platform('S2A_11UNA_20201203_0_L2A') == 'S2'


### PR DESCRIPTION
This PR adds support for an ISCE3 based multi-burst workflow.

Unit tests are passing locally, but will not run in actions without Mario's autoRIFT changes having been merged.

TODO (NOT PART OF THIS PR):
- Mario's autoRIFT changes need to be merged, so that autoRIFT need not be installed manually.
- Add autoRIFT back to the environment file and make sure it installs properly.
- Remove the manual installation of autoRIFT from the Dockfile.
- The COMPASS library is released with Mario's changes.
- Add COMPASS back to the environment file and remove the manual install.
- Remove the `# type: ignore[import-not-found]` that were related to ISCE and autoRIFT if they are no longer needed after fixing the installs for autoRIFT and COMPASS.
