### PR TITLE
Fix for Not Finding Polarization

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -54,5 +54,6 @@ dependencies:
   - tifffile>=2024.0.0
   - xarray
   - yamale>=4.0
+  - cxx-compiler
   - pip:
       - git+https://github.com/andrewplayer3/autoRIFT

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -569,9 +569,9 @@ def main():
         parser.error('Must provide exactly two granules.')
 
     if has_granules:
-        granules = sort_ref_sec([granules[0]], [granules[1]])
-        reference = granules[0]
-        secondary = granules[1]
+        granules_sorted = sort_ref_sec([granules[0]], [granules[1]])
+        reference = granules_sorted[0]
+        secondary = granules_sorted[1]
     else:
         reference, secondary = sort_ref_sec(reference, secondary)
 

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -569,8 +569,11 @@ def main():
         parser.error('Must provide exactly two granules.')
 
     if has_granules:
-        reference = [granules[0]]
-        secondary = [granules[1]]
+        granules = sort_ref_sec([granules[0]], [granules[1]])
+        reference = granules[0]
+        secondary = granules[1]
+    else:
+        reference, secondary = sort_ref_sec(reference, secondary)
 
     if len(reference) != len(secondary):
         parser.error('Must provide the same number of reference and secondary scenes.')

--- a/src/hyp3_autorift/vend/testGeogridOptical.py
+++ b/src/hyp3_autorift/vend/testGeogridOptical.py
@@ -91,6 +91,7 @@ def getPol(safe, orbit_path):
             return pol
         except:
             pass
+    raise ValueError(f"No polarization information found for {safe}.")
 
 
 def getMergedOrbit(safe,orbit_path,swath):


### PR DESCRIPTION
Not properly sorting the granules by datetime causes the wrong orbits to be passed to s1reader, which leads to pol being None. This PR adds sorting to fix this. It also adds `cxx-compiler` which allows for `autoRIFT` to be built on systems without a proper compiler, such as MacOS.