### PR TITLE
Align Chunks Spatially over Time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,6 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# MacOS Directory File
+**/.DS_Store


### PR DESCRIPTION
This PR changes how the netCDF products are chunked and cropped such that all products in the same frame should have aligned chunks of fixed sizes. This means that the geographic position of an index within a given chunk should be the same for a stack of products within that frame.