### PR TITLE
Release v0.24.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: prefix-dev/setup-pixi@v0.8.11
+      - uses: prefix-dev/setup-pixi@v0.8.14
         with:
           activate-environment: true
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.8.11
+      - uses: prefix-dev/setup-pixi@v0.8.14
         with:
           activate-environment: true
 
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.8.11
+      - uses: prefix-dev/setup-pixi@v0.8.14
         with:
           activate-environment: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.8.11
+      - uses: prefix-dev/setup-pixi@v0.8.14
 
       - name: Run pixi tests task
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0]
+
+### Added
+* When the `--publish-bucket` option is provided, the publication prefix determined from the netCDF4 product file will be saved to a `publish_info.json` file and uploaded to the S3 bucket specified by `--bucket` if provided.
+
 ## [0.23.0]
 
 > [!IMPORTANT]

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -338,7 +338,7 @@ def point_to_region(lat: float, lon: float) -> str:
     return f'{nw_hemisphere}{region_lat:02d}{ew_hemisphere}{region_lon:03d}'
 
 
-def get_opendata_prefix(file: Path):
+def get_opendata_prefix(file: Path) -> str:
     # filenames have form GRANULE1_X_GRANULE2
     scene = file.name.split('_X_')[0]
 
@@ -347,6 +347,20 @@ def get_opendata_prefix(file: Path):
     region = point_to_region(lat, lon)
 
     return '/'.join(['velocity_image_pair', PLATFORM_SHORTNAME_LONGNAME_MAPPING[platform_shortname], 'v02', region])
+
+
+def save_publication_info(bucket: str, prefix: str, name: str) -> Path:
+    publish_info_file = Path.cwd() / 'publish_info.json'
+    publish_info_file.write_text(
+        json.dumps(
+            {
+                'bucket': bucket,
+                'prefix': prefix,
+                'name': name,
+            }
+        )
+    )
+    return publish_info_file
 
 
 def process(
@@ -637,3 +651,7 @@ def main():
         utils.upload_file_to_s3_with_publish_access_keys(product_file, args.publish_bucket, prefix)
         utils.upload_file_to_s3_with_publish_access_keys(browse_file, args.publish_bucket, prefix)
         utils.upload_file_to_s3_with_publish_access_keys(thumbnail_file, args.publish_bucket, prefix)
+
+        if args.bucket:
+            publish_info_file = save_publication_info(args.bucket, prefix, product_file.name)
+            upload_file_to_s3(publish_info_file, args.bucket, args.bucket_prefix)


### PR DESCRIPTION
## [0.24.0]

### Added
* When the `--publish-bucket` option is provided, the publication prefix determined from the netCDF4 product file will be saved to a `publish_info.json` file and uploaded to the S3 bucket specified by `--bucket` if provided.