### PR TITLE
Add time dimension when missing from dataset while cropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.25.0]
 
 ### Changed
-* The netCDF products are now padded and chunked such that all products from the same frame should have aligned chunks, and the chunks now have a fixed size.
+* `crop.py` will now ensure that the netCDF products will:
+  * be padded and chunked such that all products from the same frame should have aligned chunks, and the chunks now have a fixed size.
+  * have an unlimited time dimension with the center date as the (sole) value to allows stacking of products.
 
 ### Fixed
 * The publication bucket (`--publish-bucket`) is saved in the `publish_info.json`, not the HyP3 content bucket (`--bucket`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `pixi-pycharm` was added to the conda-forge dependencies to support better development environment integration when using PyCharm.
 * A short description of setting up pixi in VS Code and Pycharm was added the to README
 
+### Changed
+* `crop.py` will now ensure that the netCDF products will have an unlimited time dimension with the center date as the (sole) value to allows stacking of products.
+
 ### Fixed
 * The `crop_netcdf_product` console script entrypoint now uses `-` prefixed optional arguments instead of `+`.
 * `crop.py` now specifies the xarray engine when opening the netCDF prodcuts for cropping.
@@ -20,9 +23,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.25.0]
 
 ### Changed
-* `crop.py` will now ensure that the netCDF products will:
-  * be padded and chunked such that all products from the same frame should have aligned chunks, and the chunks now have a fixed size.
-  * have an unlimited time dimension with the center date as the (sole) value to allows stacking of products.
+* The netCDF products are now padded and chunked such that all products from the same frame should have aligned chunks, and the chunks now have a fixed size.
 
 ### Fixed
 * The publication bucket (`--publish-bucket`) is saved in the `publish_info.json`, not the HyP3 content bucket (`--bucket`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     'numpy>=1.20',
     'pandas>=1.4',
     'pyproj>=3.3',
+    'python-dateutil',
     'requests>=2.0',
     'scipy>=1.0',
     'xarray',
@@ -150,6 +151,7 @@ numpy = "==1.26.0"
 opencv = "*"
 pandas = ">=1.4"
 pyproj = ">=3.3"
+python-dateutil = "*"
 requests = ">=2.0"
 scipy = ">=1.0"
 xarray = "*"
@@ -168,6 +170,7 @@ ruamel = "*"
 yamale = "*"
 backoff = "*"
 pysolid = "*"
+# For PyCharm IDE integration
 pixi-pycharm = ">=0.0.8,<0.0.9"
 
 [tool.pixi.target.linux-64.dependencies]

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -142,13 +142,13 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
 
         if 'time' not in cropped_ds.coords:
             date_center = np.datetime64(parse_dt(cropped_ds['img_pair_info'].date_center))
-            gps_epoch = np.datetime64('1980-01-06T00:00:00Z')
-            delta = (date_center - gps_epoch) / np.timedelta64(1, 's')
+            gps_epoch = '1980-01-06T00:00:00Z'
+            delta = (date_center - np.datetime64(gps_epoch)) / np.timedelta64(1, 's')
             cropped_ds = cropped_ds.assign_coords(time=delta)
             cropped_ds = cropped_ds.expand_dims(dim='time', axis=0)
             cropped_ds['time'].attrs = {
                 'standard_name': 'time_coordinate',
-                'description': 'mid-date of the acquisitions in seconds since 1980-01-06 00:00:00Z',
+                'description': f'mid-date of the acquisitions in seconds since {gps_epoch}',
                 'calendar': 'proleptic_gregorian',
             }
 

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -114,7 +114,7 @@ def numeric_hash(data: Hashable, n_digits: int = 6) -> int:
     Returns:
         The numeric hash value
     """
-    return hash(data) % (10 ** n_digits)
+    return hash(data) % (10**n_digits)
 
 
 def crop_netcdf_product(netcdf_file: Path) -> Path:
@@ -200,7 +200,7 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
                 'units': time_units,
                 'calendar': calendar,
                 'microseconds_added': jitter,
-                'microseconds_added_description': '6-digit numeric hash of the filename.'
+                'microseconds_added_description': '6-digit numeric hash of the filename.',
             }
 
         cropped_ds['mapping'] = ds['mapping']

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -179,7 +179,7 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
             # and (2) isn't unique for S2 tiles.
             #
             # So, instead, let's add microseconds computed as a numeric hash of the input filename (will be unique) to
-            # "jitter" in the time dimension description.
+            # "jitter" the mid-date and record it in the time attributes.
             jitter = numeric_hash(netcdf_file.name)
 
             # time_units and calendar should be the same as TIME_UNITS and CALENDAR,

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -148,7 +148,7 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
             cropped_ds = cropped_ds.expand_dims(dim='time', axis=0)
             cropped_ds['time'].attrs = {
                 'standard_name': 'time_coordinate',
-                'description': 'mid-date of the aquisition in seconds since 1980-01-06 00:00:00Z',
+                'description': 'mid-date of the acquisitions in seconds since 1980-01-06 00:00:00Z',
                 'calendar': 'proleptic_gregorian',
             }
 

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -38,6 +38,7 @@ import pyproj
 import xarray as xr
 from dateutil.parser import parse as parse_dt
 
+
 ENCODING_ATTRS = ['_FillValue', 'dtype', 'zlib', 'complevel', 'shuffle', 'add_offset', 'scale_factor']
 CHUNK_SIZE = 512
 PIXEL_SIZE = 120

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -141,12 +141,14 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
         cropped_ds.drop_vars('mapping')
 
         if 'time' not in cropped_ds.coords:
-            date_center = parse_dt(cropped_ds['img_pair_info'].date_center)
-            cropped_ds = cropped_ds.assign_coords(time=date_center)
+            date_center = np.datetime64(parse_dt(cropped_ds['img_pair_info'].date_center))
+            gps_epoch = np.datetime64('1980-01-06T00:00:00Z')
+            delta = (date_center - gps_epoch) / np.timedelta64(1, 's')
+            cropped_ds = cropped_ds.assign_coords(time=delta)
             cropped_ds = cropped_ds.expand_dims(dim='time', axis=0)
             cropped_ds['time'].attrs = {
                 'standard_name': 'time_coordinate',
-                'description': 'mid date of the image pair aquisition dates',
+                'description': 'mid-date of the aquisition in seconds since 1980-01-06 00:00:00Z',
                 'calendar': 'proleptic_gregorian',
             }
 

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -174,7 +174,7 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
             # but this ensures we use exactly what xarray encodes
             # see: https://docs.xarray.dev/en/latest/internals/time-coding.html#cf-time-encoding
             time, time_units, calendar = xr.coding.times.encode_cf_datetime(
-                date_center + timedelta(microseconds=jitter), TIME_UNITS, CALENDAR, dtype=np.float64
+                date_center + timedelta(microseconds=jitter), TIME_UNITS, CALENDAR, dtype=np.dtype('float64')
             )
 
             cropped_ds = cropped_ds.assign_coords(time=time)

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -114,7 +114,7 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
             ds = ds.expand_dims(dim='time', axis=0)
             ds['time'].attrs = {
                 'standard_name': 'time_coordinate',
-                'description': 'mid date of the image pair aquisition dates'
+                'description': 'mid date of the image pair aquisition dates',
             }
 
         # this will drop X/Y coordinates, so drop non-None values just to get X/Y extends

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -49,6 +49,7 @@ GPS_EPOCH = '1980-01-06T00:00:00Z'
 TIME_UNITS = f'seconds since {GPS_EPOCH}'
 CALENDAR = 'proleptic_gregorian'
 
+
 def get_aligned_min(val, grid_spacing):
     """Align a value with the nearest grid posting less than it"""
     nearest = np.floor(val / grid_spacing) * grid_spacing
@@ -180,8 +181,10 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
             cropped_ds = cropped_ds.expand_dims(dim='time', axis=0)
             cropped_ds['time'].attrs = {
                 'standard_name': 'time',
-                'description': f'mid-date between acquisition_date_img1 and acquisition_date_img2 with {jitter} '
-                               f'microseconds added to ensure uniqueness.',
+                'description': (
+                    f'mid-date between acquisition_date_img1 and acquisition_date_img2 with {jitter} '
+                    'microseconds added to ensure uniqueness.'
+                ),
                 'units': time_units,
                 'calendar': calendar,
             }

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -108,12 +108,16 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
         The Path to the cropped netCDF file
     """
     with xr.open_dataset(netcdf_file, engine='h5netcdf') as ds:
-        # this will drop X/Y coordinates, so drop non-None values just to get X/Y extends
         if 'time' not in ds.coords:
             date_center = parse_dt(ds['img_pair_info'].date_center)
             ds = ds.assign_coords(time=date_center)
             ds = ds.expand_dims(dim='time', axis=0)
+            ds['time'].attrs = {
+                'standard_name': 'time_coordinate',
+                'description': 'mid date of the image pair aquisition dates'
+            }
 
+        # this will drop X/Y coordinates, so drop non-None values just to get X/Y extends
         xy_ds = ds.where(ds.v.notnull()).dropna(dim='x', how='all').dropna(dim='y', how='all')
 
         x_values = xy_ds.x.values

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -167,13 +167,13 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
             # "jitter" in the time dimension description. Collisions should be improbable (1e-12 chance) though it's
             # theoretically possible to have drawn the same value, or the jitter to unluckily align the center_dates.
             rng = np.random.default_rng()
-            jitter = timedelta(microseconds=rng.integers(0, 1_000_000))
+            jitter = int(rng.integers(0, 1_000_000))
 
             # time_units and calendar should be the same as TIME_UNITS and CALENDAR,
             # but this ensures we use exactly what xarray encodes
             # see: https://docs.xarray.dev/en/latest/internals/time-coding.html#cf-time-encoding
             time, time_units, calendar = xr.coding.times.encode_cf_datetime(
-                date_center + jitter, TIME_UNITS, CALENDAR, dtype=np.float64
+                date_center + timedelta(microseconds=jitter), TIME_UNITS, CALENDAR, dtype=np.float64
             )
 
             cropped_ds = cropped_ds.assign_coords(time=time)

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -147,6 +147,7 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
             cropped_ds['time'].attrs = {
                 'standard_name': 'time_coordinate',
                 'description': 'mid date of the image pair aquisition dates',
+                'calendar': 'proleptic_gregorian',
             }
 
         cropped_ds['mapping'] = ds['mapping']

--- a/src/hyp3_autorift/image.py
+++ b/src/hyp3_autorift/image.py
@@ -42,6 +42,8 @@ COLOR_MAP = np.array(
 def make_browse(
     out_file: Path, data: np.ndarray, min_value: Optional[float] = None, max_value: Optional[float] = 625.0
 ) -> Path:
+    data = data[0]
+    
     data_values = COLOR_MAP[:, 0]
     pchip = PchipInterpolator(data_values, np.linspace(0, 1, len(data_values)))
     image = pchip(np.clip(data, min_value, max_value))

--- a/src/hyp3_autorift/image.py
+++ b/src/hyp3_autorift/image.py
@@ -43,7 +43,7 @@ def make_browse(
     out_file: Path, data: np.ndarray, min_value: Optional[float] = None, max_value: Optional[float] = 625.0
 ) -> Path:
     data = data[0]
-    
+
     data_values = COLOR_MAP[:, 0]
     pchip = PchipInterpolator(data_values, np.linspace(0, 1, len(data_values)))
     image = pchip(np.clip(data, min_value, max_value))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -8,6 +8,7 @@ def test_make_browse(tmp_path):
     image_file = tmp_path / 'test.png'
     rng = np.random.default_rng(42)
     data = rng.uniform(0, 700, size=(10, 10))
+    data = np.asarray([data])
 
     out_file = image.make_browse(image_file, data)
     assert out_file == image_file
@@ -15,4 +16,4 @@ def test_make_browse(tmp_path):
 
     with Image.open(out_file) as img:
         assert img.format == 'PNG'
-        assert img.size == data.shape
+        assert img.size == data[0].shape


### PR DESCRIPTION
Work in progress. Things that need to be fixed:
- [x] ensure time will be unique as there can be multiple velocity products with the same center time. When generating the datacubes, @mliukis has been adding microseconds based on the acquisition year to jitter the mid date (center_date). 
   https://github.com/nasa-jpl/its_live_production/blob/e089577545c6f0c7737e0d3ca037895c170e4847/src/itscube.py#L1167-L1178
   
   Note: we may need to think about this more, as that doesn't always seem to work, and we still end up with duplicate center dates in the cubes
- [x] :no_entry_sign: ~~use the acquisition dates to calculate the time instead of the reported center_date?~~
   
   Should be unnecessary -- not using the `center_date` was introduced for products created before Sept. 16, 2021 (pre [hyp3-autorift v0.7.0](https://github.com/ASFHyP3/hyp3-autorift/releases/v0.7.0) and autoRIFT v1.4.0), when we only recorded the center-time down to days (e.g.: [here in v1.3.1](https://github.com/nasa-jpl/autoRIFT/blob/v1.3.1/testautoRIFT.py#L777)). Since v1.4.0, the center date is calculated from the same acquisition times recorded in the metadata, and recorded down to the microseconds, so it will be the same as calculating it again from the acquisition dates. We shouldn't have any existing products this old because we did a re-processing campaign since then. Confirmed! The oldest product was created on 2021-10-08.
- [x] while we want `img_pair_info` to have a `time` dimension, we don't want `mapping` to. Need to figure out how to exclude `mapping` from the `expand_dims` call
- [x] the `x` and `y` variables seem to have lost all their attributes, e.g.:
   ```diff
   	double x(x) ;
   -		string x:standard_name = "projection_x_coordinate" ;
   -		string x:description = "x coordinate of projection" ;
   -		string x:units = "m" ;
   +		x:_FillValue = NaN ;
   ```
- [x] Should we pick a consistent reference date (date since X) for the time dimension?
   ```
   	int64 time(time) ;
		string time:units = "days since 2017-06-05 09:08:49.239968" ;
		string time:calendar = "proleptic_gregorian" ;
   ```