### PR TITLE
change `scene_?_frame` to `frame_img?` to match metadata style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 * `--frame-id` optional argument to record the OPERA frame of a Sentinel-1 scene for the output product metadata.
-* The OPERA frame or OPERA burst ID will be recorded in `scene_1_frame` and `scene_2_frame` in `img_pair_info` in the output product metadata for Sentinel-1 products.
+* The OPERA frame or OPERA burst ID will be recorded in `frame_img1` and `frame_img2` in `img_pair_info` in the output product metadata for Sentinel-1 products.
 
 ## [0.26.0]
 

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -161,8 +161,8 @@ def process_burst(
 
     with netCDF4.Dataset(netcdf_file, 'a', clobber=True, format='NETCDF4') as ds:
         var = ds.variables['img_pair_info']
-        var.setncattr('scene_1_frame', burst_id_ref[1:])
-        var.setncattr('scene_2_frame', burst_id_sec[1:])
+        var.setncattr('frame_img1', burst_id_ref[1:])
+        var.setncattr('frame_img2', burst_id_sec[1:])
 
     return netcdf_file
 
@@ -281,8 +281,8 @@ def process_slc(
     if frame_id:
         with netCDF4.Dataset(netcdf_file, 'a', clobber=True, format='NETCDF4') as ds:
             var = ds.variables['img_pair_info']
-            var.setncattr('scene_1_frame', frame_id)
-            var.setncattr('scene_2_frame', frame_id)
+            var.setncattr('frame_img1', frame_id)
+            var.setncattr('frame_img2', frame_id)
 
     return netcdf_file
 


### PR DESCRIPTION
the ITS_LIVE granule metadata uses a "<thing>_img?" style for the image pair info metadata, so this updates the frame attributes to match:

```
netcdf S1A_IW_SLC__1SSH_20170221T204710_20170221T204737_015387_0193F6_AB07_X_S1B_IW_SLC__1SSH_20170227T204628_20170227T204655_004491_007D11_6654_G0120V02_P089 {
dimensions:
	time = UNLIMITED ; // (1 currently)
	y = 1536 ;
	x = 2560 ;
variables:
	string img_pair_info(time) ;
		string img_pair_info:standard_name = "image_pair_information" ;
		string img_pair_info:id_img1 = "S1A_IW_SLC__1SSH_20170221T204710_20170221T204737_015387_0193F6_AB07" ;
		string img_pair_info:id_img2 = "S1B_IW_SLC__1SSH_20170227T204628_20170227T204655_004491_007D11_6654" ;
		string img_pair_info:absolute_orbit_number_img1 = "015387" ;
		string img_pair_info:absolute_orbit_number_img2 = "004491" ;
		string img_pair_info:acquisition_date_img1 = "20170221T20:47:12.994806" ;
		string img_pair_info:acquisition_date_img2 = "20170227T20:46:30.862608" ;
		string img_pair_info:flight_direction_img1 = "ascending" ;
		string img_pair_info:flight_direction_img2 = "ascending" ;
		string img_pair_info:mission_data_take_ID_img1 = "0193F6" ;
		string img_pair_info:mission_data_take_ID_img2 = "007D11" ;
		string img_pair_info:mission_img1 = "S" ;
		string img_pair_info:mission_img2 = "S" ;
		string img_pair_info:product_unique_ID_img1 = "AB07" ;
		string img_pair_info:product_unique_ID_img2 = "6654" ;
		string img_pair_info:satellite_img1 = "1A" ;
		string img_pair_info:satellite_img2 = "1B" ;
		string img_pair_info:sensor_img1 = "C" ;
		string img_pair_info:sensor_img2 = "C" ;
		string img_pair_info:time_standard_img1 = "UTC" ;
		string img_pair_info:time_standard_img2 = "UTC" ;
		string img_pair_info:date_center = "20170224T20:46:51.928707" ;
		img_pair_info:date_dt = 5.99951235881944 ;
		img_pair_info:latitude = 69.97 ;
		img_pair_info:longitude = -50.63 ;
		img_pair_info:roi_valid_percentage = 89.6 ;
		img_pair_info:frame_img1 = "foo" ;
		img_pair_info:frame_img2 = "foo" ;
```	

I also opened https://github.com/betolink/cryoforge/pull/5 to match	