### PR TITLE
Enable optical autoRIFT processing for multiple granules and add support for non-glacial applications 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* Support for processing multiple reference and secondary granules for optical data (Sentinel-2 and Landsat) by creating VRT mosaics in `process.py`
+* A `--chip-size` argument to override the chip size specified in `DEFAULT_PARAMETER_FILE`. This includes updates to `testGeogrid.py` to skip intermediate TIF generation and `testautoRIFT.py` to manually construct static grid arrays when `--chip-size` is specified.
+* A `--search-range` argument to override the parameter file's search limit. This includes updates to `testautoRIFT.py` to manually overwrite search grid arrays, enabling processing of non-glacial terrain where default parameters are masked.
+* Logic to zero out reference displacement velocities in `testautoRIFT.py` when parameter overrides are used.
+
+### Changed
+* Refactored the optical workflow in `process.py` to accept list inputs and calculate union metadata for mosaicked inputs
+* Updated `apply_landsat_filtering` in `process.py` to accept an explicit platform argument, fixing platform detection for VRT filenames
+* Propagated chip size and search range arguments through Sentinel-1 ISCE3 workflows in `s1_isce3.py`
+
 ## [0.26.0]
 
 ### Added

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -160,11 +160,11 @@ def get_s2_metadata(scene_name):
 
 def _create_mosaic_metadata(metas: list[dict]) -> dict:
     """Creates a union metadata object from a list of granule metadata"""
-    log.info(f"Creating union metadata for {len(metas)} granules.")
-    
+    log.info(f'Creating union metadata for {len(metas)} granules.')
+
     # Use first granule as base for properties (like projection)
     mosaic_meta = metas[0].copy()
-    
+
     # Create a union of all bounding boxes
     try:
         min_lon = min(m['bbox'][0] for m in metas)
@@ -179,9 +179,9 @@ def _create_mosaic_metadata(metas: list[dict]) -> dict:
 
     mosaic_meta['bbox'] = union_bbox
     # Overwrite ID to show it's a mosaic
-    mosaic_meta['id'] = f"{metas[0].get('id', 'MOSAIC')}_AND_{len(metas)-1}_MORE" 
-    
-    log.info(f"Mosaic union BBOX: {union_bbox}")
+    mosaic_meta['id'] = f'{metas[0].get("id", "MOSAIC")}_AND_{len(metas) - 1}_MORE'
+
+    log.info(f'Mosaic union BBOX: {union_bbox}')
     return mosaic_meta
 
 
@@ -334,12 +334,16 @@ def process(
     if platform == 'S1-BURST':
         from hyp3_autorift.s1_isce3 import process_sentinel1_burst_isce3
 
-        netcdf_file = process_sentinel1_burst_isce3(reference, secondary, publish_bucket, use_static_files, frame_id, chip_size=chip_size)
+        netcdf_file = process_sentinel1_burst_isce3(
+            reference, secondary, publish_bucket, use_static_files, frame_id, chip_size=chip_size
+        )
 
     elif platform == 'S1-SLC':
         from hyp3_autorift.s1_isce3 import process_sentinel1_slc_isce3
 
-        netcdf_file = process_sentinel1_slc_isce3(reference[0], secondary[0], publish_bucket, use_static_files, chip_size=chip_size)
+        netcdf_file = process_sentinel1_slc_isce3(
+            reference[0], secondary[0], publish_bucket, use_static_files, chip_size=chip_size
+        )
 
     else:
         # Set config and env for new CXX threads in Geogrid/autoRIFT
@@ -356,12 +360,12 @@ def process(
         sec_paths = []
 
         if platform == 'S2':
-            log.info(f"Processing {len(reference)} reference S2 granules.")
+            log.info(f'Processing {len(reference)} reference S2 granules.')
             for granule in reference:
                 meta = get_s2_metadata(granule)
                 ref_metas.append(meta)
                 ref_paths.append(meta['path'])
-            log.info(f"Processing {len(secondary)} secondary S2 granules.")
+            log.info(f'Processing {len(secondary)} secondary S2 granules.')
             for granule in secondary:
                 meta = get_s2_metadata(granule)
                 sec_metas.append(meta)
@@ -372,30 +376,30 @@ def process(
             gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
             os.environ['AWS_REQUEST_PAYER'] = 'requester'
 
-            log.info(f"Processing {len(reference)} reference Landsat Collection 2 granules.")
+            log.info(f'Processing {len(reference)} reference Landsat Collection 2 granules.')
             for granule in reference:
                 meta = get_lc2_metadata(granule)
                 ref_metas.append(meta)
                 ref_paths.append(get_lc2_path(meta))
-            log.info(f"Processing {len(secondary)} secondary Landsat Collection 2 granules.")
+            log.info(f'Processing {len(secondary)} secondary Landsat Collection 2 granules.')
             for granule in secondary:
                 meta = get_lc2_metadata(granule)
                 sec_metas.append(meta)
                 sec_paths.append(get_lc2_path(meta))
 
-        # Handle mosaicking/metadata if multiple scenes were provided, otherwise just get metadata from the single scene        
+        # Handle mosaicking/metadata if multiple scenes were provided, otherwise just get metadata from the single scene
         if len(ref_paths) > 1:
             reference_path = f'{reference[0]}.vrt'
-            log.info(f"Creating VRT mosaic: {reference_path}")
+            log.info(f'Creating VRT mosaic: {reference_path}')
             gdal.BuildVRT(reference_path, ref_paths)
             reference_metadata = _create_mosaic_metadata(ref_metas)
         else:
             reference_path = ref_paths[0]
             reference_metadata = ref_metas[0]
-        
+
         if len(sec_paths) > 1:
             secondary_path = f'{secondary[0]}.vrt'
-            log.info(f"Creating VRT mosaic: {secondary_path}")
+            log.info(f'Creating VRT mosaic: {secondary_path}')
             gdal.BuildVRT(secondary_path, sec_paths)
             secondary_metadata = _create_mosaic_metadata(sec_metas)
         else:
@@ -443,7 +447,7 @@ def process(
             parameter_info['autorift']['chip_size_max'] = None
 
         if search_range is not None:
-            log.info(f"Overriding search range with user-defined value: {search_range}")
+            log.info(f'Overriding search range with user-defined value: {search_range}')
             # Inject user-specified search_range into 'autorift' dictionary
             parameter_info['autorift']['SearchLimitX'] = search_range
             parameter_info['autorift']['SearchLimitY'] = search_range
@@ -613,7 +617,7 @@ def main():
         secondary = granules_sorted[1]
     else:
         reference, secondary = utils.sort_ref_sec(reference, secondary)
-    
+
     try:
         ref_platforms = {get_platform(scene) for scene in reference}
         sec_platforms = {get_platform(scene) for scene in secondary}

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -4,6 +4,7 @@ import math
 import os
 import shutil
 import subprocess
+import logging
 from datetime import timedelta
 
 import netCDF4
@@ -31,7 +32,9 @@ from hyp3_autorift.vend.testGeogrid import getPol, loadMetadata, loadMetadataSlc
 from hyp3_autorift.vend.testautoRIFT import generateAutoriftProduct
 
 
-def process_sentinel1_burst_isce3(reference, secondary, static_files_bucket, use_static_files, frame_id):
+log = logging.getLogger(__name__)
+
+def process_sentinel1_burst_isce3(reference, secondary, static_files_bucket, use_static_files, frame_id, chip_size: int | None = None):
     safe_ref = download_burst(reference)
     safe_sec = download_burst(secondary)
 
@@ -55,6 +58,7 @@ def process_sentinel1_burst_isce3(reference, secondary, static_files_bucket, use
             use_static_files,
             frame_id,
             swaths,
+            chip_size,
         )
 
     reference = reference[0]
@@ -73,6 +77,7 @@ def process_sentinel1_burst_isce3(reference, secondary, static_files_bucket, use
         burst_id_sec,
         static_files_bucket,
         use_static_files,
+        chip_size,
     )
 
 
@@ -86,6 +91,7 @@ def process_burst(
     burst_id_sec,
     static_files_bucket,
     use_static_files,
+    chip_size: int | None = None
 ):
     swath = int(granule_ref.split('_')[2][2])
     lat_limits, lon_limits = bounding_box(safe_ref, orbit_ref, False, swaths=[swath])
@@ -137,6 +143,19 @@ def process_burst(
     meta_s.sensingStart = meta_temp.sensingStart
     meta_s.sensingStop = meta_temp.sensingStop
 
+    if chip_size is not None:
+        log.info(f"Overriding chip size with user-defined value: {chip_size}") # Add this log
+        
+        # Modify geogrid params (sends ChipSizeX to runGeogrid)
+        parameter_info['geogrid']['ChipSizeX'] = chip_size
+        parameter_info['geogrid']['ChipSizeY'] = chip_size
+        
+        # Modify autorift params (sends ChipSizeX to generateAutoriftProduct/runAutorift)
+        parameter_info['autorift']['ChipSizeX'] = chip_size
+        parameter_info['autorift']['ChipSizeY'] = chip_size
+        parameter_info['autorift']['chip_size_min'] = None
+        parameter_info['autorift']['chip_size_max'] = None
+
     geogrid_info = runGeogrid(
         info=meta_r,
         info1=meta_s,
@@ -167,7 +186,7 @@ def process_burst(
     return netcdf_file
 
 
-def process_sentinel1_slc_isce3(slc_ref, slc_sec, static_files_bucket, use_static_files):
+def process_sentinel1_slc_isce3(slc_ref, slc_sec, static_files_bucket, use_static_files, chip_size: int | None = None):
     safe_ref = download_file(get_download_url(slc_ref), chunk_size=5242880)
     safe_sec = download_file(get_download_url(slc_sec), chunk_size=5242880)
 
@@ -187,6 +206,7 @@ def process_sentinel1_slc_isce3(slc_ref, slc_sec, static_files_bucket, use_stati
         static_files_bucket,
         use_static_files,
         frame_id='N/A',
+        chip_size=chip_size,
     )
 
 
@@ -201,6 +221,7 @@ def process_slc(
     use_static_files,
     frame_id,
     swaths=(1, 2, 3),
+    chip_size: int | None = None
 ):
     lat_limits, lon_limits = bounding_box(safe_ref, orbit_ref, True, swaths=swaths)
     scene_poly = geometry.polygon_from_bbox(x_limits=lat_limits, y_limits=lon_limits)
@@ -255,6 +276,19 @@ def process_slc(
     meta_s = copy.copy(meta_r)
     meta_s.sensingStart = meta_temp.sensingStart
     meta_s.sensingStop = meta_temp.sensingStop
+
+    if chip_size is not None:
+        log.info(f"Overriding chip size with user-defined value: {chip_size}") # Add this log
+        
+        # Modify geogrid params (sends ChipSizeX to runGeogrid)
+        parameter_info['geogrid']['ChipSizeX'] = chip_size
+        parameter_info['geogrid']['ChipSizeY'] = chip_size
+        
+        # Modify autorift params (sends ChipSizeX to generateAutoriftProduct/runAutorift)
+        parameter_info['autorift']['ChipSizeX'] = chip_size
+        parameter_info['autorift']['ChipSizeY'] = chip_size
+        parameter_info['autorift']['chip_size_min'] = None
+        parameter_info['autorift']['chip_size_max'] = None
 
     geogrid_info = runGeogrid(
         info=meta_r,

--- a/src/hyp3_autorift/s1_isce3.py
+++ b/src/hyp3_autorift/s1_isce3.py
@@ -1,10 +1,10 @@
 import copy
 import glob
+import logging
 import math
 import os
 import shutil
 import subprocess
-import logging
 from datetime import timedelta
 
 import netCDF4
@@ -34,8 +34,16 @@ from hyp3_autorift.vend.testautoRIFT import generateAutoriftProduct
 
 log = logging.getLogger(__name__)
 
-def process_sentinel1_burst_isce3(reference, secondary, static_files_bucket, use_static_files,
-                                  frame_id, chip_size: int | None = None, search_range: int | None = None):
+
+def process_sentinel1_burst_isce3(
+    reference,
+    secondary,
+    static_files_bucket,
+    use_static_files,
+    frame_id,
+    chip_size: int | None = None,
+    search_range: int | None = None,
+):
     safe_ref = download_burst(reference)
     safe_sec = download_burst(secondary)
 
@@ -146,20 +154,20 @@ def process_burst(
     meta_s.sensingStop = meta_temp.sensingStop
 
     if chip_size is not None:
-        log.info(f"Overriding chip size with user-defined value: {chip_size}") # Add this log
-        
+        log.info(f'Overriding chip size with user-defined value: {chip_size}')  # Add this log
+
         # Modify geogrid params (sends ChipSizeX to runGeogrid)
         parameter_info['geogrid']['ChipSizeX'] = chip_size
         parameter_info['geogrid']['ChipSizeY'] = chip_size
-        
+
         # Modify autorift params (sends ChipSizeX to generateAutoriftProduct/runAutorift)
         parameter_info['autorift']['ChipSizeX'] = chip_size
         parameter_info['autorift']['ChipSizeY'] = chip_size
         parameter_info['autorift']['chip_size_min'] = None
         parameter_info['autorift']['chip_size_max'] = None
-    
+
     if search_range is not None:
-        log.info(f"Overriding search range with user-defined value: {search_range}")
+        log.info(f'Overriding search range with user-defined value: {search_range}')
         # Inject user-specified search_range into 'autorift' dictionary
         parameter_info['autorift']['SearchLimitX'] = search_range
         parameter_info['autorift']['SearchLimitY'] = search_range
@@ -196,8 +204,14 @@ def process_burst(
     return netcdf_file
 
 
-def process_sentinel1_slc_isce3(slc_ref, slc_sec, static_files_bucket, use_static_files,
-                                chip_size: int | None = None, search_range: int | None = None):
+def process_sentinel1_slc_isce3(
+    slc_ref,
+    slc_sec,
+    static_files_bucket,
+    use_static_files,
+    chip_size: int | None = None,
+    search_range: int | None = None,
+):
     safe_ref = download_file(get_download_url(slc_ref), chunk_size=5242880)
     safe_sec = download_file(get_download_url(slc_sec), chunk_size=5242880)
 
@@ -291,12 +305,12 @@ def process_slc(
     meta_s.sensingStop = meta_temp.sensingStop
 
     if chip_size is not None:
-        log.info(f"Overriding chip size with user-defined value: {chip_size}") # Add this log
-        
+        log.info(f'Overriding chip size with user-defined value: {chip_size}')  # Add this log
+
         # Modify geogrid params (sends ChipSizeX to runGeogrid)
         parameter_info['geogrid']['ChipSizeX'] = chip_size
         parameter_info['geogrid']['ChipSizeY'] = chip_size
-        
+
         # Modify autorift params (sends ChipSizeX to generateAutoriftProduct/runAutorift)
         parameter_info['autorift']['ChipSizeX'] = chip_size
         parameter_info['autorift']['ChipSizeY'] = chip_size
@@ -304,7 +318,7 @@ def process_slc(
         parameter_info['autorift']['chip_size_max'] = None
 
     if search_range is not None:
-        log.info(f"Overriding search range with user-defined value: {search_range}")
+        log.info(f'Overriding search range with user-defined value: {search_range}')
         # Inject user-specified search_range into 'autorift' dictionary
         parameter_info['autorift']['SearchLimitX'] = search_range
         parameter_info['autorift']['SearchLimitY'] = search_range

--- a/src/hyp3_autorift/utils.py
+++ b/src/hyp3_autorift/utils.py
@@ -182,6 +182,14 @@ def nullable_string(argument_string: str) -> str | None:
     return argument_string if argument_string else None
 
 
+def nullable_int(argument_string: str) -> int | None:
+    processed_string = argument_string.replace('None', '').strip()
+    if not processed_string:
+        return None
+    else:
+        return int(processed_string)
+
+
 def nullable_granule_list(granule_string: str) -> list[str]:
     granule_string = granule_string.replace('None', '').strip()
     granule_list = [granule for granule in granule_string.split(' ') if granule]

--- a/src/hyp3_autorift/vend/testGeogrid.py
+++ b/src/hyp3_autorift/vend/testGeogrid.py
@@ -31,6 +31,7 @@ import argparse
 import os
 import re
 from datetime import date, timedelta
+import logging
 
 import isce3
 import numpy as np
@@ -38,6 +39,7 @@ from geogrid import GeogridOptical, GeogridRadar
 from osgeo import gdal
 from s1reader import load_bursts
 
+log = logging.getLogger(__name__)
 
 def cmdLineParse():
     """
@@ -318,6 +320,20 @@ def runGeogrid(
         obj.csmaxxname = csmaxx
         obj.csmaxyname = csmaxy
         obj.ssmname = ssm
+        # If chip size override is provided, use it
+        if 'ChipSizeX' in kwargs and kwargs['ChipSizeX'] is not None:
+            log.info(f"Geogrid: Overriding chip size with {kwargs['ChipSizeX']}")
+            # Set the integer-based properties on the object
+            obj.ChipSizeX = int(kwargs['ChipSizeX'])
+            if 'ChipSizeY' in kwargs and kwargs['ChipSizeY'] is not None:
+                obj.ChipSizeY = int(kwargs['ChipSizeY'])
+            else:
+                obj.ChipSizeY = int(kwargs['ChipSizeX'])
+            # Clear the tif-based properties to avoid conflicts
+            obj.csminxname = None
+            obj.csminyname = None
+            obj.csmaxxname = None
+            obj.csmaxyname = None
         obj.winlocname = 'window_location.tif'
         obj.winoffname = 'window_offset.tif'
         obj.winsrname = 'window_search_range.tif'
@@ -388,6 +404,20 @@ def runGeogrid(
         obj.csmaxxname = csmaxx
         obj.csmaxyname = csmaxy
         obj.ssmname = ssm
+        # If chip size override is provided, use it
+        if 'ChipSizeX' in kwargs and kwargs['ChipSizeX'] is not None:
+            log.info(f"Geogrid: Overriding chip size with {kwargs['ChipSizeX']}")
+            # Set the integer-based properties on the object
+            obj.ChipSizeX = int(kwargs['ChipSizeX'])
+            if 'ChipSizeY' in kwargs and kwargs['ChipSizeY'] is not None:
+                obj.ChipSizeY = int(kwargs['ChipSizeY'])
+            else:
+                obj.ChipSizeY = int(kwargs['ChipSizeX'])
+            # Clear the tif-based properties to avoid conflicts
+            obj.csminxname = None
+            obj.csminyname = None
+            obj.csmaxxname = None
+            obj.csmaxyname = None
         obj.winlocname = 'window_location.tif'
         obj.winoffname = 'window_offset.tif'
         obj.winsrname = 'window_search_range.tif'

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -80,6 +80,33 @@ def test_get_lc2_stac_json_key():
 
 
 @responses.activate
+def test_create_mosaic_metadata():
+    responses.add(
+        responses.GET,
+        f'{process.LC2_SEARCH_URL}/LC08_L1TP_009011_20200703_20200913_02_T1',
+        body='{"id": "LC08_L1TP_009011_20200703_20200913_02_T1", "bbox": [-1, -1, 0, 0]}',
+        status=200,
+    )
+
+    meta1 = process.get_lc2_metadata('LC08_L1TP_009011_20200703_20200913_02_T1')
+
+    responses.add(
+        responses.GET,
+        f'{process.LC2_SEARCH_URL}/LC08_L1TP_009011_20200603_20200813_02_T1',
+        body='{"id": "LC08_L1TP_009011_20200603_20200813_02_T1", "bbox": [0, 0, 1, 1]}',
+        status=200,
+    )
+
+    meta2 = process.get_lc2_metadata('LC08_L1TP_009011_20200603_20200813_02_T1')
+
+    metas = [meta1, meta2]
+    reference_metadata = process._create_mosaic_metadata(metas)
+
+    assert reference_metadata['bbox'] == [-1, -1, 1, 1]
+    assert reference_metadata['id'] == 'LC08_L1TP_009011_20200703_20200913_02_T1_AND_1_MORE'
+
+
+@responses.activate
 def test_get_lc2_metadata():
     responses.add(
         responses.GET,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,6 +226,18 @@ def test_get_opendata_prefix():
     [
         ('', None),
         ('None', None),
+        ('1', 1),
+    ],
+)
+def test_nullable_int(argument_string, expected):
+    assert utils.nullable_int(argument_string) == expected
+
+
+@pytest.mark.parametrize(
+    'argument_string,expected',
+    [
+        ('', None),
+        ('None', None),
         ('none', 'none'),
         ('foobar', 'foobar'),
     ],


### PR DESCRIPTION
This PR introduces updates to (1) support autoRIFT processing for non-glacial applications (e.g., earthquakes/landslides) via manual overrides of default parameter file parameters and (2) enable optical processing for multiple input reference and secondary scenes.

## Updates
### 1. Parameter File Overrides 
The hype-autoRIFT `DEFAULT_PARAMETER_FILE` is optimized for tracking glacier movement (masking out land, enforcing specific chip sizes, and applying reference flow velocities). This PR adds overrides to bypass these limitations:

- Chip Size: Added `--chip-size` CLI argument to enable user-specified chip size. Modified `runGeogrid` to skip adaptive TIF generation when set, and updated `generateAutoriftProduct` to manually construct grid arrays, bypassing the default parameter file logic.

- Search Range: Added --search-range CLI argument to enable user-specified search range. This fixes specific runtime errors where the `DEFAULT_PARAMETER_FILE` set the search range to 0 (masked) over non-glacial terrain.

- Reference Velocity Removal: Implemented logic to force reference velocities (`Dx0`, `Dy0`) to zero when parameter overrides are active. This effectively removes reference displacement velocities that would otherwise bias the search window center, ensuring unbiased tracking for general ground motion (e.g., earthquake coseismic displacement).

- S1 Integration: Propagated `chip_size` and `search_range` arguments through `s1_isce3.py` workflows to ensure these features are available for radar processing.

### 2. Optical mosaicking prior to autoRIFT processing
- Refactored optical workflow in `process.py` to accept lists of reference and secondary granules, rather than single files.

- Implemented `gdal.BuildVRT` to create virtual mosaics for input scenes, allowing seamless processing of overlapping or adjacent granules.

- Added `_create_mosaic_metadata` helper to `process.py` to compute the union bounding box of all input granules, ensuring `utils.find_jpl_parameter_info` selects the correct DEM and parameter file for the full extent.

- Updated `apply_landsat_filtering` signature to accept an explicit platform argument. This is necessary to ensure the appropriate platform name is retained in the mosaic VRT filenames.

## Testing and example output
An example product over the July 2019 Ridgecrest earthquake may be generated using the following:
`pixi run hyp3_autorift --reference S2B_MSIL1C_20190628T182929_N0500_R027_T11SMV_20230716T131046 --secondary S2B_MSIL1C_20190708T182929_N0500_R027_T11SMV_20230629T125639 --chip-size 24 --search-range 64`

<img width="3460" height="2480" alt="ridgecrest" src="https://github.com/user-attachments/assets/a0cdf095-2904-477f-828b-2acc920ea662" />

An example product over the March 2025 Myanmar earthquake (consisting of 16 reference and secondary S2 granules) may be generated with the following:

```
pixi run hyp3_autorift \
  --reference \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QHH_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QGH_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QGJ_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QGL_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T47QKD_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T47QKB_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QHF_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T47QKF_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T47QKC_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QGG_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QGK_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QHG_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T47QKE_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QHK_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QHJ_20250228T055635 \
    S2B_MSIL1C_20250228T040619_N0511_R047_T46QHL_20250228T055635 \
  --secondary \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QHF_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QHH_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QHK_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T47QKD_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QHG_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T47QKC_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T47QKB_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QHJ_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QGJ_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QHL_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QGK_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QGG_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QGL_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T47QKE_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T47QKF_20250404T074259 \
    S2C_MSIL1C_20250404T040611_N0511_R047_T46QGH_20250404T074259 \
   --chip-size 24 \
   --search-range 64
```
<img width="2307" height="1653" alt="myanmar" src="https://github.com/user-attachments/assets/c2bbbdb8-8d42-4d5e-9b01-012d70d79d8d" />




