### PR TITLE
Use Matrix strategy for Dockerization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,11 +141,13 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
+        if: ${{ !env.act }}
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,9 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - version-info
       - dockerize

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           export SDIST_VERSION=$(python -m setuptools_scm)
           SDIST_VERSION=${SDIST_VERSION:-dev}
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
-          echo "version_tag=${SDIST_VERSION/+/_}" >> $GITHUB_OUTPUT
+          echo "version_tag=${SDIST_VERSION}" >> $GITHUB_OUTPUT
           echo "Version number: ${SDIST_VERSION}"
 
   dockerize:
@@ -75,9 +75,9 @@ jobs:
         run: |
           echo "Building docker container for ${{ matrix.arch }}: ${{ env.IMAGE }}"
           docker build -t ${{ env.IMAGE }} \
-            --label CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }}
-            --label version=${{ needs.version_info.outputs.version_tag }}
-            --label revision=${{ github.sha }}
+            --label CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }} \
+            --label version=${{ needs.version_info.outputs.version_tag }} \
+            --label revision=${{ github.sha }} \
             --build-arg ARCH=${{ matrix.arch }} .
 
       - name: Push docker image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,19 +72,19 @@ jobs:
         with:
           activate-environment: true
 
-      - name: Build docker image
-        run: |
-          echo "Building docker container for ${{ matrix.arch }}: ${{ env.IMAGE }}"
-          docker build -t ghcr.io/${{ env.IMAGE }} \
-            --label "CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }}" \
-            --label "version=${{ needs.version-info.outputs.version_tag }}" \
-            --label "revision=${{ github.sha }}" \
-            --build-arg ARCH=${{ matrix.arch }} .
-
-      - name: Push docker image
-        if: ${{ !env.act }}
-        run: |
-          docker push ghcr.io/${{ env.IMAGE }}
+      - name: Build, tag, and push image to GitHub Container Registry
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          context: .
+          file: ./Dockerfile
+          push: ${{ ! github.event.pull_request.head.repo.fork }}
+          tags: |
+            ghcr.io/${{ env.IMAGE }}
+          labels: |
+            org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
+            org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
+            org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Write matrix output
         uses: cloudposse/github-action-matrix-outputs-write@v1
@@ -133,20 +133,7 @@ jobs:
 #   - name: Set up Docker Buildx
 #     uses: docker/setup-buildx-action@v3
 #
-#   - name: Build, tag, and push image to GitHub Container Registry
-#     uses: docker/build-push-action@v6
-#     with:
-#       platforms: linux/amd64,linux/arm64
-#       context: .
-#       file: ./Dockerfile
-#       push: ${{ ! github.event.pull_request.head.repo.fork }}
-#       tags: |
-#         ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
-#       labels: |
-#         org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
-#         org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
-#         org.opencontainers.image.revision=${{ github.sha }}
-#
+
 #   - name: Add test tag
 #     if: ${{ github.event_name != 'pull_request' && contains(needs.version-info.outputs.version_tag, '.dev') }}
 #     uses: akhilerm/tag-push-action@v2.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,18 @@ jobs:
     outputs:
       version: ${{ steps.set_outputs.outputs.version }}
       version_tag: ${{ steps.set_outputs.outputs.version_tag }}
+      image: ${{ steps.set_outputs.outputs.image }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup Image name
+        id: vars
+        run: |
+          export IMAGE="${{ github.repository }}"
+          IMAGE="${IMAGE,,}"
+          echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
 
       - name: set outputs
         id: set_outputs
@@ -31,6 +39,7 @@ jobs:
           SDIST_VERSION=${SDIST_VERSION:-dev}
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
           echo "version_tag=${SDIST_VERSION}" >> $GITHUB_OUTPUT
+          echo "image=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
           echo "Version number: ${SDIST_VERSION}"
 
   dockerize:
@@ -56,9 +65,6 @@ jobs:
         id: vars
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
-          export IMAGE="${{ github.repository }}"
-          IMAGE="${IMAGE,,}"
-          echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
         if: ${{ !env.act }}
@@ -71,6 +77,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
           activate-environment: true
+          cache: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -87,7 +94,7 @@ jobs:
           file: ./Dockerfile
           push: ${{ ! github.event.pull_request.head.repo.fork }}
           tags: |
-            ghcr.io/${{ env.IMAGE }}
+            ghcr.io/${{ needs.version-info.outputs.image }}
           labels: |
             org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
             org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
@@ -137,7 +144,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ghcr.io/${{ needs.version-info.outputs.image }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -148,8 +155,8 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf 'ghcr.io/${{ needs.version-info.outputs.image }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ needs.version-info.outputs.image }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - dockerize
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,22 +40,32 @@ jobs:
       contents: read
       packages: write
     concurrency:
-      group: ${{ needs.version-info.outputs.version_tag }}
+      group: ${{ matrix.arch }}
       cancel-in-progress: true
     strategy:
       matrix:
         # Define all architectures we want to containerize for
         arch: [linux/amd64, linux/arm64]
-    env:
-      imagename: ${{ github.repository }}:${{ needs.version-info.outputs.version_tag || 'dev' }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: set environment variables
+        id: vars
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
+          export IMAGE="${{ github.repository }}:${{ needs.version-info.outputs.version_tag || 'dev' }}"
+          IMAGE="${IMAGE,,}"
+          echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
@@ -63,13 +73,17 @@ jobs:
 
       - name: Build docker image
         run: |
-          echo "Building docker container for ${{ matrix.arch }}: ${{ env.imagename}}@sha256:${{ github.sha }}"
-          docker build -t ${{ env.imagename }} --build-arg ARCH=${{ matrix.arch }} .
+          echo "Building docker container for ${{ matrix.arch }}: ${{ env.IMAGE }}"
+          docker build -t ${{ env.IMAGE }} \
+            --label CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }}
+            --label version=${{ needs.version_info.outputs.version_tag }}
+            --label revision=${{ github.sha }}
+            --build-arg ARCH=${{ matrix.arch }} .
 
       - name: Push docker image
         if: ${{ !env.act }}
         run: |
-          docker push ${{ env.imagename }}
+          docker push ${{ env.IMAGE }}
 
       - name: Write matrix output
         uses: cloudposse/github-action-matrix-outputs-write@v1
@@ -77,7 +91,7 @@ jobs:
           matrix-step-name: ${{ github.job }}
           matrix-key: ${{ matrix.arch }}
           outputs: |-
-            image: ${{ env.imagename }}
+            image: ${{ env.IMAGE }}
 
   collect:
     needs: [dockerize]
@@ -106,12 +120,7 @@ jobs:
 # needs: dockerize
 # runs-on: ububtu-latest
 # steps:
-#   - name: Login to GitHub Container Registry
-#     uses: docker/login-action@v3
-#     with:
-#       registry: ghcr.io
-#       username: ${{ github.actor }}
-#       password: ${{ secrets.GITHUB_TOKEN }}
+
 #
 #   - name: Lowercase repo for container registry
 #     run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build, tag, and push image to GitHub Container Registry
+        id: build
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,9 @@ jobs:
         run: |
           echo "Building docker container for ${{ matrix.arch }}: ${{ env.IMAGE }}"
           docker build -t ${{ env.IMAGE }} \
-            --label CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }} \
-            --label version=${{ needs.version-info.outputs.version_tag }} \
-            --label revision=${{ github.sha }} \
+            --label "CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }}" \
+            --label "version=${{ needs.version-info.outputs.version_tag }}" \
+            --label "revision=${{ github.sha }}" \
             --build-arg ARCH=${{ matrix.arch }} .
 
       - name: Push docker image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       version: ${{ steps.set_outputs.outputs.version }}
       version_tag: ${{ steps.set_outputs.outputs.version_tag }}
-      image: ${{ steps.set_outputs.outputs.image }}
+      repo: ${{ steps.set_outputs.outputs.repo }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -28,17 +28,17 @@ jobs:
       - name: Setup Image name
         id: vars
         run: |
-          export IMAGE="${{ github.repository }}"
-          IMAGE="${IMAGE,,}"
-          echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
 
       - name: set outputs
         id: set_outputs
         run: |
+          export REPO="${{ github.repository }}"
+          IMAGE="${REPO,,}"
+          echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
           export SDIST_VERSION=$(python -m setuptools_scm)
           SDIST_VERSION=${SDIST_VERSION:-dev}
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
-          echo "version_tag=${SDIST_VERSION}" >> $GITHUB_OUTPUT
+          echo "version_tag=${SDIST_VERSION/+/_}" >> $GITHUB_OUTPUT
           echo "image=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
           echo "Version number: ${SDIST_VERSION}"
 
@@ -69,8 +69,6 @@ jobs:
         id: vars
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
         if: ${{ !env.act }}
@@ -97,7 +95,7 @@ jobs:
           file: ./Dockerfile
           push: ${{ ! github.event.pull_request.head.repo.fork }}
           tags: |
-            ghcr.io/${{ needs.version-info.outputs.image }}
+            ghcr.io/${{ needs.version-info.outputs.repo }}
           labels: |
             org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
             org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
@@ -105,8 +103,8 @@ jobs:
           cache-from: |
             type=gha,scope=build-project-deps-linux-amd64
             type=gha,scope=build-project-deps-linux-arm64
-          cache-to: type=gha,mode=max,scope=build-project-deps-${{ env.PLATFORM_PAIR }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          cache-to: type=gha,mode=max,scope=build-project-deps-${{ matrix.runner }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ ! github.event.pull_request.head.repo.fork }}
 
       - name: Export digest
         run: |
@@ -117,7 +115,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.runner }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -155,10 +153,7 @@ jobs:
         with:
           images: ghcr.io/${{ needs.version-info.outputs.image }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=${{ needs.version-info.outputs.version_tag }}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ needs.version-info.outputs.version_tag }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           activate-environment: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build, tag, and push image to GitHub Container Registry
         uses: docker/build-push-action@v6
         with:
@@ -119,6 +125,9 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -141,4 +150,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,10 +77,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: prefix-dev/setup-pixi@v0.9.3
-        with:
-          activate-environment: true
-          cache: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         id: vars
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
-          export IMAGE="${{ github.repository }}:${{ needs.version-info.outputs.version_tag || 'dev' }}"
+          export IMAGE="${{ github.repository }}"
           IMAGE="${IMAGE,,}"
           echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
 
@@ -110,6 +110,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs:
+      - version-info
       - dockerize
     steps:
       - name: Download digests
@@ -139,7 +140,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
+            type=semver,pattern=${{ version-info.outputs.version_tag }}
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Create manifest list and push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,65 +85,60 @@ jobs:
             org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
             org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
             org.opencontainers.image.revision=${{ github.sha }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
-      - name: Write matrix output
-        uses: cloudposse/github-action-matrix-outputs-write@v1
-        with:
-          matrix-step-name: ${{ github.job }}
-          matrix-key: ${{ matrix.arch }}
-          outputs: |-
-            image: ${{ env.IMAGE }}
-
-  collect:
-    needs: [dockerize]
-    runs-on: ubuntu-24.04-arm
-    if: ${{ !cancelled() }}
-    outputs:
-      outcomes: ${{ steps.collect.outputs.result }}
-    steps:
-      - uses: cloudposse/github-action-matrix-outputs-read@v1
-        id: read
-        with:
-          matrix-step-name: dockerize
-
-  dockermanifest:
-    needs: collect
-    runs-on: ubuntu-24.04-arm
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.collect.outputs.result) }}
-    steps:
-      - name: Create dockermanifest
+      - name: Export digest
         run: |
-          echo echo ${{ matrix.runner }} ${{ matrix.result }}
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
-#dockermanifest:
-# needs: dockerize
-# runs-on: ububtu-latest
-# steps:
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
-#
-#   - name: Lowercase repo for container registry
-#     run: |
-#       echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
-#
-#   - name: Set up QEMU
-#     uses: docker/setup-qemu-action@v3
-#
-#   - name: Set up Docker Buildx
-#     uses: docker/setup-buildx-action@v3
-#
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
-#   - name: Add test tag
-#     if: ${{ github.event_name != 'pull_request' && contains(needs.version-info.outputs.version_tag, '.dev') }}
-#     uses: akhilerm/tag-push-action@v2.2.0
-#     with:
-#       src: ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
-#       dst: ghcr.io/${{ env.REPO }}:test
-#
-#   - name: Add latest tag
-#     if: ${{ github.event_name != 'pull_request' && ! contains(needs.version-info.outputs.version_tag, '.dev') }}
-#     uses: akhilerm/tag-push-action@v2.2.0
-#     with:
-#       src: ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
-#       dst: ghcr.io/${{ env.REPO }}:latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=${{ version-info.outputs.version_tag }}
+            type=semver,pattern=${{ needs.version-info.outputs.version_tag }}
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Create manifest list and push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             image: ${{ env.imagename }}
 
   collect:
-    needs: dockerize
+    needs: [dockerize]
     runs-on: ubuntu-24.04-arm
     if: ${{ !cancelled() }}
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           context: .
           file: ./Dockerfile
-          push: ${{ ! github.event.pull_request.head.repo.fork }}
           tags: |
             ghcr.io/${{ needs.version-info.outputs.repo }}
           labels: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,21 +25,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Image name
-        id: vars
-        run: |
-
       - name: set outputs
         id: set_outputs
         run: |
           export REPO="${{ github.repository }}"
-          IMAGE="${REPO,,}"
-          echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
+          REPO="${REPO,,}"
+          echo "REPO=${REPO}" >> $GITHUB_ENV
           export SDIST_VERSION=$(python -m setuptools_scm)
           SDIST_VERSION=${SDIST_VERSION:-dev}
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
           echo "version_tag=${SDIST_VERSION/+/_}" >> $GITHUB_OUTPUT
-          echo "image=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
           echo "Version number: ${SDIST_VERSION}"
 
   dockerize:
@@ -151,7 +146,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ needs.version-info.outputs.image }}
+          images: ghcr.io/${{ needs.version-info.outputs.repo }}
           tags: |
             type=raw,value=${{ needs.version-info.outputs.version_tag }}
 
@@ -159,18 +154,18 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'ghcr.io/${{ needs.version-info.outputs.image }}@sha256:%s ' *)
+            $(printf 'ghcr.io/${{ needs.version-info.outputs.repo }}@sha256:%s ' *)
 
       - name: Add test tag
         if: ${{ github.event_name != 'pull_request' && contains(needs.version-info.outputs.version_tag, '.dev') }}
         uses: akhilerm/tag-push-action@v2.2.0
         with:
-          src: ghcr.io/${{ needs.version-info.outputs.image }}
-          dst: ghcr.io/${{ env.REPO }}:test
+          src: ghcr.io/${{ needs.version-info.outputs.repo }}
+          dst: ghcr.io/${{ needs.version-info.outputs.repo }}:test
 
       - name: Add latest tag
         if: ${{ github.event_name != 'pull_request' && ! contains(needs.version-info.outputs.version_tag, '.dev') }}
         uses: akhilerm/tag-push-action@v2.2.0
         with:
-          src: ghcr.io/${{ needs.version-info.outputs.image }}
-          dst: ghcr.io/${{ env.REPO }}:latest
+          src: ghcr.io/${{ needs.version-info.outputs.repo }}
+          dst: ghcr.io/${{ needs.version.info.outputs.repo }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          activate-environment: true
+
       - name: set outputs
         id: set_outputs
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
             org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
             org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
             org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=build-project-deps # Use GHA cache for restoring
+          cache-to: type=gha,mode=max,scope=build-project-deps # Use GHA cache for saving
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         id: set_outputs
         run: |
           export SDIST_VERSION=$(python -m setuptools_scm)
+          SDIST_VERSION=${SDIST_VERSION:-dev}
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
           echo "version_tag=${SDIST_VERSION/+/_}" >> $GITHUB_OUTPUT
           echo "Version number: ${SDIST_VERSION}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           echo "Building docker container for ${{ matrix.arch }}: ${{ env.IMAGE }}"
           docker build -t ${{ env.IMAGE }} \
             --label CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }} \
-            --label version=${{ needs.version_info.outputs.version_tag }} \
+            --label version=${{ needs.version-info.outputs.version_tag }} \
             --label revision=${{ github.sha }} \
             --build-arg ARCH=${{ matrix.arch }} .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,8 @@ jobs:
             org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
             org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=build-project-deps # Use GHA cache for restoring
-          cache-to: type=gha,mode=max,scope=build-project-deps # Use GHA cache for saving
+          cache-from: type=gha,scope=build-project-deps-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=build-project-deps-${{ matrix.platform }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -161,6 +161,16 @@ jobs:
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/${{ needs.version-info.outputs.image }}@sha256:%s ' *)
 
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ghcr.io/${{ needs.version-info.outputs.image }}
+      - name: Add test tag
+        if: ${{ github.event_name != 'pull_request' && contains(needs.version-info.outputs.version_tag, '.dev') }}
+        uses: akhilerm/tag-push-action@v2.2.0
+        with:
+          src: ghcr.io/${{ needs.version-info.outputs.image }}
+          dst: ghcr.io/${{ env.REPO }}:test
+
+      - name: Add latest tag
+        if: ${{ github.event_name != 'pull_request' && ! contains(needs.version-info.outputs.version_tag, '.dev') }}
+        uses: akhilerm/tag-push-action@v2.2.0
+        with:
+          src: ghcr.io/${{ needs.version-info.outputs.image }}
+          dst: ghcr.io/${{ env.REPO }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
           echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
+        if: ${{ !env.act }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -74,7 +75,7 @@ jobs:
       - name: Build docker image
         run: |
           echo "Building docker container for ${{ matrix.arch }}: ${{ env.IMAGE }}"
-          docker build -t ${{ env.IMAGE }} \
+          docker build -t ghcr.io/${{ env.IMAGE }} \
             --label "CI_JOB_TIMESTAMP=${{ env.CI_JOB_TIMESTAMP }}" \
             --label "version=${{ needs.version-info.outputs.version_tag }}" \
             --label "revision=${{ github.sha }}" \
@@ -83,7 +84,7 @@ jobs:
       - name: Push docker image
         if: ${{ !env.act }}
         run: |
-          docker push ${{ env.IMAGE }}
+          docker push ghcr.io/${{ env.IMAGE }}
 
       - name: Write matrix output
         uses: cloudposse/github-action-matrix-outputs-write@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,6 @@ jobs:
           activate-environment: true
           cache: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -148,9 +145,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         id: vars
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
-          platform=${{ matrix.platform }}
+          platform=${{ matrix.arch }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
@@ -161,4 +161,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ needs.version-info.outputs.image }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ needs.version-info.outputs.image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     branches:
       - main
@@ -24,10 +24,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: prefix-dev/setup-pixi@v0.9.3
-        with:
-          activate-environment: true
-
       - name: set outputs
         id: set_outputs
         run: |
@@ -35,7 +31,6 @@ jobs:
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
           echo "version_tag=${SDIST_VERSION/+/_}" >> $GITHUB_OUTPUT
           echo "Version number: ${SDIST_VERSION}"
-
 
   dockerize:
     needs: version-info
@@ -46,6 +41,12 @@ jobs:
     concurrency:
       group: ${{ needs.version-info.outputs.version_tag }}
       cancel-in-progress: true
+    strategy:
+      matrix:
+        # Define all architectures we want to containerize for
+        arch: [linux/amd64, linux/arm64]
+    env:
+      imagename: ${{ github.repository }}:${{ needs.version-info.outputs.version_tag || 'dev' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -55,47 +56,96 @@ jobs:
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          activate-environment: true
 
-      - name: Lowercase repo for container registry
+      - name: Build docker image
         run: |
-          echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+          echo "Building docker container for ${{ matrix.arch }}: ${{ env.imagename}}@sha256:${{ github.sha }}"
+          docker build -t ${{ env.imagename }} --build-arg ARCH=${{ matrix.arch }} .
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Push docker image
+        if: ${{ !env.act }}
+        run: |
+          docker push ${{ env.imagename }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build, tag, and push image to GitHub Container Registry
-        uses: docker/build-push-action@v6
+      - name: Write matrix output
+        uses: cloudposse/github-action-matrix-outputs-write@v1
         with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: ./Dockerfile
-          push: ${{ ! github.event.pull_request.head.repo.fork }}
-          tags: |
-            ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
-          labels: |
-            org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
-            org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
-            org.opencontainers.image.revision=${{ github.sha }}
+          matrix-step-name: ${{ github.job }}
+          matrix-key: ${{ matrix.arch }}
+          outputs: |-
+            image: ${{ env.imagename }}
 
-      - name: Add test tag
-        if: ${{ github.event_name != 'pull_request' && contains(needs.version-info.outputs.version_tag, '.dev') }}
-        uses: akhilerm/tag-push-action@v2.2.0
+  collect:
+    needs: dockerize
+    runs-on: ubuntu-24.04-arm
+    if: ${{ !cancelled() }}
+    outputs:
+      outcomes: ${{ steps.collect.outputs.result }}
+    steps:
+      - uses: cloudposse/github-action-matrix-outputs-read@v1
+        id: read
         with:
-          src: ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
-          dst: ghcr.io/${{ env.REPO }}:test
+          matrix-step-name: dockerize
 
-      - name: Add latest tag
-        if: ${{ github.event_name != 'pull_request' && ! contains(needs.version-info.outputs.version_tag, '.dev') }}
-        uses: akhilerm/tag-push-action@v2.2.0
-        with:
-          src: ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
-          dst: ghcr.io/${{ env.REPO }}:latest
+  dockermanifest:
+    needs: collect
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.collect.outputs.result) }}
+    steps:
+      - name: Create dockermanifest
+        run: |
+          echo echo ${{ matrix.runner }} ${{ matrix.result }}
+
+#dockermanifest:
+# needs: dockerize
+# runs-on: ububtu-latest
+# steps:
+#   - name: Login to GitHub Container Registry
+#     uses: docker/login-action@v3
+#     with:
+#       registry: ghcr.io
+#       username: ${{ github.actor }}
+#       password: ${{ secrets.GITHUB_TOKEN }}
+#
+#   - name: Lowercase repo for container registry
+#     run: |
+#       echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+#
+#   - name: Set up QEMU
+#     uses: docker/setup-qemu-action@v3
+#
+#   - name: Set up Docker Buildx
+#     uses: docker/setup-buildx-action@v3
+#
+#   - name: Build, tag, and push image to GitHub Container Registry
+#     uses: docker/build-push-action@v6
+#     with:
+#       platforms: linux/amd64,linux/arm64
+#       context: .
+#       file: ./Dockerfile
+#       push: ${{ ! github.event.pull_request.head.repo.fork }}
+#       tags: |
+#         ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
+#       labels: |
+#         org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
+#         org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
+#         org.opencontainers.image.revision=${{ github.sha }}
+#
+#   - name: Add test tag
+#     if: ${{ github.event_name != 'pull_request' && contains(needs.version-info.outputs.version_tag, '.dev') }}
+#     uses: akhilerm/tag-push-action@v2.2.0
+#     with:
+#       src: ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
+#       dst: ghcr.io/${{ env.REPO }}:test
+#
+#   - name: Add latest tag
+#     if: ${{ github.event_name != 'pull_request' && ! contains(needs.version-info.outputs.version_tag, '.dev') }}
+#     uses: akhilerm/tag-push-action@v2.2.0
+#     with:
+#       src: ghcr.io/${{ env.REPO }}:${{ needs.version-info.outputs.version_tag }}
+#       dst: ghcr.io/${{ env.REPO }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           export REPO="${{ github.repository }}"
           REPO="${REPO,,}"
-          echo "REPO=${REPO}" >> $GITHUB_ENV
+          echo "repo=$REPO" >> $GITHUB_OUTPUT
           export SDIST_VERSION=$(python -m setuptools_scm)
           SDIST_VERSION=${SDIST_VERSION:-dev}
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
         id: vars
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
         if: ${{ !env.act }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
   dockerize:
     needs: version-info
-    runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -53,8 +53,12 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        # Define all architectures we want to containerize for
-        platform: [linux/amd64, linux/arm64]
+        include:
+          # Define all architectures we want to containerize for
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -101,8 +105,10 @@ jobs:
             org.opencontainers.image.created=${{ env.CI_JOB_TIMESTAMP }}
             org.opencontainers.image.version=${{ needs.version-info.outputs.version_tag }}
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=build-project-deps-${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=build-project-deps-${{ matrix.platform }}
+          cache-from: |
+            type=gha,scope=build-project-deps-linux-amd64
+            type=gha,scope=build-project-deps-linux-arm64
+          cache-to: type=gha,mode=max,scope=build-project-deps-${{ env.PLATFORM_PAIR }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,12 +49,12 @@ jobs:
       contents: read
       packages: write
     concurrency:
-      group: ${{ matrix.arch }}
+      group: ${{ matrix.platform }}
       cancel-in-progress: true
     strategy:
       matrix:
         # Define all architectures we want to containerize for
-        arch: [linux/amd64, linux/arm64]
+        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,7 +65,7 @@ jobs:
         id: vars
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
-          platform=${{ matrix.arch }}
+          platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ COPY --chown=1000:1000 pyproject.toml pixi.lock ./
 RUN pixi install --locked && \
   pixi shell-hook -s bash >> /home/ubuntu/.profile
 
+# Install isce3 on a separate layer so we cache the 10 minute long process
+RUN pixi run install-isce3
+
 COPY --chown=1000:1000 . .
 
 RUN pixi run install-editable

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,24 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONDONTWRITEBYTECODE=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends git g++ unzip vim patch wget ca-certificates && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 USER 1000
 SHELL ["/bin/bash", "-l", "-c"]
 
-COPY --chown=1000:1000 . /hyp3-autorift/
 
 WORKDIR /hyp3-autorift/
 
+COPY --chown=1000:1000 pixi.toml pixi.lock ./
+
 RUN pixi install --locked && \
-    pixi shell-hook -s bash >> /home/ubuntu/.profile && \
-    pixi run install-editable
+  pixi shell-hook -s bash >> /home/ubuntu/.profile
+
+COPY --chown=1000:1000 . .
+
+RUN pixi run install-editable
+
 
 WORKDIR /home/ubuntu/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,10 @@ COPY --chown=1000:1000 pyproject.toml pixi.lock ./
 RUN pixi install --locked && \
   pixi shell-hook -s bash >> /home/ubuntu/.profile
 
-# Install isce3 on a separate layer so we cache the 10 minute long process
+# Install each dep on a separate layer so we cache the 10 minute long process
 RUN pixi run install-isce3
+RUN pixi run install-radar  
+RUN pixi run install-autorift
 
 COPY --chown=1000:1000 . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ SHELL ["/bin/bash", "-l", "-c"]
 
 WORKDIR /hyp3-autorift/
 
-COPY --chown=1000:1000 pixi.toml pixi.lock ./
+COPY --chown=1000:1000 pyproject.toml pixi.lock ./
 
 RUN pixi install --locked && \
   pixi shell-hook -s bash >> /home/ubuntu/.profile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,8 +224,7 @@ cmd = [
   "git+https://github.com/opera-adt/COMPASS.git@v0.5.6",
   "git+https://github.com/isce-framework/s1-reader.git@v0.2.5",
 ]
-#depends-on = ["install-isce3"]
-depends-on = []
+depends-on = ["install-isce3"]
 
 [tool.pixi.tasks.install-autorift]
 cmd = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,54 +5,52 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hyp3_autorift"
 requires-python = ">=3.10"
-authors = [
-    {name="ASF APD/Tools Team", email="uaf-asf-apd@alaska.edu"},
-]
+authors = [{ name = "ASF APD/Tools Team", email = "uaf-asf-apd@alaska.edu" }]
 description = "A HyP3 plugin for feature tracking processing with AutoRIFT-ISCE"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
-classifiers=[
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
+license = { text = "BSD-3-Clause" }
+classifiers = [
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    # NOTE: Duplicated in "[tool.pixi.dependencies]" to prefer conda-forge dependencies.
-    #       see: https://pixi.sh/dev/python/pyproject_toml/#dependency-section
-    'boto3',
-    'botocore',
-    'burst2safe>=1.4.4',
-    'gdal>=3',
-    'h5netcdf',  # for increased performance of crop.py
-    'hyp3lib>=4,<5',
-    'matplotlib',
-    'netCDF4',
-    'numpy>=1.20',
-    'pandas>=1.4',
-    'pyproj>=3.3',
-    'python-dateutil',
-    'requests>=2.0',
-    'scipy>=1.0',
-    'xarray',
+  # NOTE: Duplicated in "[tool.pixi.dependencies]" to prefer conda-forge dependencies.
+  #       see: https://pixi.sh/dev/python/pyproject_toml/#dependency-section
+  'boto3',
+  'botocore',
+  'burst2safe>=1.4.4',
+  'gdal>=3',
+  'h5netcdf',          # for increased performance of crop.py
+  'hyp3lib>=4,<5',
+  'matplotlib',
+  'netCDF4',
+  'numpy>=1.20',
+  'pandas>=1.4',
+  'pyproj>=3.3',
+  'python-dateutil',
+  'requests>=2.0',
+  'scipy>=1.0',
+  'xarray',
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 develop = [
-    'setuptools_scm',
-    'pillow>=7.0',
-    'pytest',
-    'pytest-console-scripts',
-    'pytest-cov',
-    'responses',
-    'ruff==0.14.7',
-    'mypy==1.19.0',
-    'types-requests',
+  'setuptools_scm',
+  'pillow>=7.0',
+  'pytest',
+  'pytest-console-scripts',
+  'pytest-cov',
+  'responses',
+  'ruff==0.14.7',
+  'mypy==1.19.0',
+  'types-requests',
 ]
 
 [project.scripts]
@@ -86,13 +84,13 @@ quote-style = "single"
 
 [tool.ruff.lint]
 extend-select = [
-    "NPY", # numpy-specific rules: https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy
-    "I",   # isort: https://docs.astral.sh/ruff/rules/#isort-i
-    # TODO: Uncomment the following extensions and address their warnings:
-    # "UP",  # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
-    # "D",   # pydocstyle: https://docs.astral.sh/ruff/rules/#pydocstyle-d
-    # "ANN", # annotations: https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
-    # "PTH", # use-pathlib-pth: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+  "NPY", # numpy-specific rules: https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy
+  "I",   # isort: https://docs.astral.sh/ruff/rules/#isort-i
+  # TODO: Uncomment the following extensions and address their warnings:
+  # "UP",  # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
+  # "D",   # pydocstyle: https://docs.astral.sh/ruff/rules/#pydocstyle-d
+  # "ANN", # annotations: https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+  # "PTH", # use-pathlib-pth: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -131,9 +129,7 @@ channels = ["conda-forge"]
 platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64"]
 
 [tool.pixi.pypi-options]
-no-build-isolation = [
-    'isce3',
-]
+no-build-isolation = ['isce3']
 
 [tool.pixi.dependencies]
 pip = "*"
@@ -188,7 +184,7 @@ pyre = "*"
 
 [tool.pixi.pypi-dependencies]
 snaphu = "*"
-raider = {git = "https://github.com/dbekaert/RAiDER.git", rev = "v0.5.5" }
+raider = { git = "https://github.com/dbekaert/RAiDER.git", rev = "v0.5.5" }
 
 [tool.pixi.feature.pycharm.dependencies]
 pixi-pycharm = "*"
@@ -204,57 +200,48 @@ python = "3.12.*"
 
 [tool.pixi.environments]
 default = { features = ["develop", "pycharm"], solve-group = "default" }
-py310 = { features = ["develop", "py310"]}
-py311 = { features = ["develop", "py311"]}
-py312 = { features = ["develop", "py312"], solve-group = "default"}
+py310 = { features = ["develop", "py310"] }
+py311 = { features = ["develop", "py311"] }
+py312 = { features = ["develop", "py312"], solve-group = "default" }
 
 
 [tool.pixi.tasks.install-isce3]
 cmd = [
-    "python",
-    "-m",
-    "pip",
-    "install",
-    "git+https://github.com/isce-framework/isce3.git@6116cdaca709c861839804567cca406667887d8b",
+  "python",
+  "-m",
+  "pip",
+  "install",
+  "git+https://github.com/isce-framework/isce3.git@6116cdaca709c861839804567cca406667887d8b",
 ]
 depends-on = []
 
 [tool.pixi.tasks.install-radar]
 cmd = [
-    "python",
-    "-m",
-    "pip",
-    "install",
-    "git+https://github.com/opera-adt/COMPASS.git@v0.5.6",
-    "git+https://github.com/isce-framework/s1-reader.git@v0.2.5",
+  "python",
+  "-m",
+  "pip",
+  "install",
+  "git+https://github.com/opera-adt/COMPASS.git@v0.5.6",
+  "git+https://github.com/isce-framework/s1-reader.git@v0.2.5",
 ]
-depends-on = ["install-isce3"]
+#depends-on = ["install-isce3"]
+depends-on = []
 
 [tool.pixi.tasks.install-autorift]
 cmd = [
-    "python",
-    "-m",
-    "pip",
-    "install",
-    "git+https://github.com/nasa-jpl/autoRIFT.git@v2.0.0",
+  "python",
+  "-m",
+  "pip",
+  "install",
+  "git+https://github.com/nasa-jpl/autoRIFT.git@v2.0.0",
 ]
 depends-on = ["install-radar"]
 
 
 [tool.pixi.tasks.install-editable]
-cmd = [
-    "python",
-    "-m",
-    "pip",
-    "install",
-    "-e",
-    ".",
-]
+cmd = ["python", "-m", "pip", "install", "-e", "."]
 depends-on = ["install-autorift"]
 
 [tool.pixi.tasks.tests]
-cmd = [
-    "pytest",
-    "--cov=hyp3_autorift",
-]
+cmd = ["pytest", "--cov=hyp3_autorift"]
 depends-on = ["install-editable"]


### PR DESCRIPTION
Rebuilt the `build` action to:
- Use matrix strategies for each platform.
- Each targeted platform uses its native (amd/arm) GH Action runner.
- Use artifacts uploaded/downloaded in a final stage to make the Docker manifest.

Modified the `Dockerfile` to:
- Perform the `pixi install` stage after only copying the `pyproject.toml` and `pixi.lock` files. The hope is that we cache the pixi install deps in a separate docker layer.

With bad cache hits (changing pixi/toml files) we get down to around **9-20 minutes**. With good cache hits, around 4 minutes. 