### PR TITLE
Remove M11 and M12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0]
+
+### Remove
+The M11 and M12 correction matrix values have been removed from the radar products. Since Sentinel-1 and NISAR use frame-based processing, these values will be the same for all products in a given frame. 
+
+
 ## [0.27.0]
 
 ### Added

--- a/src/hyp3_autorift/vend/netcdf_output.py
+++ b/src/hyp3_autorift/vend/netcdf_output.py
@@ -1061,65 +1061,6 @@ def netCDF_packaging(
         else:
             stable_shift_applied_p = 1
 
-        var = nc_outfile.createVariable(
-            'M11',
-            np.dtype('float32'),
-            ('y', 'x'),
-            fill_value=NoDataValue,
-            zlib=True,
-            complevel=2,
-            shuffle=True,
-            chunksizes=ChunkSize,
-        )
-        var.setncattr('standard_name', 'conversion_matrix_element_11')
-        var.setncattr(
-            'description',
-            'conversion matrix element (1st row, 1st column) that can be multiplied with vx '
-            'to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)',
-        )
-        var.setncattr('units', 'pixel/(meter/year)')
-        var.setncattr('grid_mapping', mapping_var_name)
-        var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
-        var.setncattr(
-            'dr_to_vr_factor_description',
-            'multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr',
-        )
-
-        M11 = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
-
-        M11[noDataMask] = NoDataValue
-        var[:] = M11
-
-        var = nc_outfile.createVariable(
-            'M12',
-            np.dtype('float32'),
-            ('y', 'x'),
-            fill_value=NoDataValue,
-            zlib=True,
-            complevel=2,
-            shuffle=True,
-            chunksizes=ChunkSize,
-        )
-        var.setncattr('standard_name', 'conversion_matrix_element_12')
-        var.setncattr(
-            'description',
-            'conversion matrix element (1st row, 2nd column) that can be multiplied with vy '
-            'to give range pixel displacement dr (see Eq. A18 in https://www.mdpi.com/2072-4292/13/4/749)',
-        )
-        var.setncattr('units', 'pixel/(meter/year)')
-        var.setncattr('grid_mapping', mapping_var_name)
-
-        var.setncattr('dr_to_vr_factor', dr_2_vr_factor)
-        var.setncattr(
-            'dr_to_vr_factor_description',
-            'multiplicative factor that converts slant range pixel displacement dr to slant range velocity vr',
-        )
-
-        M12 = -offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) / scale_factor_1
-
-        M12[noDataMask] = NoDataValue
-        var[:] = M12
-
     var = nc_outfile.createVariable(
         'chip_size_width',
         np.dtype('uint16'),


### PR DESCRIPTION
Since NISAR and Sentinel-1 will be frame-based, M11 and M12 will be the same over time for the products in each frame. This means we don't need to save it in each product, individually. 