### PR TITLE
Add support for Sentinel-2 L2A COGs via Element84 (AWS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,18 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 * `process.get_s2_metadata` now dynamically routes to either the Google Cloud Storage L1C workflow or the new AWS L2A workflow based on the scene name format.
 
+## [0.28.1]
+
+### Changed
+* updated autoRIFT to [v2.1.2](https://github.com/nasa-jpl/autoRIFT/releases/tag/v2.1.2) for improved OpenMP performance.
+
 ## [0.28.0]
 
 ### Added
-* Support for NISAR RSLC and GSLC products
+* Preliminary support for NISAR RSLC and GSLC products. Workflow tested with uncalibrarted data and there are some known metadata/packaging issues. Use with caution.
+
+### Fixed
+* `crop.py` now uses the appropriate fill value when padding the cropped dataset to align chunks instead of always using -32767 and causing integer underflows for ushort and ubyte type variables. Re-cropping existing granules will fix integer underflow issues in them. See [#419](https://github.com/ASFHyP3/hyp3-autorift/issues/419) for more details.
 
 ## [0.27.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.2]
+
+### Added
+* Support for Sentinel-2 L2A COG processing via the AWS Element84 API.
+
+### Changed
+* `process.get_s2_metadata` now dynamically routes to either the Google Cloud Storage L1C workflow or the new AWS L2A workflow based on the scene name format.
+
 ## [0.28.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Added
-* Support for Sentinel-2 L2A COG processing via the AWS Element84 API.
-
-### Changed
-* `process.get_s2_metadata` now dynamically routes to either the Google Cloud Storage L1C workflow or the new AWS L2A workflow based on the scene name format.
-
 ## [0.28.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+* Support for Sentinel-2 L2A COG processing via the AWS Element84 API.
+
+### Changed
+* `process.get_s2_metadata` now dynamically routes to either the Google Cloud Storage L1C workflow or the new AWS L2A workflow based on the scene name format.
+
 ## [0.28.0]
 
 ### Added

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -144,14 +144,14 @@ def get_raster_bbox(path: str):
 
 
 def get_s2_l2a_metadata(scene_name: str) -> dict:
-    url = f"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/{scene_name}"
-    
+    url = f'https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/{scene_name}'
+
     response = requests.get(url)
     response.raise_for_status()
     item = response.json()
-    
+
     band_url = item['assets']['nir']['href']
-    
+
     if band_url.startswith('s3://'):
         vsi_path = band_url.replace('s3://', '/vsis3/')
     elif band_url.startswith('https://'):
@@ -162,33 +162,30 @@ def get_s2_l2a_metadata(scene_name: str) -> dict:
     bbox = item.get('bbox')
     if not bbox:
         bbox = get_raster_bbox(vsi_path)
-        
+
     raw_dt = item['properties']['datetime']
     try:
-        dt_obj = datetime.strptime(raw_dt, "%Y-%m-%dT%H:%M:%S.%fZ")
+        dt_obj = datetime.strptime(raw_dt, '%Y-%m-%dT%H:%M:%S.%fZ')
     except ValueError:
-        dt_obj = datetime.strptime(raw_dt, "%Y-%m-%dT%H:%M:%SZ")
-        
-    clean_dt = dt_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
+        dt_obj = datetime.strptime(raw_dt, '%Y-%m-%dT%H:%M:%SZ')
+
+    clean_dt = dt_obj.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     return {
         'path': vsi_path,
         'bbox': bbox,
         'id': scene_name,
-        'properties': {
-            'datetime': clean_dt,
-            'proj:epsg': item['properties'].get('proj:epsg')
-        },
+        'properties': {'datetime': clean_dt, 'proj:epsg': item['properties'].get('proj:epsg')},
     }
 
 
 def get_s2_metadata(scene_name: str) -> dict:
     """Routes the metadata request based on the scene name format."""
-    
+
     # Element84 L2A STAC items
     if scene_name.endswith('_L2A') or 'L2A' in scene_name:
         return get_s2_l2a_metadata(scene_name)
-    
+
     # Google Cloud L1C .SAFE items
     path = get_s2_path(scene_name)
     bbox = get_raster_bbox(path)

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -390,6 +390,11 @@ def process(
         netcdf_file = process_sentinel1_slc_isce3(
             reference[0], secondary[0], publish_bucket, use_static_files, chip_size=chip_size
         )
+
+    elif platform == 'NISAR':
+        from hyp3_autorift.nisar_isce3 import process_nisar_pair
+
+        netcdf_file = process_nisar_pair(reference[0], secondary[0])
     else:
         # Set config and env for new CXX threads in Geogrid/autoRIFT
         gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -143,7 +143,53 @@ def get_raster_bbox(path: str):
     ]
 
 
-def get_s2_metadata(scene_name):
+def get_s2_l2a_metadata(scene_name: str) -> dict:
+    url = f"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/{scene_name}"
+    
+    response = requests.get(url)
+    response.raise_for_status()
+    item = response.json()
+    
+    band_url = item['assets']['nir']['href']
+    
+    if band_url.startswith('s3://'):
+        vsi_path = band_url.replace('s3://', '/vsis3/')
+    elif band_url.startswith('https://'):
+        vsi_path = '/vsicurl/' + band_url
+    else:
+        vsi_path = band_url
+
+    bbox = item.get('bbox')
+    if not bbox:
+        bbox = get_raster_bbox(vsi_path)
+        
+    raw_dt = item['properties']['datetime']
+    try:
+        dt_obj = datetime.strptime(raw_dt, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        dt_obj = datetime.strptime(raw_dt, "%Y-%m-%dT%H:%M:%SZ")
+        
+    clean_dt = dt_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return {
+        'path': vsi_path,
+        'bbox': bbox,
+        'id': scene_name,
+        'properties': {
+            'datetime': clean_dt,
+            'proj:epsg': item['properties'].get('proj:epsg')
+        },
+    }
+
+
+def get_s2_metadata(scene_name: str) -> dict:
+    """Routes the metadata request based on the scene name format."""
+    
+    # Element84 L2A STAC items
+    if scene_name.endswith('_L2A') or 'L2A' in scene_name:
+        return get_s2_l2a_metadata(scene_name)
+    
+    # Google Cloud L1C .SAFE items
     path = get_s2_path(scene_name)
     bbox = get_raster_bbox(path)
     acquisition_start = datetime.strptime(scene_name.split('_')[2], '%Y%m%dT%H%M%S')
@@ -344,11 +390,6 @@ def process(
         netcdf_file = process_sentinel1_slc_isce3(
             reference[0], secondary[0], publish_bucket, use_static_files, chip_size=chip_size
         )
-
-    elif platform == 'NISAR':
-        from hyp3_autorift.nisar_isce3 import process_nisar_pair
-
-        netcdf_file = process_nisar_pair(reference[0], secondary[0])
     else:
         # Set config and env for new CXX threads in Geogrid/autoRIFT
         gdal.SetConfigOption('GDAL_DISABLE_READDIR_ON_OPEN', 'EMPTY_DIR')


### PR DESCRIPTION
This PR adds an alternative optical processing pathway to support Sentinel-2 Level-2A (L2A) Cloud-Optimized GeoTIFFs (COGs) via the Element84 Earth Search API.

**Note:** The standard default workflow (processing L1C .SAFE granules via Google Cloud Storage) is untouched and remains backward-compatible.

## Key Changes 

* Modified `get_s2_metadata()` in `process.py` to check the scene name. If it contains `L2A`, it routes to the new AWS Element84 logic. Otherwise, it defaults to the .SAFE manifest logic.
* Added `get_s2_l2a_metadata()` to `process.py` to query the Element84 STAC API and stream the NIR band (`B08.tif`) directly via `/vsicurl/` or `/vsis3/`.
* Added a failsafe in the new L2A function to strip fractional seconds from Element84's datetime strings (e.g., ...42.581000Z -> ...42Z). This prevents a `strptime ValueError` crash in the `testautoRIFT.py`wrapper.

## Example run
The following code snippets perform the same processing with different inputs. 

This snipped uses the Element84 COGs:
```
pixi run hyp3_autorift --reference S2A_T46QHH_20250114T042103_L2A --secondary S2B_T46QHH_20250330T041545_L2A --chip-size 24 --search-range 64
```
This snipped uses the Google Cloud Storage .SAFE files:
```
pixi run hyp3_autorift --reference S2A_MSIL1C_20250114T041121_N0511_R047_T46QHH_20250114T055833 --secondary S2B_MSIL1C_20250330T040549_N0511_R047_T46QHH_20250330T055711 --chip-size 24 --search-range 64
```

## Outputs
The outputs using the L1C (left) and L2A (Right) are nearly identical. There are subtle differences at the pixel level.
<img width="2610" height="1299" alt="L1C_vs_L2A" src="https://github.com/user-attachments/assets/b1af0607-087e-497d-8e04-42a0b40e73ab" />
