### PR TITLE
Fix NISAR error vectors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read
       packages: write
     concurrency:
-      group: ${{ github.ref_name }}-${{ matrix.platform }}
+      group: ${{ github.event_name }}-${{ matrix.platform }}
       cancel-in-progress: true
     strategy:
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,7 @@ cmd = [
     "-m",
     "pip",
     "install",
-    "git+https://github.com/isce-framework/isce3.git@6116cdaca709c861839804567cca406667887d8b",
+    "git+https://github.com/isce-framework/isce3.git@6116cdaca709c861839804567cca406667887d8b",  # before v0.25.0
 ]
 depends-on = []
 

--- a/src/hyp3_autorift/vend/testautoRIFT.py
+++ b/src/hyp3_autorift/vend/testautoRIFT.py
@@ -1216,11 +1216,22 @@ def generateAutoriftProduct(
                         slave_meta =  GSLCMetadata('secondary_adjusted.tif', slave_filename)
                         pair_type = 'optical'
                         coordinates = 'map'
+
+                        # TODO: Landsat/Sentinel-2 values -- does this need to change for NISAR?
+                        error_vector = np.array([25.5, 25.5])
                     else:
                         master_meta = loadMetadataRslc(master_filename)
                         slave_meta = loadMetadataRslc(slave_filename)
                         pair_type = 'radar'
                         coordinates = 'radar, map'
+
+                        # TODO: S1 values -- does this need to change for NISAR?
+                        error_vector = np.array(
+                            [
+                                [0.0356, 0.0501, 0.0266, 0.0622, 0.0357, 0.0501],
+                                [0.5194, 1.1638, 0.3319, 1.3701, 0.5191, 1.1628],
+                            ]
+                        )
 
                     master_dt = master_meta.sensingStart
                     slave_dt = slave_meta.sensingStart
@@ -1276,14 +1287,6 @@ def generateAutoriftProduct(
                         'roi_valid_percentage': PPP,
                         'autoRIFT_software_version': version,
                     }
-
-                    # TODO: Does this need to change for NISAR?
-                    error_vector = np.array(
-                        [
-                            [0.0356, 0.0501, 0.0266, 0.0622, 0.0357, 0.0501],
-                            [0.5194, 1.1638, 0.3319, 1.3701, 0.5191, 1.1628],
-                        ]
-                    )
 
                     netcdf_file = no.netCDF_packaging(
                         VX,


### PR DESCRIPTION
This changes the error vector for NISAR to _the form_ expected by autoRIFT for RSLC (radar) and GSLC (optical) processing.

The values still are suspect, but can be fixed later since we're not going live with NISAR anytime soon.

This also tweaks the container clobbering fix from #411 to use the event name for Docker build concurrency, not the ref name, so that develop will still cancel main (to get the tags lined up right), but PRs won't cancel either of those push events. 

fixes #413 