### PR TITLE
Fix cropping bug due to change in granule dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.3]
+
+### Fixed
+* `hyp3_autorift.crop` now behaves consistently on netCDF files with either `U1` (`str`) or `i1` (`int8`) empty, attribute-only variables like `img_pair_info` and `mapping`.
+
 ## [0.28.2]
 
 ### Added

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -146,14 +146,16 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
 
         cropped_ds = ds.sel(
             # Setting the step inline with the coordinate monocity since (-1)**True -> -1 and (-1)**False -> 1
-            y=slice(grid_y_min, grid_y_max, (-1)**ds.indexes['y'].is_monotonic_decreasing),
-            x=slice(grid_x_min, grid_x_max, (-1)**ds.indexes['x'].is_monotonic_decreasing),
+            y=slice(grid_y_min, grid_y_max, (-1) ** ds.indexes['y'].is_monotonic_decreasing),
+            x=slice(grid_x_min, grid_x_max, (-1) ** ds.indexes['x'].is_monotonic_decreasing),
         )
         cropped_ds = cropped_ds.load()
 
         projection = ds['mapping'].attrs['spatial_epsg']
 
-        aligned_bounds, padding, aligned_x_values, aligned_y_values = get_alignment_info(grid_x_min, grid_y_min, grid_x_max, grid_y_max)
+        aligned_bounds, padding, aligned_x_values, aligned_y_values = get_alignment_info(
+            grid_x_min, grid_y_min, grid_x_max, grid_y_max
+        )
 
         aligned_x_min, aligned_y_min, aligned_x_max, aligned_y_max = aligned_bounds
         left_pad, bottom_pad, right_pad, top_pad = padding
@@ -240,7 +242,9 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
         x_cell = aligned_x_values[1] - aligned_x_values[0]
 
         # It was decided to keep all values in GeoTransform center-based
-        cropped_ds['mapping'].attrs['GeoTransform'] = f'{aligned_x_values[0]} {x_cell} 0 {aligned_y_values[0]} 0 {y_cell}'
+        cropped_ds['mapping'].attrs['GeoTransform'] = (
+            f'{aligned_x_values[0]} {x_cell} 0 {aligned_y_values[0]} 0 {y_cell}'
+        )
 
         dim_chunks_settings = (1, CHUNK_SIZE, CHUNK_SIZE)
 

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -144,12 +144,11 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
         x_values = yx_ds.x.values
         grid_x_min, grid_x_max = x_values.min(), x_values.max()
 
-        # Based on Y/X extends, mask original dataset
-        mask_lat = (ds.y >= grid_y_min) & (ds.y <= grid_y_max)
-        mask_lon = (ds.x >= grid_x_min) & (ds.x <= grid_x_max)
-        mask = mask_lat & mask_lon
-
-        cropped_ds = ds.where(mask).dropna(dim='y', how='all').dropna(dim='x', how='all')
+        cropped_ds = ds.sel(
+            # Setting the step inline with the coordinate monocity since (-1)**True -> -1 and (-1)**False -> 1
+            y=slice(grid_y_min, grid_y_max, (-1)**ds.indexes['y'].is_monotonic_decreasing),
+            x=slice(grid_x_min, grid_x_max, (-1)**ds.indexes['x'].is_monotonic_decreasing),
+        )
         cropped_ds = cropped_ds.load()
 
         projection = ds['mapping'].attrs['spatial_epsg']

--- a/src/hyp3_autorift/crop.py
+++ b/src/hyp3_autorift/crop.py
@@ -135,28 +135,28 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
         The Path to the cropped netCDF file
     """
     with xr.open_dataset(netcdf_file, engine='h5netcdf') as ds:
-        # this will drop X/Y coordinates, so drop non-None values just to get X/Y extends
-        xy_ds = ds.where(ds.v.notnull()).dropna(dim='x', how='all').dropna(dim='y', how='all')
+        # this will drop Y/X coordinates, so drop non-None values just to get Y/X extends
+        yx_ds = ds.where(ds.v.notnull()).dropna(dim='y', how='all').dropna(dim='x', how='all')
 
-        x_values = xy_ds.x.values
-        grid_x_min, grid_x_max = x_values.min(), x_values.max()
-
-        y_values = xy_ds.y.values
+        y_values = yx_ds.y.values
         grid_y_min, grid_y_max = y_values.min(), y_values.max()
 
-        # Based on X/Y extends, mask original dataset
-        mask_lon = (ds.x >= grid_x_min) & (ds.x <= grid_x_max)
-        mask_lat = (ds.y >= grid_y_min) & (ds.y <= grid_y_max)
-        mask = mask_lon & mask_lat
+        x_values = yx_ds.x.values
+        grid_x_min, grid_x_max = x_values.min(), x_values.max()
 
-        cropped_ds = ds.where(mask).dropna(dim='x', how='all').dropna(dim='y', how='all')
+        # Based on Y/X extends, mask original dataset
+        mask_lat = (ds.y >= grid_y_min) & (ds.y <= grid_y_max)
+        mask_lon = (ds.x >= grid_x_min) & (ds.x <= grid_x_max)
+        mask = mask_lat & mask_lon
+
+        cropped_ds = ds.where(mask).dropna(dim='y', how='all').dropna(dim='x', how='all')
         cropped_ds = cropped_ds.load()
 
         projection = ds['mapping'].attrs['spatial_epsg']
 
-        aligned_bounds, padding, x_values, y_values = get_alignment_info(grid_x_min, grid_y_min, grid_x_max, grid_y_max)
+        aligned_bounds, padding, aligned_x_values, aligned_y_values = get_alignment_info(grid_x_min, grid_y_min, grid_x_max, grid_y_max)
 
-        grid_x_min, grid_y_min, grid_x_max, grid_y_max = aligned_bounds
+        aligned_x_min, aligned_y_min, aligned_x_max, aligned_y_max = aligned_bounds
         left_pad, bottom_pad, right_pad, top_pad = padding
 
         constant_values = {var: ds[var].encoding.get('_FillValue') for var in cropped_ds}
@@ -217,15 +217,15 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
         cropped_ds['mapping'] = ds['mapping'].where(False, -127).astype('int8')
         cropped_ds['mapping'].encoding = {'dtype': np.dtype('int8'), '_FillValue': -127}
 
-        cropped_ds['x'] = x_values
-        cropped_ds['y'] = y_values
+        cropped_ds['y'] = aligned_y_values
+        cropped_ds['x'] = aligned_x_values
 
-        cropped_ds['x'].attrs = ds['x'].attrs
         cropped_ds['y'].attrs = ds['y'].attrs
+        cropped_ds['x'].attrs = ds['x'].attrs
 
         # Compute centroid longitude/latitude
-        center_x = (grid_x_min + grid_x_max) / 2
-        center_y = (grid_y_min + grid_y_max) / 2
+        center_y = (aligned_y_min + aligned_y_max) / 2
+        center_x = (aligned_x_min + aligned_x_max) / 2
 
         # Convert to lon/lat coordinates
         to_lon_lat_transformer = pyproj.Transformer.from_crs(f'EPSG:{projection}', 'EPSG:4326', always_xy=True)
@@ -237,11 +237,11 @@ def crop_netcdf_product(netcdf_file: Path) -> Path:
         cropped_ds['img_pair_info'].attrs['longitude'] = round(center_lon_lat[0], 2)
 
         # Update mapping.GeoTransform
-        x_cell = x_values[1] - x_values[0]
-        y_cell = y_values[1] - y_values[0]
+        y_cell = aligned_y_values[1] - aligned_y_values[0]
+        x_cell = aligned_x_values[1] - aligned_x_values[0]
 
         # It was decided to keep all values in GeoTransform center-based
-        cropped_ds['mapping'].attrs['GeoTransform'] = f'{x_values[0]} {x_cell} 0 {y_values[0]} 0 {y_cell}'
+        cropped_ds['mapping'].attrs['GeoTransform'] = f'{aligned_x_values[0]} {x_cell} 0 {aligned_y_values[0]} 0 {y_cell}'
 
         dim_chunks_settings = (1, CHUNK_SIZE, CHUNK_SIZE)
 


### PR DESCRIPTION
For some reason, xarray `Dataset.where` behaves differently when `img_pair_info` and `mapping` have `U1` (`str`) or `i1` (`int8`) data types. 

I tried a variety of ways to circumvent this problem, including, in particular, dropping the `img_pair_info` and `mapping` right after loading the netCDF file.

In the end, using `Dataset.sel` was the only way to achieve the expected behavior across both dtypes, but selecting using the min/max bounds requires knowing whether the index is monotonically increasing ( :roll_eyes: ). I *believe* Y is always monotonic decreasing and X is always increasing for our data, but I'm not sure, so I included a trixy way to handle that.