### PR TITLE
Select common subset of reference/secondary bursts provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.4]
+
+### Fixed
+* The common Sentinel-1 bursts in the reference and secondary list will now be used for processing and the final burst group validity will be checked by `burst2safe` before processing. This makes autoRIFT more robust to frames with alternating acquisition strategies for some bursts (e.g., a burst is only acquired for S1A and not S1B).
+
 ## [0.28.3]
 
 ### Fixed

--- a/pixi.lock
+++ b/pixi.lock
@@ -302,7 +302,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -677,7 +677,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -780,7 +780,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1107,7 +1107,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1721,7 +1721,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2099,7 +2099,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2206,7 +2206,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2536,7 +2536,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -3152,7 +3152,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -3527,7 +3527,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -3630,7 +3630,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -3957,7 +3957,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.4-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -4571,7 +4571,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -4946,7 +4946,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -5049,7 +5049,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -5376,7 +5376,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.39.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.39.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -16911,25 +16911,26 @@ packages:
   - pkg:pypi/botocore?source=compressed-mapping
   size: 7877600
   timestamp: 1752116962734
-- conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-1.4.5-pyhd8ed1ab_0.conda
-  sha256: 81f42722ee101e55fe1d5412d7ca2e296da63e5aa6ee5146ebe22cef3f1ff93f
-  md5: c21f44e056aa4591d4159af14e2333c1
+- conda: https://conda.anaconda.org/conda-forge/noarch/burst2safe-2.0.2-pyhd8ed1ab_0.conda
+  sha256: 70de293928454ce1e3a25d4e41ebbd7c9624c3af43c004b4899351e2245abdf4
+  md5: f82694e3bfc49370827a849a31b9439e
   depends:
-  - aiohttp
+  - aiohttp >=3.12.6
   - asf_search
   - dateparser !=1.1.0
   - gdal
   - lxml
-  - numpy <2.1.0
-  - python >=3.9
-  - shapely >=2
+  - numpy
+  - python >=3.10
+  - shapely >=2.1.0
   - tifffile >=2022.04.22
   license: BSD-2-Clause
   license_family: BSD
   purls:
   - pkg:pypi/burst2safe?source=hash-mapping
-  size: 168993
-  timestamp: 1750376722198
+  run_exports: {}
+  size: 169167
+  timestamp: 1767654122991
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.7.9-hbd8a1cb_0.conda
   sha256: d2d7327b09d990d0f51e7aec859a5879743675e377fcf9b4ec4db2dbeb75e15d
   md5: 54521bf3b59c86e2f55b7294b40a04dc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ no-build-isolation = ['isce3']
 pip = "*"
 boto3 = "*"
 botocore = "*"
-burst2safe = ">=1.4.4"
+burst2safe = ">=2.0.0"
 gdal = ">=3"
 h5netcdf = "*"
 hyp3lib = ">=4,<5"

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -674,7 +674,6 @@ def main():
         parser.error('Must provide exactly two granules.')
 
     if has_granules:
-        # FIXME: won't actually warn because of: https://github.com/ASFHyP3/burst2safe/issues/160
         warnings.warn(
             'The positional argument for granules is deprecated and will be removed in a future release. '
             'Please use --reference and --secondary.',

--- a/src/hyp3_autorift/process.py
+++ b/src/hyp3_autorift/process.py
@@ -701,9 +701,13 @@ def main():
     if ref_platforms != sec_platforms and not (ref_platforms | sec_platforms).issubset(landsat_missions):
         parser.error('all scenes must be of the same type.')
 
-    is_optical = ref_platforms.issubset({'S2'} | landsat_missions)
-    if not is_optical and len(reference) != len(secondary):
-        parser.error('Must provide the same number of reference and secondary scenes.')
+    is_radar = ref_platforms.issubset({'S1-BURST', 'S1-SLC', 'NISAR'})
+    if is_radar:
+        if ref_platforms == {'S1-BURST'}:
+            reference, secondary = utils.ensure_burst_group_validity(reference, secondary)
+
+        if len(reference) != len(secondary):
+            parser.error('Must provide the same number of reference and secondary scenes.')
 
     product_file, browse_file, thumbnail_file = process(
         reference,

--- a/src/hyp3_autorift/utils.py
+++ b/src/hyp3_autorift/utils.py
@@ -354,9 +354,11 @@ def ensure_burst_group_validity(reference: list, secondary: list) -> Tuple[list,
         secondary = [info.granule for info in sec_infos]
 
     if len(reference) < 5 or len(secondary) < 5:
-        raise ValueError('At least 5 common bursts are required for ITS_LIVE processing:\n'
-                         f'reference = {reference}\n'
-                         f'secondary = {secondary}')
+        raise ValueError(
+            'At least 5 common bursts are required for ITS_LIVE processing:\n'
+            f'reference = {reference}\n'
+            f'secondary = {secondary}'
+        )
 
     Safe.check_group_validity(ref_infos)
     Safe.check_group_validity(sec_infos)

--- a/src/hyp3_autorift/utils.py
+++ b/src/hyp3_autorift/utils.py
@@ -3,12 +3,15 @@
 import json
 import logging
 import os
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Tuple, Union
 
 import boto3
 import numpy as np
+from burst2safe.safe import Safe
+from burst2safe.utils import BurstInfo
 from hyp3lib import DemError
 from hyp3lib.aws import get_content_type, get_tag_set
 from netCDF4 import Dataset
@@ -299,3 +302,63 @@ def get_platform(scene: str) -> str:
     if scene.startswith('NISAR'):
         return 'NISAR'
     raise NotImplementedError(f'autoRIFT processing not available for this platform. {scene}')
+
+
+def get_burst_rid_and_info(scene: str) -> Tuple[str, BurstInfo]:
+    platform, burst_id, swath, acquisition, polarization, _ = scene.split('_')
+    rid = '_'.join([platform, burst_id, swath, polarization])
+
+    # FIXME: do an asf_search.search here? Only thing missing is absolute orbit... This is obnoxious because we'll call
+    #        burst2safe way later so will do multiple lookups
+    info = BurstInfo(
+        # required for burst group validity check
+        granule=scene,
+        swath=swath,
+        polarization=polarization,
+        burst_id=int(burst_id),
+        # Side-stepping that this is required to be the same for all bursts in burst group validity check
+        absolute_orbit=0,
+        # Required but not used by burst group validity check
+        metadata_path=Path('/dev/null'),
+        # Fake because required to instantiate class but not needed for burst group validity check
+        direction='',
+        burst_index=0,
+        relative_orbit=0,
+        data_url='',
+        # Not-optional optionals
+        slc_granule=None,
+        date=None,
+        data_path=None,
+        metadata_url=None,
+    )
+    return rid, info
+
+
+def ensure_burst_group_validity(reference: list, secondary: list) -> Tuple[list, list]:
+    ref_rids, ref_infos = zip(*[get_burst_rid_and_info(scene) for scene in reference])
+    sec_rids, sec_infos = zip(*[get_burst_rid_and_info(scene) for scene in secondary])
+
+    if len(ref_rids) != len(sec_rids):
+        warnings.warn(
+            'A different number of reference and secondary bursts were provided!\n'
+            f'reference = {reference}\n'
+            f'secondary = {secondary}\n'
+            'Selecting the bursts common to each set.'
+        )
+        common_rids = set(ref_rids) & set(sec_rids)
+
+        ref_infos = [ref_infos for ref_rid, ref_infos in zip(ref_rids, ref_infos) if ref_rid in common_rids]
+        sec_infos = [sec_infos for sec_rid, sec_infos in zip(sec_rids, sec_infos) if sec_rid in common_rids]
+
+        reference = [info.granule for info in ref_infos]
+        secondary = [info.granule for info in sec_infos]
+
+    if len(reference) < 5 or len(secondary) < 5:
+        raise ValueError('At least 5 common bursts are required for ITS_LIVE processing:\n'
+                         f'reference = {reference}\n'
+                         f'secondary = {secondary}')
+
+    Safe.check_group_validity(ref_infos)
+    Safe.check_group_validity(sec_infos)
+
+    return reference, secondary

--- a/src/hyp3_autorift/utils.py
+++ b/src/hyp3_autorift/utils.py
@@ -347,8 +347,8 @@ def ensure_burst_group_validity(reference: list, secondary: list) -> Tuple[list,
         )
         common_rids = set(ref_rids) & set(sec_rids)
 
-        ref_infos = [ref_infos for ref_rid, ref_infos in zip(ref_rids, ref_infos) if ref_rid in common_rids]
-        sec_infos = [sec_infos for sec_rid, sec_infos in zip(sec_rids, sec_infos) if sec_rid in common_rids]
+        ref_infos = tuple(ref_infos for ref_rid, ref_infos in zip(ref_rids, ref_infos) if ref_rid in common_rids)
+        sec_infos = tuple(sec_infos for sec_rid, sec_infos in zip(sec_rids, sec_infos) if sec_rid in common_rids)
 
         reference = [info.granule for info in ref_infos]
         secondary = [info.granule for info in sec_infos]

--- a/src/hyp3_autorift/utils.py
+++ b/src/hyp3_autorift/utils.py
@@ -320,7 +320,7 @@ def get_burst_rid_and_info(scene: str) -> Tuple[str, BurstInfo]:
         absolute_orbit=0,
         # Required but not used by burst group validity check
         metadata_path=Path('/dev/null'),
-        # Fake because required to instantiate class but not needed for burst group validity check
+        # Fake; required to instantiate class but not needed for burst group validity check
         direction='',
         burst_index=0,
         relative_orbit=0,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,3 +260,36 @@ def test_nullable_string(argument_string, expected):
 )
 def test_nullable_granule_list(granule_string, expected):
     assert utils.nullable_granule_list(granule_string) == expected
+
+
+def test_ensure_burst_group_validity():
+    reference = [
+        'S1_175514_IW1_20190915T082904_HH_4194-BURST',
+        'S1_175515_IW1_20190915T082907_HH_4194-BURST',
+        'S1_175516_IW1_20190915T082910_HH_4194-BURST',
+        'S1_175517_IW1_20190915T082912_HH_4194-BURST',
+        'S1_175518_IW1_20190915T082915_HH_4194-BURST',
+        'S1_175519_IW1_20190915T082918_HH_4194-BURST',
+        'S1_175520_IW1_20190915T082921_HH_4194-BURST',
+        'S1_175521_IW1_20190915T082923_HH_B381-BURST',
+    ]
+    secondary = [
+        'S1_175514_IW1_20190909T082822_HH_9B4C-BURST',
+        'S1_175515_IW1_20190909T082825_HH_9B4C-BURST',
+        'S1_175516_IW1_20190909T082828_HH_9B4C-BURST',
+        'S1_175517_IW1_20190909T082830_HH_9B4C-BURST',
+        'S1_175518_IW1_20190909T082833_HH_9B4C-BURST',
+        'S1_175519_IW1_20190909T082836_HH_9B4C-BURST',
+        'S1_175520_IW1_20190909T082839_HH_9B4C-BURST',
+    ]
+    ref, sec = utils.ensure_burst_group_validity(reference, secondary)
+    assert ref == reference[:-1]
+    assert sec == secondary
+
+    with pytest.raises(ValueError):
+        # burst gap in swath
+        _, _ = utils.ensure_burst_group_validity(reference=reference[:4] + reference[5:], secondary=secondary)
+
+    with pytest.raises(ValueError):
+        # less than 5 bursts
+        _, _ = utils.ensure_burst_group_validity(reference=reference[:4], secondary=secondary)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -282,7 +282,9 @@ def test_ensure_burst_group_validity():
         'S1_175519_IW1_20190909T082836_HH_9B4C-BURST',
         'S1_175520_IW1_20190909T082839_HH_9B4C-BURST',
     ]
-    ref, sec = utils.ensure_burst_group_validity(reference, secondary)
+    with pytest.warns(UserWarning):
+        ref, sec = utils.ensure_burst_group_validity(reference, secondary)
+
     assert ref == reference[:-1]
     assert sec == secondary
 
@@ -292,4 +294,4 @@ def test_ensure_burst_group_validity():
 
     with pytest.raises(ValueError):
         # less than 5 bursts
-        _, _ = utils.ensure_burst_group_validity(reference=reference[:4], secondary=secondary)
+        _, _ = utils.ensure_burst_group_validity(reference=reference[:4], secondary=secondary[:4])


### PR DESCRIPTION
Fixes scenes failing with  "Must provide the same number of reference and secondary scenes." in cases where the common subset of bursts are valid scenes. Fixing here instead of ITS_LIVE monitoring because burst2safe is already a dependency (https://github.com/ASFHyP3/burst2safe/pull/258) here and includes GDAL, which is too heavyweight for the monitoring lambdas.

For example, this happens when S1A and S1B don't have identical observing plans. The ITS_LIVE S1-burst frames include one burst from the rightmost SLC, but it's only acquired by S1A, and not S1B, so any pairs that cross missions will have 1 missing reference or secondary burst, which would previously fail when processing.
<img width="1918" height="927" alt="image" src="https://github.com/user-attachments/assets/7dc27480-3a1d-4120-8ac5-35d8ff906d5d" />
